### PR TITLE
Claude Memory import command

### DIFF
--- a/.mnemonic/notes/import-claude-memory-cli-command-design-and-implementation-dcdc5a05.md
+++ b/.mnemonic/notes/import-claude-memory-cli-command-design-and-implementation-dcdc5a05.md
@@ -1,0 +1,47 @@
+---
+title: 'import-claude-memory CLI command: design and implementation'
+tags:
+  - cli
+  - import
+  - claude-memory
+  - design-decision
+lifecycle: permanent
+createdAt: '2026-03-09T21:24:01.304Z'
+updatedAt: '2026-03-09T21:24:01.304Z'
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+Added `mnemonic import-claude-memory` CLI command to import Claude Code auto-memory into the mnemonic vault.
+
+## What it does
+
+Reads Claude Code auto-memory files from `~/.claude/projects/<encoded-path>/memory/*.md`, splits each file on `##` headings into sections, and writes each section as a separate mnemonic note to the main vault with `lifecycle: permanent`, `scope: global`, and tags `["claude-memory", "imported", "<filename-slug>"]`. Duplicate titles are skipped (case-insensitive match).
+
+## Path encoding
+
+Claude Code encodes the project path as directory name by replacing every `/` with `-`. For example:
+`/Users/foo/Projects/bar` → `-Users-foo-Projects-bar`
+The memory directory is then: `~/.claude/projects/<encoded>/memory/`
+
+## Design decisions
+
+- **One note per `##` section** (not one per file) — maximizes `recall` surface area; each section can surface independently in semantic search
+- **Global scope, main vault** — Claude auto-memory is personal context, not project-shareable knowledge; user can `move_memory` to project vault later if needed
+- **Title-based deduplication** — safe to re-run; existing notes are never overwritten to avoid clobbering user edits
+- **No embedding on import** — notes are written raw; user runs `sync` afterwards to embed and push (consistent with how `remember` works when Ollama is unavailable)
+- **`CLAUDE_HOME` env override** — allows non-default Claude home paths without code changes
+
+## Rejected alternatives
+
+- One note per file: less useful for recall, especially if MEMORY.md has 5+ unrelated sections
+- Auto-update existing notes on re-run: too aggressive — user may have edited or enriched imported notes
+- Project scope: auto-memory is personal; it may reference multiple projects and shouldn't automatically land in any one project vault
+
+## Entry point
+
+`src/index.ts` — same pattern as `migrate` CLI block. `process.argv[2] === "import-claude-memory"` check at top, early-exits with `process.exit(0/1)`. Blocking `await new Promise(() => {})` prevents MCP server from starting.
+
+## Documentation
+
+Documented in README.md under `## CLI utilities` and in `docs/index.html` Setup section as a two-column CLI utilities block.

--- a/README.md
+++ b/README.md
@@ -252,6 +252,49 @@ Each vault has its own `config.json` with a `schemaVersion`, so main and project
 - Failed migration runs roll staged note writes back instead of leaving partial edits.
 - Metadata-only migrations do not re-embed automatically; re-embedding happens on title/content change or during `sync` backfill.
 
+## CLI commands
+
+mnemonic ships CLI commands in addition to the MCP server.
+
+### `mnemonic migrate`
+
+Apply pending schema migrations to your vaults. Always preview with `--dry-run` first.
+
+```bash
+# Preview what would change
+mnemonic migrate --dry-run
+
+# Apply and auto-commit
+mnemonic migrate
+
+# Limit to one project vault
+mnemonic migrate --dry-run --cwd=/path/to/project
+mnemonic migrate --cwd=/path/to/project
+
+# List available migrations and pending count
+mnemonic migrate --list
+```
+
+### `mnemonic import-claude-memory`
+
+Import [Claude Code auto-memory](https://docs.anthropic.com/en/docs/claude-code/memory) into your vault. Claude Code stores per-project auto-memory at `~/.claude/projects/<encoded-path>/memory/*.md`. Each `##` heading becomes a separate mnemonic note tagged with `claude-memory` and `imported`. Notes whose titles already exist in the vault are skipped, so the command is safe to re-run.
+
+```bash
+# Preview what would be imported
+mnemonic import-claude-memory --dry-run
+
+# Import from the current directory's Claude memory
+mnemonic import-claude-memory
+
+# Import for a specific project path
+mnemonic import-claude-memory --cwd=/path/to/project
+
+# Use a non-default Claude home
+mnemonic import-claude-memory --claude-home=/custom/.claude
+```
+
+Imported notes are written to the main vault with `lifecycle: permanent` and `scope: global`. After importing, run `sync` to embed them and push to your remote.
+
 ## Tools
 
 | Tool                        | Description                                                              |

--- a/docs/index.html
+++ b/docs/index.html
@@ -1656,6 +1656,49 @@
     </div>
     <p>The runtime is compatible with other Ollama embedding models that support <code>/api/embed</code>. For example, <code>qwen3-embedding:0.6b</code> works as a drop-in <code>EMBED_MODEL</code> override and may be preferable for longer-context notes.</p>
 
+    <div class="fade-up" style="margin-top:48px">
+      <h3 style="font-size:1.15rem;font-weight:600;margin-bottom:16px">CLI utilities</h3>
+      <p style="color:var(--text-dim);margin-bottom:24px">mnemonic ships two CLI commands alongside the MCP server.</p>
+      <div class="quickstart-grid" style="gap:24px">
+        <div>
+          <h4 style="font-size:0.9rem;font-weight:600;color:var(--primary-lt);margin-bottom:10px">mnemonic migrate</h4>
+          <p style="color:var(--text-dim);font-size:0.9rem;margin-bottom:12px">Apply pending schema migrations to your vaults. Always preview with <code>--dry-run</code> first.</p>
+          <div class="code-block">
+            <div class="code-block-header">
+              <span class="code-label">bash</span>
+              <button class="copy-btn" onclick="copyCode(this)">copy</button>
+            </div>
+            <pre><span class="cmt"># Preview changes</span>
+<span class="cmd">mnemonic migrate --dry-run</span>
+
+<span class="cmt"># Apply and auto-commit</span>
+<span class="cmd">mnemonic migrate</span>
+
+<span class="cmt"># List pending migrations</span>
+<span class="cmd">mnemonic migrate --list</span></pre>
+          </div>
+        </div>
+        <div>
+          <h4 style="font-size:0.9rem;font-weight:600;color:var(--cyan-lt);margin-bottom:10px">mnemonic import-claude-memory</h4>
+          <p style="color:var(--text-dim);font-size:0.9rem;margin-bottom:12px">Import Claude Code auto-memory into your vault. Each <code>##</code> heading in <code>~/.claude/projects/&lt;project&gt;/memory/*.md</code> becomes a separate mnemonic note. Duplicate titles are skipped — safe to re-run.</p>
+          <div class="code-block">
+            <div class="code-block-header">
+              <span class="code-label">bash</span>
+              <button class="copy-btn" onclick="copyCode(this)">copy</button>
+            </div>
+            <pre><span class="cmt"># Preview what would be imported</span>
+<span class="cmd">mnemonic import-claude-memory --dry-run</span>
+
+<span class="cmt"># Import from current project's Claude memory</span>
+<span class="cmd">mnemonic import-claude-memory</span>
+
+<span class="cmt"># Specific project path</span>
+<span class="cmd">mnemonic import-claude-memory --cwd=/path/to/project</span></pre>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <div id="agent-snippet" class="agent-snippet fade-up">
       <h3>Add to your AGENT.md or system prompt</h3>
       <p>Drop this snippet into your <code style="font-family:JetBrains Mono,monospace;font-size:0.85em;color:var(--cyan-lt)">AGENT.md</code>, Cursor rules, or Claude system prompt to activate proactive memory behavior.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1043,6 +1043,7 @@
       <li><a href="#how">How it works</a></li>
       <li><a href="#tools">Tools</a></li>
       <li><a href="#setup">Setup</a></li>
+      <li><a href="#cli">CLI</a></li>
       <li><a href="#dogfooding">Dogfooding</a></li>
       <li><a href="#agent-snippet">System prompt</a></li>
       <li>
@@ -1656,49 +1657,6 @@
     </div>
     <p>The runtime is compatible with other Ollama embedding models that support <code>/api/embed</code>. For example, <code>qwen3-embedding:0.6b</code> works as a drop-in <code>EMBED_MODEL</code> override and may be preferable for longer-context notes.</p>
 
-    <div class="fade-up" style="margin-top:48px">
-      <h3 style="font-size:1.15rem;font-weight:600;margin-bottom:16px">CLI utilities</h3>
-      <p style="color:var(--text-dim);margin-bottom:24px">mnemonic ships two CLI commands alongside the MCP server.</p>
-      <div class="quickstart-grid" style="gap:24px">
-        <div>
-          <h4 style="font-size:0.9rem;font-weight:600;color:var(--primary-lt);margin-bottom:10px">mnemonic migrate</h4>
-          <p style="color:var(--text-dim);font-size:0.9rem;margin-bottom:12px">Apply pending schema migrations to your vaults. Always preview with <code>--dry-run</code> first.</p>
-          <div class="code-block">
-            <div class="code-block-header">
-              <span class="code-label">bash</span>
-              <button class="copy-btn" onclick="copyCode(this)">copy</button>
-            </div>
-            <pre><span class="cmt"># Preview changes</span>
-<span class="cmd">mnemonic migrate --dry-run</span>
-
-<span class="cmt"># Apply and auto-commit</span>
-<span class="cmd">mnemonic migrate</span>
-
-<span class="cmt"># List pending migrations</span>
-<span class="cmd">mnemonic migrate --list</span></pre>
-          </div>
-        </div>
-        <div>
-          <h4 style="font-size:0.9rem;font-weight:600;color:var(--cyan-lt);margin-bottom:10px">mnemonic import-claude-memory</h4>
-          <p style="color:var(--text-dim);font-size:0.9rem;margin-bottom:12px">Import Claude Code auto-memory into your vault. Each <code>##</code> heading in <code>~/.claude/projects/&lt;project&gt;/memory/*.md</code> becomes a separate mnemonic note. Duplicate titles are skipped — safe to re-run.</p>
-          <div class="code-block">
-            <div class="code-block-header">
-              <span class="code-label">bash</span>
-              <button class="copy-btn" onclick="copyCode(this)">copy</button>
-            </div>
-            <pre><span class="cmt"># Preview what would be imported</span>
-<span class="cmd">mnemonic import-claude-memory --dry-run</span>
-
-<span class="cmt"># Import from current project's Claude memory</span>
-<span class="cmd">mnemonic import-claude-memory</span>
-
-<span class="cmt"># Specific project path</span>
-<span class="cmd">mnemonic import-claude-memory --cwd=/path/to/project</span></pre>
-          </div>
-        </div>
-      </div>
-    </div>
-
     <div id="agent-snippet" class="agent-snippet fade-up">
       <h3>Add to your AGENT.md or system prompt</h3>
       <p>Drop this snippet into your <code style="font-family:JetBrains Mono,monospace;font-size:0.85em;color:var(--cyan-lt)">AGENT.md</code>, Cursor rules, or Claude system prompt to activate proactive memory behavior.</p>
@@ -1849,6 +1807,114 @@ Guidelines:
 - Be specific about dates and versions when they matter:
   "as of March 2026, using Prisma 5.x"</pre>
       </div>
+    </div>
+  </div>
+</section>
+
+<!-- ── CLI ── -->
+<div class="divider"></div>
+<section id="cli">
+  <svg class="section-art" width="480" height="480" viewBox="0 0 480 480" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <defs>
+      <marker id="cli-arr-g" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto">
+        <polyline points="0,1.5 8,5 0,8.5" stroke="#4ade80" stroke-width="1.5" fill="none"/>
+      </marker>
+      <marker id="cli-arr-c" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto">
+        <polyline points="0,1.5 8,5 0,8.5" stroke="#06b6d4" stroke-width="1.5" fill="none"/>
+      </marker>
+    </defs>
+    <!-- Source file (MEMORY.md) -->
+    <rect x="52" y="148" width="128" height="184" rx="5" stroke="#4ade80" stroke-width="1.2" fill="none"/>
+    <!-- Folded corner detail -->
+    <polyline points="148,148 180,148 180,172 148,172 148,148" stroke="#4ade80" stroke-width="0.8" fill="none"/>
+    <line x1="148" y1="148" x2="180" y2="172" stroke="#4ade80" stroke-width="0.8"/>
+    <!-- ## Section heading lines (bold = H2, thin = body) -->
+    <line x1="70" y1="190" x2="160" y2="190" stroke="#4ade80" stroke-width="1.6"/>
+    <line x1="70" y1="205" x2="148" y2="205" stroke="#4ade80" stroke-width="0.5"/>
+    <line x1="70" y1="215" x2="153" y2="215" stroke="#4ade80" stroke-width="0.5"/>
+    <line x1="70" y1="237" x2="160" y2="237" stroke="#4ade80" stroke-width="1.6"/>
+    <line x1="70" y1="252" x2="143" y2="252" stroke="#4ade80" stroke-width="0.5"/>
+    <line x1="70" y1="262" x2="150" y2="262" stroke="#4ade80" stroke-width="0.5"/>
+    <line x1="70" y1="284" x2="160" y2="284" stroke="#4ade80" stroke-width="1.6"/>
+    <line x1="70" y1="299" x2="140" y2="299" stroke="#4ade80" stroke-width="0.5"/>
+    <line x1="70" y1="309" x2="147" y2="309" stroke="#4ade80" stroke-width="0.5"/>
+    <!-- Branch stem from file right edge to hub -->
+    <line x1="180" y1="240" x2="248" y2="240" stroke="#06b6d4" stroke-width="1.2"/>
+    <!-- Three branch lines from hub to notes -->
+    <path d="M 248,240 L 248,175 L 308,175" stroke="#06b6d4" stroke-width="1" fill="none" marker-end="url(#cli-arr-c)"/>
+    <line x1="248" y1="240" x2="308" y2="240" stroke="#06b6d4" stroke-width="1" marker-end="url(#cli-arr-c)"/>
+    <path d="M 248,240 L 248,305 L 308,305" stroke="#06b6d4" stroke-width="1" fill="none" marker-end="url(#cli-arr-c)"/>
+    <!-- Note card 1 -->
+    <rect x="318" y="148" width="110" height="54" rx="4" stroke="#4ade80" stroke-width="1.1" fill="none"/>
+    <line x1="332" y1="165" x2="414" y2="165" stroke="#4ade80" stroke-width="1.4"/>
+    <line x1="332" y1="178" x2="404" y2="178" stroke="#4ade80" stroke-width="0.5"/>
+    <line x1="332" y1="188" x2="408" y2="188" stroke="#4ade80" stroke-width="0.5"/>
+    <!-- Note card 2 -->
+    <rect x="318" y="213" width="110" height="54" rx="4" stroke="#06b6d4" stroke-width="1.1" fill="none"/>
+    <line x1="332" y1="230" x2="414" y2="230" stroke="#06b6d4" stroke-width="1.4"/>
+    <line x1="332" y1="243" x2="400" y2="243" stroke="#06b6d4" stroke-width="0.5"/>
+    <line x1="332" y1="253" x2="406" y2="253" stroke="#06b6d4" stroke-width="0.5"/>
+    <!-- Note card 3 -->
+    <rect x="318" y="278" width="110" height="54" rx="4" stroke="#4ade80" stroke-width="1.1" fill="none"/>
+    <line x1="332" y1="295" x2="414" y2="295" stroke="#4ade80" stroke-width="1.4"/>
+    <line x1="332" y1="308" x2="398" y2="308" stroke="#4ade80" stroke-width="0.5"/>
+    <line x1="332" y1="318" x2="404" y2="318" stroke="#4ade80" stroke-width="0.5"/>
+    <!-- Faint hub dot -->
+    <circle cx="248" cy="240" r="3" stroke="#06b6d4" stroke-width="1" fill="none"/>
+    <!-- Faint label line under file: MEMORY.md -->
+    <line x1="86" y1="346" x2="146" y2="346" stroke="#4ade80" stroke-width="0.5"/>
+  </svg>
+  <div class="container">
+    <div class="section-label">CLI</div>
+    <h2 class="section-title">Commands for your terminal.</h2>
+    <p class="section-desc">Vault maintenance and onboarding without an MCP client. Run them directly from the shell.</p>
+
+    <div class="quickstart-grid fade-up" style="margin-top:48px;gap:40px">
+
+      <div class="qs-col">
+        <h3>mnemonic migrate</h3>
+        <p style="color:var(--text-dim);font-size:0.9rem;margin-bottom:16px">Apply pending schema migrations to your vaults. Always preview with <code>--dry-run</code> first — failed runs roll staged writes back automatically.</p>
+        <div class="code-block">
+          <div class="code-block-header">
+            <span class="code-label">bash</span>
+            <button class="copy-btn" onclick="copyCode(this)">copy</button>
+          </div>
+          <pre><span class="cmt"># Preview what would change</span>
+<span class="cmd">mnemonic migrate --dry-run</span>
+
+<span class="cmt"># Apply and auto-commit</span>
+<span class="cmd">mnemonic migrate</span>
+
+<span class="cmt"># List available migrations</span>
+<span class="cmd">mnemonic migrate --list</span>
+
+<span class="cmt"># Limit to one project vault</span>
+<span class="cmd">mnemonic migrate --cwd=/path/to/project</span></pre>
+        </div>
+      </div>
+
+      <div class="qs-col">
+        <h3>mnemonic import-claude-memory</h3>
+        <p style="color:var(--text-dim);font-size:0.9rem;margin-bottom:16px">Import <a href="https://docs.anthropic.com/en/docs/claude-code/memory" style="color:var(--cyan-lt);text-decoration:none" target="_blank" rel="noopener">Claude Code auto-memory</a> into your vault. Each <code>##</code> heading in <code>~/.claude/projects/&lt;project&gt;/memory/*.md</code> becomes a separate mnemonic note — independently searchable via <code>recall</code>. Duplicate titles are skipped, so it's safe to re-run.</p>
+        <div class="code-block">
+          <div class="code-block-header">
+            <span class="code-label">bash</span>
+            <button class="copy-btn" onclick="copyCode(this)">copy</button>
+          </div>
+          <pre><span class="cmt"># Preview what would be imported</span>
+<span class="cmd">mnemonic import-claude-memory --dry-run</span>
+
+<span class="cmt"># Import for the current project</span>
+<span class="cmd">mnemonic import-claude-memory</span>
+
+<span class="cmt"># Specific project path</span>
+<span class="cmd">mnemonic import-claude-memory --cwd=/path/to/project</span>
+
+<span class="cmt"># Then embed and push</span>
+<span class="cmd">mnemonic sync</span></pre>
+        </div>
+      </div>
+
     </div>
   </div>
 </section>

--- a/src/import.ts
+++ b/src/import.ts
@@ -1,0 +1,42 @@
+/**
+ * Parses a Claude Code auto-memory file into importable sections.
+ *
+ * Claude Code MEMORY.md files may contain multiple `# Project` blocks,
+ * each with `##` subsections. Each subsection becomes one mnemonic note.
+ * The H1 project heading is prepended to the section title so notes are
+ * self-identifying: "DocsEngine: Key Architecture" rather than just
+ * "Key Architecture".
+ */
+export function parseMemorySections(content: string): Array<{ title: string; content: string }> {
+  const lines = content.split("\n");
+  const sections: Array<{ title: string; content: string }> = [];
+  let currentH1 = "";
+  let currentTitle = "";
+  let currentLines: string[] = [];
+
+  const flush = () => {
+    if (currentTitle) {
+      const title = currentH1 ? `${currentH1}: ${currentTitle}` : currentTitle;
+      sections.push({ title, content: currentLines.join("\n").trim() });
+    }
+  };
+
+  for (const line of lines) {
+    if (line.startsWith("# ") && !line.startsWith("## ")) {
+      flush();
+      currentH1 = line.slice(2).trim();
+      currentTitle = "";
+      currentLines = [];
+    } else if (line.startsWith("## ")) {
+      flush();
+      currentTitle = line.slice(3).trim();
+      currentLines = [];
+    } else if (currentTitle) {
+      currentLines.push(line);
+    }
+  }
+
+  flush();
+
+  return sections.filter(s => s.content.length > 0);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -216,14 +216,25 @@ if (process.argv[2] === "import-claude-memory") {
   function parseMemorySections(content: string): Array<{ title: string; content: string }> {
     const lines = content.split("\n");
     const sections: Array<{ title: string; content: string }> = [];
+    let currentH1 = "";
     let currentTitle = "";
     let currentLines: string[] = [];
 
+    const flush = () => {
+      if (currentTitle) {
+        const title = currentH1 ? `${currentH1}: ${currentTitle}` : currentTitle;
+        sections.push({ title, content: currentLines.join("\n").trim() });
+      }
+    };
+
     for (const line of lines) {
-      if (line.startsWith("## ")) {
-        if (currentTitle) {
-          sections.push({ title: currentTitle, content: currentLines.join("\n").trim() });
-        }
+      if (line.startsWith("# ") && !line.startsWith("## ")) {
+        flush();
+        currentH1 = line.slice(2).trim();
+        currentTitle = "";
+        currentLines = [];
+      } else if (line.startsWith("## ")) {
+        flush();
         currentTitle = line.slice(3).trim();
         currentLines = [];
       } else if (currentTitle) {
@@ -231,9 +242,7 @@ if (process.argv[2] === "import-claude-memory") {
       }
     }
 
-    if (currentTitle) {
-      sections.push({ title: currentTitle, content: currentLines.join("\n").trim() });
-    }
+    flush();
 
     return sections.filter(s => s.content.length > 0);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ import { classifyTheme, summarizePreview, titleCaseTheme } from "./project-intro
 import { detectProject, resolveProjectIdentity, type ProjectIdentityResolution } from "./project.js";
 import { VaultManager, type Vault } from "./vault.js";
 import { Migrator } from "./migration.js";
+import { parseMemorySections } from "./import.js";
 import type {
   StructuredResponse,
   RememberResult,
@@ -205,47 +206,15 @@ Examples:
 // ── CLI: import-claude-memory ─────────────────────────────────────────────────
 
 if (process.argv[2] === "import-claude-memory") {
+  const homeDir = process.env["HOME"] ?? process.env["USERPROFILE"] ?? "~";
+
   const VAULT_PATH = process.env["VAULT_PATH"]
     ? path.resolve(process.env["VAULT_PATH"])
-    : path.join(process.env["HOME"] ?? "~", "mnemonic-vault");
+    : path.join(homeDir, "mnemonic-vault");
 
   const CLAUDE_HOME = process.env["CLAUDE_HOME"]
     ? path.resolve(process.env["CLAUDE_HOME"])
-    : path.join(process.env["HOME"] ?? "~", ".claude");
-
-  function parseMemorySections(content: string): Array<{ title: string; content: string }> {
-    const lines = content.split("\n");
-    const sections: Array<{ title: string; content: string }> = [];
-    let currentH1 = "";
-    let currentTitle = "";
-    let currentLines: string[] = [];
-
-    const flush = () => {
-      if (currentTitle) {
-        const title = currentH1 ? `${currentH1}: ${currentTitle}` : currentTitle;
-        sections.push({ title, content: currentLines.join("\n").trim() });
-      }
-    };
-
-    for (const line of lines) {
-      if (line.startsWith("# ") && !line.startsWith("## ")) {
-        flush();
-        currentH1 = line.slice(2).trim();
-        currentTitle = "";
-        currentLines = [];
-      } else if (line.startsWith("## ")) {
-        flush();
-        currentTitle = line.slice(3).trim();
-        currentLines = [];
-      } else if (currentTitle) {
-        currentLines.push(line);
-      }
-    }
-
-    flush();
-
-    return sections.filter(s => s.content.length > 0);
-  }
+    : path.join(homeDir, ".claude");
 
   function makeImportNoteId(title: string): string {
     const slug = title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60);
@@ -293,7 +262,8 @@ Examples:
 
     // Encode the project path the same way Claude Code does:
     // /Users/foo/Projects/bar → -Users-foo-Projects-bar
-    const projectDirName = targetCwd.replace(/\//g, "-");
+    // On Windows both \ and / are replaced with -
+    const projectDirName = targetCwd.replace(/[/\\]/g, "-");
     const memoryDir = path.join(claudeHome, "projects", projectDirName, "memory");
 
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -202,6 +202,194 @@ Examples:
   await new Promise(() => {});
 }
 
+// ── CLI: import-claude-memory ─────────────────────────────────────────────────
+
+if (process.argv[2] === "import-claude-memory") {
+  const VAULT_PATH = process.env["VAULT_PATH"]
+    ? path.resolve(process.env["VAULT_PATH"])
+    : path.join(process.env["HOME"] ?? "~", "mnemonic-vault");
+
+  const CLAUDE_HOME = process.env["CLAUDE_HOME"]
+    ? path.resolve(process.env["CLAUDE_HOME"])
+    : path.join(process.env["HOME"] ?? "~", ".claude");
+
+  function parseMemorySections(content: string): Array<{ title: string; content: string }> {
+    const lines = content.split("\n");
+    const sections: Array<{ title: string; content: string }> = [];
+    let currentTitle = "";
+    let currentLines: string[] = [];
+
+    for (const line of lines) {
+      if (line.startsWith("## ")) {
+        if (currentTitle) {
+          sections.push({ title: currentTitle, content: currentLines.join("\n").trim() });
+        }
+        currentTitle = line.slice(3).trim();
+        currentLines = [];
+      } else if (currentTitle) {
+        currentLines.push(line);
+      }
+    }
+
+    if (currentTitle) {
+      sections.push({ title: currentTitle, content: currentLines.join("\n").trim() });
+    }
+
+    return sections.filter(s => s.content.length > 0);
+  }
+
+  function makeImportNoteId(title: string): string {
+    const slug = title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60);
+    const suffix = randomUUID().split("-")[0]!;
+    return slug ? `${slug}-${suffix}` : suffix;
+  }
+
+  async function runImportCli() {
+    const argv = process.argv.slice(3);
+
+    if (argv.includes("--help") || argv.includes("-h")) {
+      console.log(`
+Mnemonic: Import Claude Code Auto-Memory
+
+Usage:
+  mnemonic import-claude-memory [options]
+
+Options:
+  --dry-run         Show what would be imported without writing anything
+  --cwd=<path>      Project path to resolve Claude memory for (default: cwd)
+  --claude-home=<p> Claude home directory (default: ~/.claude, or $CLAUDE_HOME)
+  --help            Show this help message
+
+How it works:
+  Claude Code stores per-project auto-memory in:
+    ~/.claude/projects/<encoded-path>/memory/*.md
+
+  Each ## heading in those files becomes a separate mnemonic note
+  tagged with "claude-memory" and "imported". Notes with duplicate
+  titles are skipped.
+
+Examples:
+  mnemonic import-claude-memory --dry-run
+  mnemonic import-claude-memory
+  mnemonic import-claude-memory --cwd=/path/to/project
+`);
+      process.exit(0);
+    }
+
+    const dryRun = argv.includes("--dry-run");
+    const cwdOption = argv.find(arg => arg.startsWith("--cwd="));
+    const targetCwd = cwdOption ? path.resolve(cwdOption.split("=")[1]!) : process.cwd();
+    const claudeHomeOption = argv.find(arg => arg.startsWith("--claude-home="));
+    const claudeHome = claudeHomeOption ? path.resolve(claudeHomeOption.split("=")[1]!) : CLAUDE_HOME;
+
+    // Encode the project path the same way Claude Code does:
+    // /Users/foo/Projects/bar → -Users-foo-Projects-bar
+    const projectDirName = targetCwd.replace(/\//g, "-");
+    const memoryDir = path.join(claudeHome, "projects", projectDirName, "memory");
+
+    try {
+      await fs.access(memoryDir);
+    } catch {
+      console.log(`No Claude memory found for this project.`);
+      console.log(`Expected: ${memoryDir}`);
+      process.exit(0);
+    }
+
+    const files = (await fs.readdir(memoryDir)).filter(f => f.endsWith(".md")).sort();
+    if (files.length === 0) {
+      console.log("No markdown files found in Claude memory directory.");
+      process.exit(0);
+    }
+
+    console.log(`Found ${files.length} file(s) in ${memoryDir}`);
+
+    const vaultManager = new VaultManager(VAULT_PATH);
+    await vaultManager.initMain();
+    const vault = vaultManager.main;
+
+    const existingNotes = await vault.storage.listNotes();
+    const existingTitles = new Set(existingNotes.map(n => n.title.toLowerCase()));
+
+    const now = new Date().toISOString();
+    const notesToWrite: import("./storage.js").Note[] = [];
+    const skipped: string[] = [];
+
+    for (const file of files) {
+      const raw = await fs.readFile(path.join(memoryDir, file), "utf-8");
+      const sections = parseMemorySections(raw);
+      const sourceTag = file.replace(/\.md$/i, "").toLowerCase().replace(/[^a-z0-9]+/g, "-");
+
+      for (const section of sections) {
+        if (existingTitles.has(section.title.toLowerCase())) {
+          skipped.push(section.title);
+          continue;
+        }
+
+        notesToWrite.push({
+          id: makeImportNoteId(section.title),
+          title: section.title,
+          content: section.content,
+          tags: ["claude-memory", "imported", sourceTag],
+          lifecycle: "permanent",
+          createdAt: now,
+          updatedAt: now,
+          memoryVersion: 1,
+        });
+      }
+    }
+
+    if (skipped.length > 0) {
+      console.log(`\nSkipped (title already exists in vault):`);
+      skipped.forEach(t => console.log(`  ~ ${t}`));
+    }
+
+    if (notesToWrite.length === 0) {
+      console.log("\nNothing new to import.");
+      process.exit(0);
+    }
+
+    console.log(`\nSections to import (${notesToWrite.length}):`);
+    notesToWrite.forEach(n => console.log(`  + ${n.title}`));
+
+    if (dryRun) {
+      console.log("\n✓ Dry-run complete — no changes written");
+      process.exit(0);
+    }
+
+    const filesToCommit: string[] = [];
+    for (const note of notesToWrite) {
+      await vault.storage.writeNote(note);
+      filesToCommit.push(`notes/${note.id}.md`);
+    }
+
+    const commitMessage = [
+      `import: claude-memory (${notesToWrite.length} note${notesToWrite.length === 1 ? "" : "s"})`,
+      "",
+      `- Notes: ${notesToWrite.length}`,
+      `- Source: ${memoryDir}`,
+      `- Skipped: ${skipped.length} (already exist)`,
+    ].join("\n");
+
+    try {
+      await vault.git.commit(commitMessage, filesToCommit);
+      await vault.git.push();
+    } catch (err) {
+      console.error(`\nNotes written but git operation failed: ${err}`);
+    }
+
+    console.log(`\n✓ Imported ${notesToWrite.length} note${notesToWrite.length === 1 ? "" : "s"} into main vault`);
+    process.exit(0);
+  }
+
+  runImportCli().catch(err => {
+    console.error("Import failed:", err);
+    process.exit(1);
+  });
+
+  // Wait for async operations to complete
+  await new Promise(() => {});
+}
+
 // ── Config ────────────────────────────────────────────────────────────────────
 
 const VAULT_PATH = process.env["VAULT_PATH"]

--- a/tests/import.test.ts
+++ b/tests/import.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { parseMemorySections } from "../src/import.js";
+
+describe("parseMemorySections", () => {
+  it("parses a single H2 section without an H1 prefix", () => {
+    const input = `## Architecture\n- Uses multi-vault design\n- Embeddings are gitignored`;
+    const result = parseMemorySections(input);
+    expect(result).toEqual([
+      { title: "Architecture", content: "- Uses multi-vault design\n- Embeddings are gitignored" },
+    ]);
+  });
+
+  it("prepends H1 project title to each H2 section — the typical Claude memory file shape", () => {
+    // Claude Code auto-memory files have one # title at the top followed by ## sections
+    const input = [
+      "# Acme Connector",
+      "## Project Structure",
+      "- main project: `src/Acme/`",
+      "- tests: `src/UnitTests/`",
+      "",
+      "## Key Design Decisions",
+      "- adapter skips retry messages",
+      "- assembly signing required",
+    ].join("\n");
+
+    const result = parseMemorySections(input);
+    expect(result).toEqual([
+      {
+        title: "Acme Connector: Project Structure",
+        content: "- main project: `src/Acme/`\n- tests: `src/UnitTests/`",
+      },
+      {
+        title: "Acme Connector: Key Design Decisions",
+        content: "- adapter skips retry messages\n- assembly signing required",
+      },
+    ]);
+  });
+
+  it("handles multiple H1 blocks in one file as an edge case", () => {
+    // Unlikely in practice (each project has its own MEMORY.md) but handled gracefully
+    const input = [
+      "# Alpha Project",
+      "## Key Decisions",
+      "- chose X over Y",
+      "",
+      "# Beta Project",
+      "## Key Decisions",
+      "- chose A over B",
+    ].join("\n");
+
+    const result = parseMemorySections(input);
+    expect(result).toHaveLength(2);
+    expect(result[0]!.title).toBe("Alpha Project: Key Decisions");
+    expect(result[1]!.title).toBe("Beta Project: Key Decisions");
+  });
+
+  it("preserves multi-line content under each section", () => {
+    const input = `# Proj\n## Notes\nline one\nline two\nline three`;
+    const [section] = parseMemorySections(input);
+    expect(section!.content).toBe("line one\nline two\nline three");
+  });
+
+  it("trims leading and trailing blank lines from section content", () => {
+    const input = `## Section\n\n- item\n\n`;
+    const [section] = parseMemorySections(input);
+    expect(section!.content).toBe("- item");
+  });
+
+  it("skips sections with no content", () => {
+    const input = `## Empty\n\n## HasContent\n- something`;
+    const result = parseMemorySections(input);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.title).toBe("HasContent");
+  });
+
+  it("handles content before the first H1 that has no H2 sections", () => {
+    const input = `# Preamble only\nno sections here\n# Real\n## Stuff\n- content`;
+    const result = parseMemorySections(input);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.title).toBe("Real: Stuff");
+  });
+
+  it("returns empty array for a file with no sections", () => {
+    expect(parseMemorySections("")).toEqual([]);
+    expect(parseMemorySections("# Just a title\n")).toEqual([]);
+    expect(parseMemorySections("some prose with no headings")).toEqual([]);
+  });
+
+  it("does not treat ### as an H2 section boundary", () => {
+    const input = `## Parent\n### Child\n- nested content`;
+    const [section] = parseMemorySections(input);
+    expect(section!.title).toBe("Parent");
+    expect(section!.content).toBe("### Child\n- nested content");
+  });
+
+  it("handles multiple H2 sections under the same H1", () => {
+    const input = `# Project\n## Section A\ncontent a\n## Section B\ncontent b\n## Section C\ncontent c`;
+    const result = parseMemorySections(input);
+    expect(result.map(s => s.title)).toEqual([
+      "Project: Section A",
+      "Project: Section B",
+      "Project: Section C",
+    ]);
+  });
+});


### PR DESCRIPTION
This pull request introduces a new CLI command, `mnemonic import-claude-memory`, which allows users to import Claude Code auto-memory into their mnemonic vault. The implementation includes robust deduplication, section splitting, and flexible configuration. Documentation and onboarding have been updated to reflect this new feature, including examples and visual explanations.

New CLI command: Claude memory import

* Added `mnemonic import-claude-memory` CLI command to import Claude Code auto-memory files from `~/.claude/projects/<encoded-path>/memory/*.md` into the main mnemonic vault. Each file is split into sections based on `##` headings, and each section becomes a separate note. Duplicate titles are skipped, and notes are tagged with `claude-memory`, `imported`, and a filename slug. (`src/index.ts`, `.mnemonic/notes/import-claude-memory-cli-command-design-and-implementation-dcdc5a05.md`, [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R205-R392) [[2]](diffhunk://#diff-701af6e30cb2ba401b80f7ba4fef5bef83706ce3684f48fdfc24be74803a4893R1-R47)

* Supports `--dry-run`, `--cwd`, `--claude-home`, and `--help` options for flexible usage and previewing imports. (`src/index.ts`, [src/index.tsR205-R392](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R205-R392))

Documentation and onboarding

* Added detailed documentation for the new command in `README.md` under "CLI utilities", including usage examples and explanations of import behavior. (`README.md`, [README.mdR103-R145](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R103-R145))
* Updated onboarding and setup in `docs/index.html` with a new "CLI" section, visual diagrams, and quickstart code blocks for both `migrate` and `import-claude-memory` commands. (`docs/index.html`, [[1]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeR1046) [[2]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeR1814-R1921)

Design decisions

* Notes are imported with `lifecycle: permanent` and `scope: global`, and embedding is deferred until after import. The command is safe to re-run, and imported notes are never overwritten. (`.mnemonic/notes/import-claude-memory-cli-command-design-and-implementation-dcdc5a05.md`, [.mnemonic/notes/import-claude-memory-cli-command-design-and-implementation-dcdc5a05.mdR1-R47](diffhunk://#diff-701af6e30cb2ba401b80f7ba4fef5bef83706ce3684f48fdfc24be74803a4893R1-R47))