### PR TITLE
Fix home path expansion for vault/Claude config and release 0.3.1

### DIFF
--- a/.mnemonic/notes/import-claude-memory-cli-command-design-and-implementation-dcdc5a05.md
+++ b/.mnemonic/notes/import-claude-memory-cli-command-design-and-implementation-dcdc5a05.md
@@ -7,9 +7,12 @@ tags:
   - design-decision
 lifecycle: permanent
 createdAt: '2026-03-09T21:24:01.304Z'
-updatedAt: '2026-03-09T21:24:01.304Z'
+updatedAt: '2026-03-11T10:32:28.981Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: path-resolution-support-both-absolute-and-tilde-home-paths-e48a0280
+    type: related-to
 memoryVersion: 1
 ---
 Added `mnemonic import-claude-memory` CLI command to import Claude Code auto-memory into the mnemonic vault.

--- a/.mnemonic/notes/mnemonic-source-file-layout-4d11294d.md
+++ b/.mnemonic/notes/mnemonic-source-file-layout-4d11294d.md
@@ -7,7 +7,7 @@ tags:
   - structure
 lifecycle: permanent
 createdAt: '2026-03-07T17:58:59.865Z'
-updatedAt: '2026-03-07T19:11:53.717Z'
+updatedAt: '2026-03-11T10:32:28.988Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
@@ -15,6 +15,8 @@ relatedTo:
     type: explains
   - id: mnemonic-bugs-fixed-during-initial-setup-e4faea32
     type: related-to
+  - id: path-resolution-support-both-absolute-and-tilde-home-paths-e48a0280
+    type: explains
 memoryVersion: 1
 ---
 All runtime TypeScript source files live under `src/` to keep the repository layout obvious and predictable.

--- a/.mnemonic/notes/path-resolution-support-both-absolute-and-tilde-home-paths-e48a0280.md
+++ b/.mnemonic/notes/path-resolution-support-both-absolute-and-tilde-home-paths-e48a0280.md
@@ -7,7 +7,7 @@ tags:
   - configuration
 lifecycle: permanent
 createdAt: '2026-03-11T10:30:20.416Z'
-updatedAt: '2026-03-11T10:30:20.416Z'
+updatedAt: '2026-03-11T10:30:56.887Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 memoryVersion: 1
@@ -28,11 +28,17 @@ Using `path.resolve("~/mnemonic-vault")` does **not** expand `~`; Node treats it
   - MCP startup `VAULT_PATH`
   - `migrate` command `VAULT_PATH`
   - `import-claude-memory` `VAULT_PATH` and `CLAUDE_HOME`
+  - `import-claude-memory` CLI options `--cwd=` and `--claude-home=`
 - Added `tests/paths.test.ts` to lock behavior for:
   - tilde expansion
   - absolute path pass-through
   - USERPROFILE fallback
   - sane defaults when env is missing
+
+## Audit findings
+
+- Remaining `path.resolve(...)` calls in `config.ts`, `vault.ts`, and `storage.ts` operate on already-resolved/internal paths and are safe.
+- Risk pattern to avoid: directly calling `path.resolve` on raw user/env path inputs.
 
 ## Rule going forward
 

--- a/.mnemonic/notes/path-resolution-support-both-absolute-and-tilde-home-paths-e48a0280.md
+++ b/.mnemonic/notes/path-resolution-support-both-absolute-and-tilde-home-paths-e48a0280.md
@@ -7,9 +7,14 @@ tags:
   - configuration
 lifecycle: permanent
 createdAt: '2026-03-11T10:30:20.416Z'
-updatedAt: '2026-03-11T10:30:56.887Z'
+updatedAt: '2026-03-11T10:32:28.988Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: import-claude-memory-cli-command-design-and-implementation-dcdc5a05
+    type: related-to
+  - id: mnemonic-source-file-layout-4d11294d
+    type: explains
 memoryVersion: 1
 ---
 Key learning: configuration paths must support both absolute paths and home-directory shorthand (`~`), not just absolute paths.

--- a/.mnemonic/notes/path-resolution-support-both-absolute-and-tilde-home-paths-e48a0280.md
+++ b/.mnemonic/notes/path-resolution-support-both-absolute-and-tilde-home-paths-e48a0280.md
@@ -1,0 +1,39 @@
+---
+title: 'Path resolution: support both absolute and tilde home paths'
+tags:
+  - path-resolution
+  - vault
+  - bugfix
+  - configuration
+lifecycle: permanent
+createdAt: '2026-03-11T10:30:20.416Z'
+updatedAt: '2026-03-11T10:30:20.416Z'
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+Key learning: configuration paths must support both absolute paths and home-directory shorthand (`~`), not just absolute paths.
+
+## Problem observed
+
+Using `path.resolve("~/mnemonic-vault")` does **not** expand `~`; Node treats it as a normal directory name relative to cwd. This can silently point mnemonic to the wrong vault.
+
+## Fix applied
+
+- Added path utilities in `src/paths.ts`:
+  - `expandHomePath()` to expand `~`, `~/...`, and `~\\...` using `HOME`/`USERPROFILE`.
+  - `resolveUserPath()` to combine home-expansion with absolute resolution.
+  - `defaultVaultPath()` and `defaultClaudeHome()` defaults.
+- Updated `src/index.ts` to use these helpers for:
+  - MCP startup `VAULT_PATH`
+  - `migrate` command `VAULT_PATH`
+  - `import-claude-memory` `VAULT_PATH` and `CLAUDE_HOME`
+- Added `tests/paths.test.ts` to lock behavior for:
+  - tilde expansion
+  - absolute path pass-through
+  - USERPROFILE fallback
+  - sane defaults when env is missing
+
+## Rule going forward
+
+All user-configurable filesystem paths should pass through a home-expansion helper before `path.resolve` so both absolute paths and home shorthand work predictably.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to `mnemonic` will be documented in this file.
 
 The format is loosely based on Keep a Changelog and uses semver-style version headings.
 
+## [0.3.1] - 2026-03-11
+
+### Fixed
+
+- Path resolution now correctly supports home-directory shorthand (`~`) for user-configurable paths before absolute resolution. `VAULT_PATH` and `CLAUDE_HOME` no longer resolve to accidental cwd-relative paths when configured with tildes.
+- `import-claude-memory` now applies the same home-aware path resolution to CLI options (`--cwd`, `--claude-home`) for consistent behavior across absolute and home-based paths.
+
 ## [0.3.0] - 2026-03-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A local MCP memory server backed by markdown + JSON files, synced via git",
   "type": "module",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import { detectProject, resolveProjectIdentity, type ProjectIdentityResolution }
 import { VaultManager, type Vault } from "./vault.js";
 import { Migrator } from "./migration.js";
 import { parseMemorySections } from "./import.js";
+import { defaultClaudeHome, defaultVaultPath, resolveUserPath } from "./paths.js";
 import type {
   StructuredResponse,
   RememberResult,
@@ -82,8 +83,8 @@ import {
 
 if (process.argv[2] === "migrate") {
   const VAULT_PATH = process.env["VAULT_PATH"]
-    ? path.resolve(process.env["VAULT_PATH"])
-    : path.join(process.env["HOME"] ?? "~", "mnemonic-vault");
+    ? resolveUserPath(process.env["VAULT_PATH"])
+    : defaultVaultPath();
 
   async function runMigrationCli() {
     const cwd = process.cwd();
@@ -206,15 +207,13 @@ Examples:
 // ── CLI: import-claude-memory ─────────────────────────────────────────────────
 
 if (process.argv[2] === "import-claude-memory") {
-  const homeDir = process.env["HOME"] ?? process.env["USERPROFILE"] ?? "~";
-
   const VAULT_PATH = process.env["VAULT_PATH"]
-    ? path.resolve(process.env["VAULT_PATH"])
-    : path.join(homeDir, "mnemonic-vault");
+    ? resolveUserPath(process.env["VAULT_PATH"])
+    : defaultVaultPath();
 
   const CLAUDE_HOME = process.env["CLAUDE_HOME"]
-    ? path.resolve(process.env["CLAUDE_HOME"])
-    : path.join(homeDir, ".claude");
+    ? resolveUserPath(process.env["CLAUDE_HOME"])
+    : defaultClaudeHome();
 
   function makeImportNoteId(title: string): string {
     const slug = title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60);
@@ -256,9 +255,9 @@ Examples:
 
     const dryRun = argv.includes("--dry-run");
     const cwdOption = argv.find(arg => arg.startsWith("--cwd="));
-    const targetCwd = cwdOption ? path.resolve(cwdOption.split("=")[1]!) : process.cwd();
+    const targetCwd = cwdOption ? resolveUserPath(cwdOption.split("=")[1]!) : process.cwd();
     const claudeHomeOption = argv.find(arg => arg.startsWith("--claude-home="));
-    const claudeHome = claudeHomeOption ? path.resolve(claudeHomeOption.split("=")[1]!) : CLAUDE_HOME;
+    const claudeHome = claudeHomeOption ? resolveUserPath(claudeHomeOption.split("=")[1]!) : CLAUDE_HOME;
 
     // Encode the project path the same way Claude Code does:
     // /Users/foo/Projects/bar → -Users-foo-Projects-bar
@@ -376,8 +375,8 @@ Examples:
 // ── Config ────────────────────────────────────────────────────────────────────
 
 const VAULT_PATH = process.env["VAULT_PATH"]
-  ? path.resolve(process.env["VAULT_PATH"])
-  : path.join(process.env["HOME"] ?? "~", "mnemonic-vault");
+  ? resolveUserPath(process.env["VAULT_PATH"])
+  : defaultVaultPath();
 
 const DEFAULT_RECALL_LIMIT = 5;
 const DEFAULT_MIN_SIMILARITY = 0.3;

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,0 +1,40 @@
+import path from "path";
+import os from "os";
+
+type PathEnv = {
+  HOME?: string;
+  USERPROFILE?: string;
+};
+
+function homeDirectory(env: PathEnv = process.env): string | undefined {
+  return env.HOME ?? env.USERPROFILE ?? os.homedir();
+}
+
+export function expandHomePath(rawPath: string, env: PathEnv = process.env): string {
+  const home = homeDirectory(env);
+  if (!home) {
+    return rawPath;
+  }
+
+  if (rawPath === "~") {
+    return home;
+  }
+
+  if (rawPath.startsWith("~/") || rawPath.startsWith("~\\")) {
+    return path.join(home, rawPath.slice(2));
+  }
+
+  return rawPath;
+}
+
+export function resolveUserPath(rawPath: string, env: PathEnv = process.env): string {
+  return path.resolve(expandHomePath(rawPath, env));
+}
+
+export function defaultVaultPath(env: PathEnv = process.env): string {
+  return path.join(homeDirectory(env) ?? "~", "mnemonic-vault");
+}
+
+export function defaultClaudeHome(env: PathEnv = process.env): string {
+  return path.join(homeDirectory(env) ?? "~", ".claude");
+}

--- a/tests/paths.test.ts
+++ b/tests/paths.test.ts
@@ -1,0 +1,36 @@
+import os from "os";
+import path from "path";
+import { describe, expect, it } from "vitest";
+
+import { defaultClaudeHome, defaultVaultPath, expandHomePath, resolveUserPath } from "../src/paths.js";
+
+describe("path resolution", () => {
+  it("expands a tilde home prefix", () => {
+    const resolved = resolveUserPath("~/mnemonic-vault", { HOME: "/tmp/home" });
+    expect(resolved).toBe(path.resolve("/tmp/home", "mnemonic-vault"));
+  });
+
+  it("keeps absolute paths unchanged", () => {
+    const absolute = path.resolve("/tmp/absolute-vault");
+    expect(resolveUserPath(absolute, { HOME: "/tmp/home" })).toBe(absolute);
+  });
+
+  it("does not expand non-home tildes", () => {
+    expect(expandHomePath("~other/path", { HOME: "/tmp/home" })).toBe("~other/path");
+  });
+
+  it("supports USERPROFILE fallback", () => {
+    const resolved = resolveUserPath("~/mnemonic-vault", { USERPROFILE: "C:\\Users\\daniel" });
+    expect(resolved).toBe(path.resolve("C:\\Users\\daniel", "mnemonic-vault"));
+  });
+
+  it("builds default paths from HOME", () => {
+    expect(defaultVaultPath({ HOME: "/tmp/home" })).toBe(path.join("/tmp/home", "mnemonic-vault"));
+    expect(defaultClaudeHome({ HOME: "/tmp/home" })).toBe(path.join("/tmp/home", ".claude"));
+  });
+
+  it("falls back to process home when env is missing", () => {
+    expect(defaultVaultPath({})).toBe(path.join(os.homedir(), "mnemonic-vault"));
+    expect(defaultClaudeHome({})).toBe(path.join(os.homedir(), ".claude"));
+  });
+});


### PR DESCRIPTION
- Fix path resolution for user-configurable paths so ~/home shorthand works correctly (not treated as cwd-relative), while preserving absolute path behavior.
- Apply the fix consistently across MCP startup, migrate, and import-claude-memory (including --cwd and --claude-home CLI args).
- Add src/paths.ts plus regression tests in tests/paths.test.ts, and ship as patch release 0.3.1 with changelog entry.