### PR TITLE
Consolidate `execute-merge` now resolves `sourceIds` from the full vault scan instead of the scope-filtered note list

### DIFF
--- a/.mnemonic/notes/execute-merge-scope-bug-projectnotes-filter-excludes-cross-s-99d357af.md
+++ b/.mnemonic/notes/execute-merge-scope-bug-projectnotes-filter-excludes-cross-s-99d357af.md
@@ -9,9 +9,12 @@ tags:
   - design
 lifecycle: permanent
 createdAt: '2026-03-11T11:07:07.938Z'
-updatedAt: '2026-03-11T11:07:07.938Z'
+updatedAt: '2026-03-11T11:07:16.639Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: mnemonic-consolidate-tool-design-b9cbac6a
+    type: explains
 memoryVersion: 1
 ---
 # execute-merge scope bug: projectNotes filter excludes cross-scope sources

--- a/.mnemonic/notes/execute-merge-scope-bug-projectnotes-filter-excludes-cross-s-99d357af.md
+++ b/.mnemonic/notes/execute-merge-scope-bug-projectnotes-filter-excludes-cross-s-99d357af.md
@@ -1,0 +1,58 @@
+---
+title: 'execute-merge scope bug: projectNotes filter excludes cross-scope sources'
+tags:
+  - bug
+  - consolidate
+  - execute-merge
+  - scope
+  - fix
+  - design
+lifecycle: permanent
+createdAt: '2026-03-11T11:07:07.938Z'
+updatedAt: '2026-03-11T11:07:07.938Z'
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+# execute-merge scope bug: projectNotes filter excludes cross-scope sources
+
+## What broke
+
+`consolidate` with `strategy: "execute-merge"` passed `projectNotes` (scope-filtered) to `executeMerge`, not the full `entries` list. This meant:
+
+- With `cwd`: only project-associated notes were searchable — purely global notes (no `.project` field) were silently not found.
+- Without `cwd`: only global notes were searchable — project-associated notes in main-vault were silently not found.
+
+The result was a "Source note not found" warning and a no-op merge whenever `sourceIds` spanned both a global note and a project-associated note, even when both physically lived in main-vault.
+
+## Root cause (index.ts)
+
+```typescript
+// Before fix — executeMerge only sees one scope
+const projectNotes = project
+  ? entries.filter((e) => e.note.project === project.id)
+  : entries.filter((e) => !e.note.project);
+
+return executeMerge(projectNotes, mergePlan, ...);
+```
+
+The filter is correct for discovery strategies (suggest-merges, detect-duplicates, find-clusters) where scoped analysis is intentional. But `execute-merge` with explicit `sourceIds` should never be scope-restricted — the caller has named every source explicitly.
+
+## Fix
+
+```typescript
+// After fix — executeMerge receives the full vault scan
+return executeMerge(entries, mergePlan, ...);
+```
+
+One-line change. All other strategies still receive `projectNotes`.
+
+## Design principle to preserve
+
+**Discovery strategies** (suggest-merges, detect-duplicates, find-clusters, dry-run, prune-superseded) operate on a scoped note set — this is intentional, they only analyse notes relevant to the current project or global context.
+
+**execute-merge** with explicit `sourceIds` must operate on the full entry set. The caller owns the scope decision; the tool must not second-guess it by filtering.
+
+## Test added
+
+`tests/mcp.integration.test.ts`: "merges a global note and a project-associated note in a single execute-merge call" — creates one purely global note and one project-associated-but-main-vault note, merges both without `cwd`, verifies no "not found" warning and both sources are deleted.

--- a/.mnemonic/notes/mnemonic-consolidate-tool-design-b9cbac6a.md
+++ b/.mnemonic/notes/mnemonic-consolidate-tool-design-b9cbac6a.md
@@ -7,7 +7,7 @@ tags:
   - architecture
 lifecycle: permanent
 createdAt: '2026-03-07T23:15:43.251Z'
-updatedAt: '2026-03-08T09:52:24.892Z'
+updatedAt: '2026-03-11T11:07:16.639Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
@@ -17,6 +17,8 @@ relatedTo:
     type: explains
   - id: agent-instruction-improvements-session-start-recall-first-an-ecd402c3
     type: example-of
+  - id: execute-merge-scope-bug-projectnotes-filter-excludes-cross-s-99d357af
+    type: explains
 memoryVersion: 1
 ---
 New MCP tool `consolidate` for memory consolidation with cross-vault support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `mnemonic` will be documented in this file.
 
 The format is loosely based on Keep a Changelog and uses semver-style version headings.
 
+## [0.3.2] - 2026-03-11
+
+### Fixed
+
+- `consolidate` `execute-merge` now resolves `sourceIds` from the full vault scan instead of the scope-filtered note list. Previously, merging a purely global note with a project-associated note in a single call silently failed with "Source note not found" because each scope filter excluded the other scope's notes. Explicit `sourceIds` now bypass scope filtering — the caller owns the scope decision.
+
 ## [0.3.1] - 2026-03-11
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@danielmarbach/mnemonic-mcp",
-      "version": "0.3.0",
+      "version": "0.3.2",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.1",
         "gray-matter": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A local MCP memory server backed by markdown + JSON files, synced via git",
   "type": "module",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2666,7 +2666,7 @@ server.registerTool(
         if (!mergePlan) {
           return { content: [{ type: "text", text: "execute-merge strategy requires a mergePlan with sourceIds and targetTitle." }], isError: true };
         }
-        return executeMerge(projectNotes, mergePlan, defaultConsolidationMode, project, cwd, mode);
+        return executeMerge(entries, mergePlan, defaultConsolidationMode, project, cwd, mode);
 
       case "prune-superseded":
         return pruneSuperseded(projectNotes, mode ?? defaultConsolidationMode, project);

--- a/tests/mcp.integration.test.ts
+++ b/tests/mcp.integration.test.ts
@@ -1210,6 +1210,74 @@ describe("local MCP script", () => {
     }
   }, 15000);
 
+  it("merges a global note and a project-associated note in a single execute-merge call", async () => {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mcp-vault-"));
+    const repoDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mcp-project-"));
+    tempDirs.push(vaultDir, repoDir);
+
+    await execFileAsync("git", ["init"], { cwd: repoDir });
+
+    const embeddingServer = await startFakeEmbeddingServer();
+
+    try {
+      // A purely global note — no project association, no cwd
+      const globalRemember = await callLocalMcp(vaultDir, "remember", {
+        title: "Cross scope source A (global)",
+        content: "A purely global note with no project association.",
+        tags: ["integration", "cross-scope"],
+        lifecycle: "permanent",
+        summary: "Create global note for cross-scope consolidation test",
+        scope: "global",
+      }, embeddingServer.url);
+      const globalId = extractRememberedId(globalRemember);
+
+      // A project-associated note stored in main-vault (private/global scope with cwd)
+      const projectRemember = await callLocalMcp(vaultDir, "remember", {
+        title: "Cross scope source B (project-associated, main-vault)",
+        content: "A project-associated note stored privately in main-vault.",
+        tags: ["integration", "cross-scope"],
+        lifecycle: "permanent",
+        summary: "Create project-associated note for cross-scope consolidation test",
+        cwd: repoDir,
+        scope: "global",
+      }, embeddingServer.url);
+      const projectAssociatedId = extractRememberedId(projectRemember);
+
+      // Both notes are in main-vault but have different project associations.
+      // A single execute-merge call must resolve both — previously only one scope
+      // was searched and the other source was reported as not found.
+      // Consolidate without cwd — no project context, but both notes live in main-vault.
+      // Previously this failed because the global-scope filter excluded the project-associated note.
+      const consolidateText = await callLocalMcp(vaultDir, "consolidate", {
+        strategy: "execute-merge",
+        mode: "delete",
+        mergePlan: {
+          sourceIds: [globalId, projectAssociatedId],
+          targetTitle: "Cross scope consolidated note",
+          content: "Merged content from a global note and a project-associated note.",
+        },
+      }, embeddingServer.url);
+
+      expect(consolidateText).not.toContain("not found");
+      expect(consolidateText).toContain("Mode: delete");
+      expect(consolidateText).toContain("Source notes deleted.");
+
+      const consolidatedIdMatch = consolidateText.match(/Consolidated \d+ notes into '([^']+)'/);
+      expect(consolidatedIdMatch).toBeTruthy();
+      const consolidatedId = consolidatedIdMatch![1]!;
+
+      const consolidatedPath = path.join(vaultDir, "notes", `${consolidatedId}.md`);
+      const consolidatedContents = await readFile(consolidatedPath, "utf-8");
+      expect(consolidatedContents).toContain("Merged content from a global note and a project-associated note.");
+
+      // Both source notes must be gone
+      await expect(stat(path.join(vaultDir, "notes", `${globalId}.md`))).rejects.toThrow();
+      await expect(stat(path.join(vaultDir, "notes", `${projectAssociatedId}.md`))).rejects.toThrow();
+    } finally {
+      await embeddingServer.close();
+    }
+  }, 15000);
+
   it("rebuilds all embeddings during sync when force=true", async () => {
     const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mcp-vault-"));
     tempDirs.push(vaultDir);


### PR DESCRIPTION
`consolidate` `execute-merge` now resolves `sourceIds` from the full vault scan instead of the scope-filtered note list. Pre     viously, merging a purely global note with a project-associated note in a single call silently failed with "Source note not fo       und" because each scope filter excluded the other scope's notes. Explicit `sourceIds` now bypass scope filtering — the caller owns the scope decision.    