### PR TITLE
Ask where to store for uninitialized projects

### DIFF
--- a/.mnemonic/notes/project-memory-policy-defaults-storage-location-f563f634.md
+++ b/.mnemonic/notes/project-memory-policy-defaults-storage-location-f563f634.md
@@ -5,9 +5,10 @@ tags:
   - scope
   - storage
   - ux
+  - unadopted
 lifecycle: permanent
 createdAt: '2026-03-07T19:25:37.785Z'
-updatedAt: '2026-03-07T19:41:05.715Z'
+updatedAt: '2026-03-11T11:25:50.075Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
@@ -24,3 +25,15 @@ Decision: project context and storage location are separate, and each project ca
 - `set_project_memory_policy` supports `project`, `global`, and `ask`.
 - When the policy is `ask`, agents should present a clear storage selection instead of guessing.
 - `update` no longer rewrites project metadata just because `cwd` was passed for lookup.
+
+## Unadopted project detection (added 2026-03-11)
+
+For projects with no saved policy AND no existing `.mnemonic/` directory, `resolveWriteScope()` returns `"ask"` instead of silently creating `.mnemonic/`. This prevents mnemonic from adopting a project without the user's knowledge.
+
+- The `projectVaultExists` boolean is the signal: `false` = unadopted, `true` = already adopted.
+- Policy config is stored in `~/mnemonic-vault/config.json` (main vault), not in `.mnemonic/`.
+- `projectVaultExists` and `savedPolicy` are distinct: vault existence = adoption signal, policy = persisted preference.
+- `remember` handler fetches `getProjectVaultIfExists(cwd)` before calling `resolveWriteScope`.
+- `formatAskForWriteScope` differentiates unadopted (first-time) from explicit `ask` policy messages.
+- The ask message hints: call `set_project_memory_policy` to avoid being prompted again.
+- Explicit `scope` or a saved policy always bypass the unadopted check.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `mnemonic` will be documented in this file.
 
 The format is loosely based on Keep a Changelog and uses semver-style version headings.
 
+## [0.4.0] - 2026-03-11
+
+### Added
+
+- Unadopted project detection in `remember`: when a project has no saved memory policy and no existing `.mnemonic/` directory, mnemonic now asks which vault to use instead of silently creating `.mnemonic/`. The prompt distinguishes first-time adoption from an explicit `ask` policy, and hints to call `set_project_memory_policy` to avoid being prompted again.
+
 ## [0.3.2] - 2026-03-11
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "A local MCP memory server backed by markdown + JSON files, synced via git",
   "type": "module",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -599,13 +599,21 @@ function formatCommitBody(options: CommitBodyOptions): string {
   return lines.join("\n");
 }
 
-function formatAskForWriteScope(project: Awaited<ReturnType<typeof resolveProject>>): string {
+function formatAskForWriteScope(
+  project: Awaited<ReturnType<typeof resolveProject>>,
+  unadopted: boolean = false,
+): string {
   const projectLabel = project ? `${project.name} (${project.id})` : "this context";
+  const header = unadopted
+    ? `No memory policy set for ${projectLabel} and this project hasn't adopted mnemonic yet.`
+    : `Project memory policy for ${projectLabel} is set to always ask.`;
   return [
-    `Project memory policy for ${projectLabel} is set to always ask.`,
+    header,
     "Choose where to store this memory and call `remember` again with one of:",
-    "- `scope: \"project\"` — shared project vault (`.mnemonic/`)",
+    "- `scope: \"project\"` — create `.mnemonic/` in this repo and store there (adopts mnemonic)",
     "- `scope: \"global\"` — private main vault with project association",
+    "",
+    "To avoid being asked again: call `set_project_memory_policy` with your preferred scope.",
   ].join("\n");
 }
 
@@ -1309,9 +1317,11 @@ server.registerTool(
     const project = await resolveProject(cwd);
     const cleanedContent = await cleanMarkdown(content);
     const policyScope = await getProjectPolicyScope(cwd);
-    const writeScope = resolveWriteScope(scope, policyScope, Boolean(project));
+    const projectVaultExists = cwd ? Boolean(await vaultManager.getProjectVaultIfExists(cwd)) : true;
+    const writeScope = resolveWriteScope(scope, policyScope, Boolean(project), projectVaultExists);
     if (writeScope === "ask") {
-      return { content: [{ type: "text", text: formatAskForWriteScope(project) }], isError: true };
+      const unadopted = !projectVaultExists && !policyScope;
+      return { content: [{ type: "text", text: formatAskForWriteScope(project, unadopted) }], isError: true };
     }
     const vault = await resolveWriteVault(cwd, writeScope);
 

--- a/src/project-memory-policy.ts
+++ b/src/project-memory-policy.ts
@@ -23,6 +23,7 @@ export function resolveWriteScope(
   explicitScope: WriteScope | undefined,
   projectPolicyScope: ProjectPolicyScope | undefined,
   hasProjectContext: boolean,
+  projectVaultExists: boolean = true,
 ): WriteScope | "ask" {
   if (explicitScope) {
     return explicitScope;
@@ -30,6 +31,12 @@ export function resolveWriteScope(
 
   if (projectPolicyScope) {
     return projectPolicyScope;
+  }
+
+  // No policy and no existing project vault: project hasn't adopted mnemonic yet.
+  // Ask rather than silently creating .mnemonic/.
+  if (hasProjectContext && !projectVaultExists) {
+    return "ask";
   }
 
   return hasProjectContext ? "project" : "global";

--- a/tests/project-memory-policy.test.ts
+++ b/tests/project-memory-policy.test.ts
@@ -14,23 +14,35 @@ afterEach(async () => {
 
 describe("resolveWriteScope", () => {
   it("prefers explicit scope over project policy", () => {
-    expect(resolveWriteScope("global", "project", true)).toBe("global");
+    expect(resolveWriteScope("global", "project", true, true)).toBe("global");
   });
 
   it("uses the project policy when scope is omitted", () => {
-    expect(resolveWriteScope(undefined, "global", true)).toBe("global");
+    expect(resolveWriteScope(undefined, "global", true, true)).toBe("global");
   });
 
   it("returns ask when the project policy requires explicit selection", () => {
-    expect(resolveWriteScope(undefined, "ask", true)).toBe("ask");
+    expect(resolveWriteScope(undefined, "ask", true, true)).toBe("ask");
   });
 
-  it("falls back to project storage when project context exists", () => {
-    expect(resolveWriteScope(undefined, undefined, true)).toBe("project");
+  it("falls back to project storage when project context and vault both exist", () => {
+    expect(resolveWriteScope(undefined, undefined, true, true)).toBe("project");
   });
 
   it("falls back to global storage without project context", () => {
-    expect(resolveWriteScope(undefined, undefined, false)).toBe("global");
+    expect(resolveWriteScope(undefined, undefined, false, false)).toBe("global");
+  });
+
+  it("returns ask when project context exists but vault does not (unadopted project)", () => {
+    expect(resolveWriteScope(undefined, undefined, true, false)).toBe("ask");
+  });
+
+  it("explicit scope bypasses unadopted project check", () => {
+    expect(resolveWriteScope("project", undefined, true, false)).toBe("project");
+  });
+
+  it("saved policy bypasses unadopted project check", () => {
+    expect(resolveWriteScope(undefined, "global", true, false)).toBe("global");
   });
 });
 


### PR DESCRIPTION
For projects with no saved policy AND no existing `.mnemonic/` directory, `resolveWriteScope()` returns `"ask"` instead of silently creating `.mnemonic/`. This prevents mnemonic from adopting a project without the user's knowledge.

- The `projectVaultExists` boolean is the signal: `false` = unadopted, `true` = already adopted.
- Policy config is stored in `~/mnemonic-vault/config.json` (main vault), not in `.mnemonic/`.
- `projectVaultExists` and `savedPolicy` are distinct: vault existence = adoption signal, policy = persisted preference.
- `remember` handler fetches `getProjectVaultIfExists(cwd)` before calling `resolveWriteScope`.
- `formatAskForWriteScope` differentiates unadopted (first-time) from explicit `ask` policy messages.
- The ask message hints: call `set_project_memory_policy` to avoid being prompted again.
- Explicit `scope` or a saved policy always bypass the unadopted check.