### PR TITLE
Examples of how to configure the MCP client with OpenCode and Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,28 @@ For local development against this repository's source tree, use `npm run mcp:lo
 | `EMBED_MODEL` | `nomic-embed-text-v2-moe` | Ollama embedding model           |
 | `DISABLE_GIT` | `false`                   | Set `true` to skip all git ops   |
 
+### config.json
+
+The main vault's `~/mnemonic-vault/config.json` holds machine-local settings that survive across sessions. You can edit it by hand — unknown fields are ignored and invalid values fall back to defaults.
+
+User-tunable fields:
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `reindexEmbedConcurrency` | `4` | Parallel embedding requests during `sync` (capped 1–16) |
+| `mutationPushMode` | `"main-only"` | When to auto-push after a write: `"all"`, `"main-only"`, or `"none"` |
+
+`projectMemoryPolicies` and `projectIdentityOverrides` are written automatically by `set_project_memory_policy` and `set_project_identity` — no need to edit them by hand.
+
+Example — raise concurrency on a fast machine and disable auto-push everywhere:
+
+```json
+{
+  "reindexEmbedConcurrency": 8,
+  "mutationPushMode": "none"
+}
+```
+
 ## How it works
 
 ### Vault layout

--- a/README.md
+++ b/README.md
@@ -140,6 +140,38 @@ For a fixed installed version, point at the local binary instead:
 
 > Ollama must be running before the MCP client invokes mnemonic. Start it once with `docker compose up ollama -d` and it will stay up between calls.
 
+### OpenCode
+
+Add to `~/.config/opencode/opencode.json` (global) or `opencode.json` in your project root:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "mnemonic": {
+      "type": "local",
+      "command": ["npx", "@danielmarbach/mnemonic-mcp"],
+      "environment": {
+        "VAULT_PATH": "/Users/you/mnemonic-vault"
+      }
+    }
+  }
+}
+```
+
+### Codex
+
+Add to `~/.codex/config.toml` (global) or `.codex/config.toml` in a trusted project:
+
+```toml
+[mcp_servers.mnemonic]
+command = "npx"
+args = ["@danielmarbach/mnemonic-mcp"]
+
+[mcp_servers.mnemonic.env]
+VAULT_PATH = "/Users/you/mnemonic-vault"
+```
+
 For local development against this repository's source tree, use `npm run mcp:local` or point your MCP client at `scripts/mcp-local.sh`.
 
 ## Configuration

--- a/docs/index.html
+++ b/docs/index.html
@@ -1619,6 +1619,42 @@
   }
 }</pre>
         </div>
+
+        <h3>OpenCode</h3>
+        <p style="font-size:0.85rem;margin:8px 0 12px">Add to <code>~/.config/opencode/opencode.json</code> or project-local <code>opencode.json</code>.</p>
+        <div class="code-block">
+          <div class="code-block-header">
+            <span class="code-label">opencode.json</span>
+            <button class="copy-btn" onclick="copyCode(this)">copy</button>
+          </div>
+          <pre>{
+  <span class="key">"$schema"</span>: <span class="str">"https://opencode.ai/config.json"</span>,
+  <span class="key">"mcp"</span>: {
+    <span class="key">"mnemonic"</span>: {
+      <span class="key">"type"</span>: <span class="str">"local"</span>,
+      <span class="key">"command"</span>: [<span class="str">"npx"</span>, <span class="str">"@danielmarbach/mnemonic-mcp"</span>],
+      <span class="key">"environment"</span>: {
+        <span class="key">"VAULT_PATH"</span>: <span class="str">"/Users/you/mnemonic-vault"</span>
+      }
+    }
+  }
+}</pre>
+        </div>
+
+        <h3>Codex</h3>
+        <p style="font-size:0.85rem;margin:8px 0 12px">Add to <code>~/.codex/config.toml</code> or project-local <code>.codex/config.toml</code>.</p>
+        <div class="code-block">
+          <div class="code-block-header">
+            <span class="code-label">config.toml</span>
+            <button class="copy-btn" onclick="copyCode(this)">copy</button>
+          </div>
+          <pre>[mcp_servers.mnemonic]
+command = <span class="str">"npx"</span>
+args = [<span class="str">"@danielmarbach/mnemonic-mcp"</span>]
+
+[mcp_servers.mnemonic.env]
+VAULT_PATH = <span class="str">"/Users/you/mnemonic-vault"</span></pre>
+        </div>
       </div>
     </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1656,7 +1656,41 @@
       </table>
     </div>
     <p>The runtime is compatible with other Ollama embedding models that support <code>/api/embed</code>. For example, <code>qwen3-embedding:0.6b</code> works as a drop-in <code>EMBED_MODEL</code> override and may be preferable for longer-context notes.</p>
-    <p>Main-vault <code>config.json</code> also supports <code>mutationPushMode</code>: <code>main-only</code> (default), <code>all</code>, or <code>none</code>. The default keeps private main-vault notes auto-pushed while leaving project-vault commits for the user or <code>sync</code>.</p>
+    <p>The main vault's <code>~/mnemonic-vault/config.json</code> holds machine-local settings you can edit by hand. Two fields are user-tunable:</p>
+    <div class="config-table-wrap fade-up" style="margin-top:16px">
+      <table class="config-table">
+        <thead>
+          <tr>
+            <th>Field</th>
+            <th>Default</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>reindexEmbedConcurrency</code></td>
+            <td class="default">4</td>
+            <td>Parallel embedding requests during <code>sync</code> (capped 1–16)</td>
+          </tr>
+          <tr>
+            <td><code>mutationPushMode</code></td>
+            <td class="default">main-only</td>
+            <td><code>all</code>, <code>main-only</code>, or <code>none</code> — controls when writes auto-push to git</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <p style="margin-top:16px"><code>projectMemoryPolicies</code> and <code>projectIdentityOverrides</code> are written automatically by MCP tools — no need to edit them by hand.</p>
+    <div class="code-block fade-up" style="margin-top:16px">
+      <div class="code-block-header">
+        <span class="code-label">~/mnemonic-vault/config.json</span>
+        <button class="copy-btn" onclick="copyCode(this)">copy</button>
+      </div>
+      <pre>{
+  <span class="key">"reindexEmbedConcurrency"</span>: <span class="num">8</span>,
+  <span class="key">"mutationPushMode"</span>: <span class="str">"none"</span>
+}</pre>
+    </div>
 
     <div id="agent-snippet" class="agent-snippet fade-up">
       <h3>Add to your AGENT.md or system prompt</h3>


### PR DESCRIPTION
This pull request improves documentation for configuring the MCP client with OpenCode and Codex, and clarifies the machine-local settings available in the main vault's `config.json`. The updates make it easier for users to integrate with different clients and understand which settings can be customized.

Integration instructions for OpenCode and Codex:

* Added example configuration blocks for OpenCode (`opencode.json`) and Codex (`config.toml`), including how to specify the local mnemonic MCP server and set environment variables like `VAULT_PATH`. These instructions are now present in both `README.md` and `docs/index.html`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R143-R174) [[2]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeR1622-R1657)

Clarification of machine-local settings:

* Expanded documentation for the main vault's `config.json`, listing user-tunable fields (`reindexEmbedConcurrency` and `mutationPushMode`) and their defaults. Provided a table and example to illustrate how these settings affect parallel embedding and auto-push behavior. This is reflected in both the markdown and HTML docs. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R186-R207) [[2]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL1659-R1729)