### PR TITLE
Docker publish flow runs in parallel with NPM

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+build
+.git
+.mnemonic
+.opencode
+tests
+*.md
+.dockerignore
+.gitignore
+.npmignore
+scripts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  publish-release:
+  publish-npm:
     runs-on: ubuntu-latest
     environment: Release
     permissions:
@@ -49,3 +49,80 @@ jobs:
 
       - name: Publish to npm
         run: npm publish  # Provenance attestation is automatic via OIDC trusted publishing
+
+  publish-docker:
+    runs-on: ubuntu-latest
+    environment: Release
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Extract version for Docker tag
+        id: version
+        run: echo "tag=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            danielmarbach/mnemonic-mcp:latest
+            danielmarbach/mnemonic-mcp:${{ steps.version.outputs.tag }}
+
+  create-release:
+    needs: [publish-npm, publish-docker]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required to create GitHub releases
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Extract release notes from changelog
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          awk "/^## \[${VERSION}\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md \
+            | sed '/./,$!d' \
+            > RELEASE_NOTES_LATEST.md
+          echo "Extracted release notes for v${VERSION}:"
+          cat RELEASE_NOTES_LATEST.md
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file RELEASE_NOTES_LATEST.md
+
+      - name: Close milestone
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          MILESTONE=$(gh api "repos/${{ github.repository }}/milestones" \
+            --jq ".[] | select(.title == \"$GITHUB_REF_NAME\") | .number" 2>/dev/null || true)
+          if [ -n "$MILESTONE" ]; then
+            gh api "repos/${{ github.repository }}/milestones/${MILESTONE}" \
+              -X PATCH -f state=closed
+            echo "Closed milestone $GITHUB_REF_NAME (#${MILESTONE})"
+          else
+            echo "No milestone named $GITHUB_REF_NAME found, skipping"
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,14 @@ on:
     tags:
       - "v*.*.*"
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to simulate (e.g. v0.4.1)"
+        required: true
+      dry_run:
+        description: "Skip publishing (npm, Docker, GitHub release, milestone)"
+        type: boolean
+        default: true
 
 jobs:
   publish-npm:
@@ -17,6 +25,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -31,7 +41,7 @@ jobs:
       - name: Verify tag matches package version
         run: |
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          TAG_NAME="${GITHUB_REF_NAME}"
+          TAG_NAME="${{ inputs.tag || github.ref_name }}"
 
           if [ "$TAG_NAME" != "v$PACKAGE_VERSION" ]; then
             echo "Tag $TAG_NAME does not match package version v$PACKAGE_VERSION"
@@ -48,6 +58,7 @@ jobs:
         run: npm test
 
       - name: Publish to npm
+        if: ${{ !inputs.dry_run }}
         run: npm publish  # Provenance attestation is automatic via OIDC trusted publishing
 
   publish-docker:
@@ -59,6 +70,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -67,6 +80,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
+        if: ${{ !inputs.dry_run }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -74,14 +88,14 @@ jobs:
 
       - name: Extract version for Docker tag
         id: version
-        run: echo "tag=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: echo "tag=${{ inputs.tag || github.ref_name }}" | sed 's/tag=v/tag=/' >> "$GITHUB_OUTPUT"
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ !inputs.dry_run }}
           tags: |
             danielmarbach/mnemonic-mcp:latest
             danielmarbach/mnemonic-mcp:${{ steps.version.outputs.tag }}
@@ -95,10 +109,13 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Extract release notes from changelog
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${{ inputs.tag || github.ref_name }}"
+          VERSION="${VERSION#v}"
           awk "/^## \[${VERSION}\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md \
             | sed '/./,$!d' \
             > RELEASE_NOTES_LATEST.md
@@ -106,23 +123,26 @@ jobs:
           cat RELEASE_NOTES_LATEST.md
 
       - name: Create GitHub release
+        if: ${{ !inputs.dry_run }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "$GITHUB_REF_NAME" \
-            --title "$GITHUB_REF_NAME" \
+          gh release create "${{ inputs.tag || github.ref_name }}" \
+            --title "${{ inputs.tag || github.ref_name }}" \
             --notes-file RELEASE_NOTES_LATEST.md
 
       - name: Close milestone
+        if: ${{ !inputs.dry_run }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          TAG="${{ inputs.tag || github.ref_name }}"
           MILESTONE=$(gh api "repos/${{ github.repository }}/milestones" \
-            --jq ".[] | select(.title == \"$GITHUB_REF_NAME\") | .number" 2>/dev/null || true)
+            --jq ".[] | select(.title == \"${TAG}\") | .number" 2>/dev/null || true)
           if [ -n "$MILESTONE" ]; then
             gh api "repos/${{ github.repository }}/milestones/${MILESTONE}" \
               -X PATCH -f state=closed
-            echo "Closed milestone $GITHUB_REF_NAME (#${MILESTONE})"
+            echo "Closed milestone ${TAG} (#${MILESTONE})"
           else
-            echo "No milestone named $GITHUB_REF_NAME found, skipping"
+            echo "No milestone named ${TAG} found, skipping"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 
 ## [0.4.1] - 2026-03-11
 
+### Added
+
+- Docker image published to `danielmarbach/mnemonic-mcp` on Docker Hub for `linux/amd64` and `linux/arm64`. Tagged with the release version and `latest`.
+
 ### Fixed
 
 - `list_migrations` now returns structured content that matches its declared MCP output schema. The handler already included `totalPending`, but the zod schema omitted it, causing the tool to fail with a structured-content validation error instead of listing migrations.

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm ci
 
-COPY *.ts tsconfig*.json ./
+COPY tsconfig*.json ./
+COPY src ./src
 RUN npm run build
 
 # ── runtime ──────────────────────────────────────────────────────────────────
@@ -22,7 +23,7 @@ COPY --from=builder /app/build ./build
 
 ENV VAULT_PATH=/vault
 ENV OLLAMA_URL=http://host-gateway:11434
-ENV EMBED_MODEL=nomic-embed-text
+ENV EMBED_MODEL=nomic-embed-text-v2-moe
 ENV DISABLE_GIT=false
 
 CMD ["node", "build/index.js"]


### PR DESCRIPTION
This pull request introduces significant improvements to the release automation and Docker build process, as well as updates to the `.dockerignore` file and Dockerfile configuration. The main focus is on streamlining multi-platform Docker image publishing, automating GitHub releases, and optimizing the build context for Docker.

Release workflow enhancements:

* Added a `publish-docker` job to `.github/workflows/publish.yml` for building and pushing multi-platform Docker images, including steps for QEMU, Buildx, Docker Hub login, and tagging images with both `latest` and version-specific tags.
* Introduced a `create-release` job to `.github/workflows/publish.yml` that extracts release notes from `CHANGELOG.md`, creates a GitHub release, and closes the corresponding milestone automatically.
* Renamed the `publish-release` job to `publish-npm` for clarity in `.github/workflows/publish.yml`.

Docker build and configuration updates:

* Updated the `Dockerfile` to copy only `tsconfig*.json` and the `src` directory, instead of all `.ts` files, reducing build context size and improving build efficiency.
* Changed the default `EMBED_MODEL` environment variable in the `Dockerfile` to `nomic-embed-text-v2-moe` for improved embedding model selection.

Build context optimization:

* Added a `.dockerignore` file to exclude unnecessary files and directories (such as `node_modules`, `build`, `.git`, test files, markdown files, and scripts) from the Docker build context, resulting in faster and cleaner builds.