### PR TITLE
Remove custom checkout reference parameter from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,8 +25,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -70,8 +68,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -109,8 +105,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.tag || github.ref }}
 
       - name: Extract release notes from changelog
         run: |


### PR DESCRIPTION
This pull request makes a minor change to the GitHub Actions workflow for publishing. It removes the custom checkout reference parameter from the repository checkout steps, simplifying the workflow configuration.