### PR TITLE
Package and docker verification step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Verify tag matches package version
+        if: ${{ !inputs.dry_run }}
         run: |
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
           TAG_NAME="${{ inputs.tag || github.ref_name }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,27 @@ on:
         default: true
 
 jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: package.json
+          sparse-checkout-cone-mode: false
+
+      - name: Verify tag matches package version
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          TAG_NAME="${{ inputs.tag || github.ref_name }}"
+
+          if [ "$TAG_NAME" != "v$PACKAGE_VERSION" ]; then
+            echo "Tag $TAG_NAME does not match package version v$PACKAGE_VERSION"
+            exit 1
+          fi
+
   publish-npm:
+    needs: verify
     runs-on: ubuntu-latest
     environment: Release
     permissions:
@@ -36,16 +56,6 @@ jobs:
       - name: Update npm for OIDC trusted publishing
         run: npm install -g npm@latest  # Requires npm >= 11.5.1
 
-      - name: Verify tag matches package version
-        run: |
-          PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          TAG_NAME="${{ inputs.tag || github.ref_name }}"
-
-          if [ "$TAG_NAME" != "v$PACKAGE_VERSION" ]; then
-            echo "Tag $TAG_NAME does not match package version v$PACKAGE_VERSION"
-            exit 1
-          fi
-
       - name: Install dependencies
         run: npm ci
 
@@ -60,6 +70,7 @@ jobs:
         run: npm publish  # Provenance attestation is automatic via OIDC trusted publishing
 
   publish-docker:
+    needs: verify
     runs-on: ubuntu-latest
     environment: Release
     permissions:


### PR DESCRIPTION
This pull request introduces a verification step to the publish workflow, ensuring that the Git tag matches the version specified in `package.json` before proceeding with publishing to npm or Docker. The verification step is now required for both the npm and Docker publish jobs, and the tag check logic has been moved out of the npm publish job for better separation of concerns.

Workflow improvements:

* Added a new `verify` job that checks out only `package.json` and ensures the Git tag matches the package version before publishing.
* Both `publish-npm` and `publish-docker` jobs now depend on the `verify` job, enforcing tag/version consistency prior to publishing.

Codebase simplification:

* Removed the tag verification logic from the `publish-npm` job, centralizing it in the new `verify` job for improved maintainability.