### PR TITLE
CI: create-release uses sparse checkout to avoid tag-ref HTTPS failure

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -118,6 +118,10 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          sparse-checkout: CHANGELOG.md
+          sparse-checkout-cone-mode: false
 
       - name: Extract release notes from changelog
         run: |

--- a/.mnemonic/notes/ci-create-release-checkout-fails-fetching-tag-ref-over-https-64dbc3b8.md
+++ b/.mnemonic/notes/ci-create-release-checkout-fails-fetching-tag-ref-over-https-64dbc3b8.md
@@ -1,0 +1,24 @@
+---
+title: 'CI: create-release checkout fails fetching tag ref over HTTPS'
+tags:
+  - ci
+  - github-actions
+  - bug
+  - checkout
+  - release
+lifecycle: permanent
+createdAt: '2026-03-12T05:41:48.692Z'
+updatedAt: '2026-03-12T05:41:48.692Z'
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+The `create-release` job in `.github/workflows/publish.yml` fails when `workflow_dispatch` is triggered targeting a tag ref (e.g. `v0.5.0`) in the GitHub UI.
+
+**Symptom:** git fetch of `refs/tags/v0.5.0` fails with "could not read Username for <https://github.com>: terminal prompts disabled", retries with 11s/19s backoff then gives up.
+
+**Root cause:** `create-release` uses `actions/checkout@v6` with no explicit `ref:`. When `workflow_dispatch` targets the tag as its run ref, `github.ref` = `refs/tags/v0.5.0`. Checkout tries to fetch that tag over HTTPS and fails — either because the tag doesn't exist on the remote yet, or the credential helper isn't wired for that refspec.
+
+**Fix:** Add `ref: ${{ github.sha }}` to the checkout step in `create-release`. The job only needs `CHANGELOG.md` — a SHA-pinned checkout is sufficient and avoids tag resolution.
+
+File: `.github/workflows/publish.yml`, job `create-release`, first step (`Check out repository`).

--- a/.mnemonic/notes/ci-create-release-checkout-fails-fetching-tag-ref-over-https-64dbc3b8.md
+++ b/.mnemonic/notes/ci-create-release-checkout-fails-fetching-tag-ref-over-https-64dbc3b8.md
@@ -1,5 +1,5 @@
 ---
-title: 'CI: create-release checkout fails fetching tag ref over HTTPS'
+title: 'CI: create-release uses sparse checkout to avoid tag-ref HTTPS failure'
 tags:
   - ci
   - github-actions
@@ -8,7 +8,7 @@ tags:
   - release
 lifecycle: permanent
 createdAt: '2026-03-12T05:41:48.692Z'
-updatedAt: '2026-03-12T05:42:36.826Z'
+updatedAt: '2026-03-12T05:46:28.186Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 memoryVersion: 1

--- a/.mnemonic/notes/ci-create-release-checkout-fails-fetching-tag-ref-over-https-64dbc3b8.md
+++ b/.mnemonic/notes/ci-create-release-checkout-fails-fetching-tag-ref-over-https-64dbc3b8.md
@@ -8,7 +8,7 @@ tags:
   - release
 lifecycle: permanent
 createdAt: '2026-03-12T05:41:48.692Z'
-updatedAt: '2026-03-12T05:41:48.692Z'
+updatedAt: '2026-03-12T05:42:36.826Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 memoryVersion: 1
@@ -19,6 +19,17 @@ The `create-release` job in `.github/workflows/publish.yml` fails when `workflow
 
 **Root cause:** `create-release` uses `actions/checkout@v6` with no explicit `ref:`. When `workflow_dispatch` targets the tag as its run ref, `github.ref` = `refs/tags/v0.5.0`. Checkout tries to fetch that tag over HTTPS and fails — either because the tag doesn't exist on the remote yet, or the credential helper isn't wired for that refspec.
 
-**Fix:** Add `ref: ${{ github.sha }}` to the checkout step in `create-release`. The job only needs `CHANGELOG.md` — a SHA-pinned checkout is sufficient and avoids tag resolution.
+**Fix:** Sparse-checkout only `CHANGELOG.md` with an explicit `ref: ${{ github.sha }}`. The job only needs that one file to extract release notes — a full clone is wasteful and tag resolution is the source of the failure.
 
 File: `.github/workflows/publish.yml`, job `create-release`, first step (`Check out repository`).
+
+Replace the bare checkout with:
+
+    - name: Check out repository
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ github.sha }}
+        sparse-checkout: CHANGELOG.md
+        sparse-checkout-cone-mode: false
+
+This mirrors the pattern already used in the `verify` job (which also does a sparse checkout of `package.json`).


### PR DESCRIPTION
## Summary

The `create-release` job in `.github/workflows/publish.yml` fails when `workflow_dispatch` is triggered targeting a tag ref (e.g. `v0.5.0`) in the GitHub UI.

## Design Decisions

### CI: create-release uses sparse checkout to avoid tag-ref HTTPS failure

**Tags:** ci, github-actions, bug, checkout, release

The `create-release` job in `.github/workflows/publish.yml` fails when `workflow_dispatch` is triggered targeting a tag ref (e.g. `v0.5.0`) in the GitHub UI.

**Symptom:** git fetch of `refs/tags/v0.5.0` fails with "could not read Username for <https://github.com>: terminal prompts disabled", retries with 11s/19s backoff then gives up.

**Root cause:** `create-release` uses `actions/checkout@v6` with no explicit `ref:`. When `workflow_dispatch` targets the tag as its run ref, `github.ref` = `refs/tags/v0.5.0`. Checkout tries to fetch that tag over HTTPS and fails — either because the tag doesn't exist on the remote yet, or the credential helper isn't wired for that refspec.

**Fix:** Sparse-checkout only `CHANGELOG.md` with an explicit `ref: ${{ github.sha }}`. The job only needs that one file to extract release notes — a full clone is wasteful and tag resolution is the source of the failure.

File: `.github/workflows/publish.yml`, job `create-release`, first step (`Check out repository`).

Replace the bare checkout with:

    - name: Check out repository
      uses: actions/checkout@v6
      with:
        ref: ${{ github.sha }}
        sparse-checkout: CHANGELOG.md
        sparse-checkout-cone-mode: false

This mirrors the pattern already used in the `verify` job (which also does a sparse checkout of `package.json`).

---

_Generated from 1 design decision note(s) in `.mnemonic/notes/`. Run `/update-pr` to regenerate._