### PR TITLE
git commits must only touch mnemonic-managed files

### DIFF
--- a/.mnemonic/notes/design-principle-git-commits-must-only-touch-mnemonic-manage-cecb8d11.md
+++ b/.mnemonic/notes/design-principle-git-commits-must-only-touch-mnemonic-manage-cecb8d11.md
@@ -1,0 +1,44 @@
+---
+title: 'Design principle: git commits must only touch mnemonic-managed files'
+tags:
+  - git
+  - design-principle
+  - bugs
+  - commit-scope
+lifecycle: permanent
+createdAt: '2026-03-12T15:45:37.398Z'
+updatedAt: '2026-03-12T15:45:37.398Z'
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+Mnemonic's git operations must never commit files outside the vault's own scope, even if such files happen to be staged in the same repository (e.g. source edits made while dogfooding).
+
+## The bug (fixed 2026-03-12)
+
+`GitOps.commitWithStatus` called `this.git.add(files)` to stage specific paths, then called `this.git.commit(message)` with no file arguments — which commits **all currently staged files**, not just the ones just added. This caused commit `d97583f5` to include `src/index.ts` and `tests/mcp.integration.test.ts` alongside the note it was supposed to commit.
+
+## The fix (`src/git.ts`)
+
+Compute a `scopedFiles` list before the add, use it for both `add` and `commit`:
+
+```typescript
+const scopedFiles = files.length > 0 ? files : [`${this.notesRelDir}/`];
+await this.git.add(scopedFiles);
+// ... staged check ...
+await this.git.commit(fullMessage, scopedFiles);
+```
+
+`simple-git`'s `commit(message, files)` maps to `git commit -- <files>`, scoping the commit to only those paths.
+
+## The invariant
+
+- With explicit files: `git add <files>` + `git commit -- <files>`
+- Without files (fallback): `git add <notesRelDir>/` + `git commit -- <notesRelDir>/`
+
+Either way, no file outside the vault's own directory can end up in a mnemonic commit.
+
+## Test coverage (`tests/git.test.ts`)
+
+- "passes explicit file paths to git commit so stray staged files are never swept in"
+- "falls back to notesRelDir/ when no files are specified, scoping the commit to the notes directory"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `mnemonic` will be documented in this file.
 
 The format is loosely based on Keep a Changelog and uses semver-style version headings.
 
+## [0.5.1] - 2026-03-12
+
+### Fixed
+
+- `GitOps.commitWithStatus` now passes the explicit file list to `git commit` so that staged changes outside the vault are never accidentally included in a mnemonic commit. Previously `git.commit(message)` was called with no path arguments, which committed everything in the index — including unrelated files that happened to be staged in the same repo.
+
 ## [0.5.0] - 2026-03-12
 
 ### Changed

--- a/src/git.ts
+++ b/src/git.ts
@@ -84,17 +84,17 @@ export class GitOps {
   async commitWithStatus(message: string, files: string[], body?: string): Promise<CommitResult> {
     if (!this.enabled) return { status: "skipped", reason: "git-disabled" };
     try {
-      if (files.length > 0) {
-        await this.git.add(files);
-      } else {
-        await this.git.add(`${this.notesRelDir}/`);
-      }
+      // Scope every add+commit to only the paths mnemonic manages.
+      // Never commit files outside the vault — e.g. src/ or test/ changes
+      // that happen to be staged in the same repo.
+      const scopedFiles = files.length > 0 ? files : [`${this.notesRelDir}/`];
+      await this.git.add(scopedFiles);
       const status = await this.git.status();
       if (status.staged.length === 0) return { status: "skipped", reason: "no-changes" };
 
       // Build commit message with optional body
       const fullMessage = body ? `${message}\n\n${body}` : message;
-      await this.git.commit(fullMessage);
+      await this.git.commit(fullMessage, scopedFiles);
 
       const displayMessage = body ? `${message} [...]` : message;
       console.error(`[git] Committed: ${displayMessage}`);

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -60,6 +60,32 @@ describe("GitOps", () => {
     );
   });
 
+  it("passes explicit file paths to git commit so stray staged files are never swept in", async () => {
+    const { GitOps } = await import("../src/git.js");
+    const git = new GitOps("/tmp/repo");
+    await git.init();
+
+    commit.mockResolvedValueOnce(undefined);
+
+    await git.commit("remember: test", ["notes/my-note.md"]);
+
+    expect(add).toHaveBeenCalledWith(["notes/my-note.md"]);
+    expect(commit).toHaveBeenCalledWith(expect.any(String), ["notes/my-note.md"]);
+  });
+
+  it("falls back to notesRelDir/ when no files are specified, scoping the commit to the notes directory", async () => {
+    const { GitOps } = await import("../src/git.js");
+    const git = new GitOps("/tmp/repo", ".mnemonic/notes");
+    await git.init();
+
+    commit.mockResolvedValueOnce(undefined);
+
+    await git.commit("chore: init vault", []);
+
+    expect(add).toHaveBeenCalledWith([".mnemonic/notes/"]);
+    expect(commit).toHaveBeenCalledWith(expect.any(String), [".mnemonic/notes/"]);
+  });
+
   it("returns false when there is nothing staged to commit", async () => {
     const { GitOps } = await import("../src/git.js");
     const git = new GitOps("/tmp/repo");


### PR DESCRIPTION
## Summary

Mnemonic's git operations must never commit files outside the vault's own scope, even if such files happen to be staged in the same repository (e.g. source edits made while dogfooding).

## Design Decisions

### Design principle: git commits must only touch mnemonic-managed files

**Tags:** git, design-principle, bugs, commit-scope

Mnemonic's git operations must never commit files outside the vault's own scope, even if such files happen to be staged in the same repository (e.g. source edits made while dogfooding).

## The bug (fixed 2026-03-12)

`GitOps.commitWithStatus` called `this.git.add(files)` to stage specific paths, then called `this.git.commit(message)` with no file arguments — which commits **all currently staged files**, not just the ones just added. This caused commit `d97583f5` to include `src/index.ts` and `tests/mcp.integration.test.ts` alongside the note it was supposed to commit.

## The fix (`src/git.ts`)

Compute a `scopedFiles` list before the add, use it for both `add` and `commit`:

```typescript
const scopedFiles = files.length > 0 ? files : [`${this.notesRelDir}/`];
await this.git.add(scopedFiles);
// ... staged check ...
await this.git.commit(fullMessage, scopedFiles);
```

`simple-git`'s `commit(message, files)` maps to `git commit -- <files>`, scoping the commit to only those paths.

## The invariant

- With explicit files: `git add <files>` + `git commit -- <files>`
- Without files (fallback): `git add <notesRelDir>/` + `git commit -- <notesRelDir>/`

Either way, no file outside the vault's own directory can end up in a mnemonic commit.

## Test coverage (`tests/git.test.ts`)

- "passes explicit file paths to git commit so stray staged files are never swept in"
- "falls back to notesRelDir/ when no files are specified, scoping the commit to the notes directory"

---

_Generated from 1 design decision note(s) in `.mnemonic/notes/`. Run `/update-pr` to regenerate._