### PR TITLE
Consolidate strategy execute-merge called getOrCreateProjectVault(cwd) unconditionally in executeMerge creating .mnemonic/ in unadopted projects

### DIFF
--- a/.mnemonic/notes/project-memory-policy-defaults-storage-location-f563f634.md
+++ b/.mnemonic/notes/project-memory-policy-defaults-storage-location-f563f634.md
@@ -8,11 +8,13 @@ tags:
   - unadopted
 lifecycle: permanent
 createdAt: '2026-03-07T19:25:37.785Z'
-updatedAt: '2026-03-12T15:36:11.244Z'
+updatedAt: '2026-03-12T15:41:39.192Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
   - id: mnemonic-key-design-decisions-3f2a6273
+    type: related-to
+  - id: vault-creation-audit-which-tools-can-create-mnemonic-and-whi-d0388691
     type: related-to
 memoryVersion: 1
 ---

--- a/.mnemonic/notes/project-memory-policy-defaults-storage-location-f563f634.md
+++ b/.mnemonic/notes/project-memory-policy-defaults-storage-location-f563f634.md
@@ -8,7 +8,7 @@ tags:
   - unadopted
 lifecycle: permanent
 createdAt: '2026-03-07T19:25:37.785Z'
-updatedAt: '2026-03-11T11:25:50.075Z'
+updatedAt: '2026-03-12T15:36:11.244Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
@@ -37,3 +37,16 @@ For projects with no saved policy AND no existing `.mnemonic/` directory, `resol
 - `formatAskForWriteScope` differentiates unadopted (first-time) from explicit `ask` policy messages.
 - The ask message hints: call `set_project_memory_policy` to avoid being prompted again.
 - Explicit `scope` or a saved policy always bypass the unadopted check.
+
+## Consolidate remnant bug (fixed 2026-03-12)
+
+`executeMerge` in `consolidate` was calling `getOrCreateProjectVault(cwd)` whenever `cwd` was passed — even when all source notes lived in main vault. This created `.mnemonic/` in an unadopted project as a side effect.
+
+Fixed by changing line 3336 in `src/index.ts` to `getProjectVaultIfExists(cwd)`. The vault-targeting logic already falls back to `vaultManager.main` when `projectVault` is null, so no consolidation behavior changed.
+
+The `update` path was already safe — it uses `findNote` → `searchOrder` → `getProjectVaultIfExists`, which never creates. When vault creation was observed after an `update` call in a session, it was caused by a prior `consolidate` call in the same session.
+
+Regression tests added in `tests/mcp.integration.test.ts`:
+
+- "does not create a project vault when updating a main-vault note with cwd pointing to unadopted project"
+- "does not create a project vault when consolidating main-vault notes with cwd pointing to unadopted project"

--- a/.mnemonic/notes/vault-creation-audit-which-tools-can-create-mnemonic-and-whi-d0388691.md
+++ b/.mnemonic/notes/vault-creation-audit-which-tools-can-create-mnemonic-and-whi-d0388691.md
@@ -8,9 +8,12 @@ tags:
   - testing
 lifecycle: permanent
 createdAt: '2026-03-12T15:41:29.294Z'
-updatedAt: '2026-03-12T15:41:29.294Z'
+updatedAt: '2026-03-12T15:41:39.192Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: project-memory-policy-defaults-storage-location-f563f634
+    type: related-to
 memoryVersion: 1
 ---
 Audit of all cwd-accepting MCP tools against spurious project vault creation. Only three call sites use `getOrCreateProjectVault` — two are intentional, one was a bug (fixed 2026-03-12).

--- a/.mnemonic/notes/vault-creation-audit-which-tools-can-create-mnemonic-and-whi-d0388691.md
+++ b/.mnemonic/notes/vault-creation-audit-which-tools-can-create-mnemonic-and-whi-d0388691.md
@@ -1,0 +1,50 @@
+---
+title: 'Vault creation audit: which tools can create .mnemonic/ and which cannot'
+tags:
+  - audit
+  - vault-routing
+  - getOrCreateProjectVault
+  - bugs
+  - testing
+lifecycle: permanent
+createdAt: '2026-03-12T15:41:29.294Z'
+updatedAt: '2026-03-12T15:41:29.294Z'
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+Audit of all cwd-accepting MCP tools against spurious project vault creation. Only three call sites use `getOrCreateProjectVault` — two are intentional, one was a bug (fixed 2026-03-12).
+
+## Safe paths (never create a vault)
+
+All read and lookup operations route through either `findNote` or `collectVisibleNotes`, both of which call `vaultManager.searchOrder(cwd)` → `getProjectVaultIfExists` — which returns null rather than creating when `.mnemonic/` doesn't exist.
+
+- `update` — `findNote` → `getProjectVaultIfExists` (regression test added)
+- `forget` — `findNote` → `getProjectVaultIfExists`
+- `get` — `findNote` → `getProjectVaultIfExists`
+- `where_is_memory` — `findNote` → `getProjectVaultIfExists`
+- `relate` / `unrelate` — `findNote` → `getProjectVaultIfExists`
+- `list` — `collectVisibleNotes` → `searchOrder` → `getProjectVaultIfExists`
+- `recent_memories` — `collectVisibleNotes` → `searchOrder` → `getProjectVaultIfExists`
+- `project_memory_summary` — `collectVisibleNotes` → `searchOrder` → `getProjectVaultIfExists`
+- `memory_graph` — `collectVisibleNotes` → `searchOrder` → `getProjectVaultIfExists`
+- `recall` — `vaultManager.searchOrder` → `getProjectVaultIfExists`
+- `sync` — `getProjectVaultIfExists`
+- `consolidate` (non-execute-merge strategies) — analysis only, no vault writes
+
+## Intentional creation (by design)
+
+- `remember` — only when `scope` resolves to `"project"` via `resolveWriteVault`
+- `move_memory` — only when `target` is explicitly `"project-vault"`
+
+## Fixed bug
+
+`consolidate` strategy `execute-merge` called `getOrCreateProjectVault(cwd)` unconditionally in `executeMerge` (`src/index.ts:3336`), creating `.mnemonic/` in unadopted projects even when all source notes were in main vault. Fixed by switching to `getProjectVaultIfExists`. Regression tests added in `tests/mcp.integration.test.ts`.
+
+## Diagnostic note
+
+If `.mnemonic/` appears unexpectedly in a project, the most likely cause is a prior `consolidate` call with `strategy: "execute-merge"` and `cwd` set — not the tool you happened to be using when you noticed it.
+
+## Key invariant
+
+`getOrCreateProjectVault` must only be called when the user has explicitly expressed intent to write to the project vault (via `scope: "project"` or `move_memory` target). Passing `cwd` for context/lookup must never trigger vault creation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 ### Fixed
 
 - `GitOps.commitWithStatus` now passes the explicit file list to `git commit` so that staged changes outside the vault are never accidentally included in a mnemonic commit. Previously `git.commit(message)` was called with no path arguments, which committed everything in the index — including unrelated files that happened to be staged in the same repo.
+- `consolidate` `execute-merge` no longer creates a `.mnemonic/` directory as a side effect when `cwd` points to a project that has not adopted mnemonic. Previously `executeMerge` called `getOrCreateProjectVault(cwd)` unconditionally, initialising the project vault even when all source notes lived in the main vault. It now calls `getProjectVaultIfExists`, consistent with the unadopted-project protection already present in `remember`.
 
 ## [0.5.0] - 2026-03-12
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3333,7 +3333,7 @@ async function executeMerge(
   );
 
   const existingTargetEntry = findExistingExecuteMergeTarget(entries, sourceEntries, targetTitle);
-  const projectVault = cwd ? await vaultManager.getOrCreateProjectVault(cwd) : null;
+  const projectVault = cwd ? await vaultManager.getProjectVaultIfExists(cwd) : null;
   const targetVault = existingTargetEntry?.vault ?? projectVault ?? vaultManager.main;
   const now = new Date().toISOString();
 

--- a/tests/mcp.integration.test.ts
+++ b/tests/mcp.integration.test.ts
@@ -1376,6 +1376,90 @@ describe("local MCP script", () => {
       await embeddingServer.close();
     }
   }, 15000);
+
+  it("does not create a project vault when updating a main-vault note with cwd pointing to unadopted project", async () => {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mcp-vault-"));
+    const repoDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mcp-project-"));
+    tempDirs.push(vaultDir, repoDir);
+
+    await execFileAsync("git", ["init"], { cwd: repoDir });
+
+    const embeddingServer = await startFakeEmbeddingServer();
+
+    try {
+      const rememberText = await callLocalMcp(vaultDir, "remember", {
+        title: "Global note for update test",
+        content: "Original content.",
+        tags: ["update-test"],
+        lifecycle: "permanent",
+        summary: "Create global note for update test",
+        cwd: repoDir,
+        scope: "global",
+      }, embeddingServer.url);
+
+      const noteId = extractRememberedId(rememberText);
+
+      await callLocalMcp(vaultDir, "update", {
+        id: noteId,
+        content: "Updated content.",
+        summary: "Update note content",
+        cwd: repoDir,
+      }, embeddingServer.url);
+
+      // Project vault must NOT have been created as a side effect of passing cwd
+      await expect(stat(path.join(repoDir, ".mnemonic"))).rejects.toThrow();
+    } finally {
+      await embeddingServer.close();
+    }
+  }, 15000);
+
+  it("does not create a project vault when consolidating main-vault notes with cwd pointing to unadopted project", async () => {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mcp-vault-"));
+    const repoDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mcp-project-"));
+    tempDirs.push(vaultDir, repoDir);
+
+    await execFileAsync("git", ["init"], { cwd: repoDir });
+
+    const embeddingServer = await startFakeEmbeddingServer();
+
+    try {
+      const firstRemember = await callLocalMcp(vaultDir, "remember", {
+        title: "Global note A",
+        content: "First global note for consolidation.",
+        tags: ["global-merge"],
+        lifecycle: "temporary",
+        summary: "Create first global note",
+        cwd: repoDir,
+        scope: "global",
+      }, embeddingServer.url);
+      const secondRemember = await callLocalMcp(vaultDir, "remember", {
+        title: "Global note B",
+        content: "Second global note for consolidation.",
+        tags: ["global-merge"],
+        lifecycle: "temporary",
+        summary: "Create second global note",
+        cwd: repoDir,
+        scope: "global",
+      }, embeddingServer.url);
+
+      const firstId = extractRememberedId(firstRemember);
+      const secondId = extractRememberedId(secondRemember);
+
+      await callLocalMcp(vaultDir, "consolidate", {
+        cwd: repoDir,
+        strategy: "execute-merge",
+        mergePlan: {
+          sourceIds: [firstId, secondId],
+          targetTitle: "Merged global note",
+        },
+      }, embeddingServer.url);
+
+      // Project vault must NOT have been created as a side effect
+      await expect(stat(path.join(repoDir, ".mnemonic"))).rejects.toThrow();
+    } finally {
+      await embeddingServer.close();
+    }
+  }, 15000);
 });
 
 async function callLocalMcp(


### PR DESCRIPTION
## Summary

This PR captures the following design decisions:

- **project memory storage policy**
- **Vault creation audit: which tools can create .mnemonic/ and which cannot**

## Design Decisions

### project memory storage policy

**Tags:** policy, scope, storage, ux, unadopted

Decision: project context and storage location are separate, and each project can keep a default write policy so agents only need to ask when necessary.

- `cwd` identifies project context.
- `scope: "project"` stores shared knowledge in `/.mnemonic/`.
- `scope: "global"` stores a private note in the main vault while keeping project association for recall and relationships.
- `remember` uses explicit `scope` first, then the saved project policy, then the fallback behavior.
- `set_project_memory_policy` supports `project`, `global`, and `ask`.
- When the policy is `ask`, agents should present a clear storage selection instead of guessing.
- `update` no longer rewrites project metadata just because `cwd` was passed for lookup.

## Unadopted project detection (added 2026-03-11)

For projects with no saved policy AND no existing `.mnemonic/` directory, `resolveWriteScope()` returns `"ask"` instead of silently creating `.mnemonic/`. This prevents mnemonic from adopting a project without the user's knowledge.

- The `projectVaultExists` boolean is the signal: `false` = unadopted, `true` = already adopted.
- Policy config is stored in `~/mnemonic-vault/config.json` (main vault), not in `.mnemonic/`.
- `projectVaultExists` and `savedPolicy` are distinct: vault existence = adoption signal, policy = persisted preference.
- `remember` handler fetches `getProjectVaultIfExists(cwd)` before calling `resolveWriteScope`.
- `formatAskForWriteScope` differentiates unadopted (first-time) from explicit `ask` policy messages.
- The ask message hints: call `set_project_memory_policy` to avoid being prompted again.
- Explicit `scope` or a saved policy always bypass the unadopted check.

## Consolidate remnant bug (fixed 2026-03-12)

`executeMerge` in `consolidate` was calling `getOrCreateProjectVault(cwd)` whenever `cwd` was passed — even when all source notes lived in main vault. This created `.mnemonic/` in an unadopted project as a side effect.

Fixed by changing line 3336 in `src/index.ts` to `getProjectVaultIfExists(cwd)`. The vault-targeting logic already falls back to `vaultManager.main` when `projectVault` is null, so no consolidation behavior changed.

The `update` path was already safe — it uses `findNote` → `searchOrder` → `getProjectVaultIfExists`, which never creates. When vault creation was observed after an `update` call in a session, it was caused by a prior `consolidate` call in the same session.

Regression tests added in `tests/mcp.integration.test.ts`:

- "does not create a project vault when updating a main-vault note with cwd pointing to unadopted project"
- "does not create a project vault when consolidating main-vault notes with cwd pointing to unadopted project"

### Vault creation audit: which tools can create .mnemonic/ and which cannot

**Tags:** audit, vault-routing, getOrCreateProjectVault, bugs, testing

Audit of all cwd-accepting MCP tools against spurious project vault creation. Only three call sites use `getOrCreateProjectVault` — two are intentional, one was a bug (fixed 2026-03-12).

## Safe paths (never create a vault)

All read and lookup operations route through either `findNote` or `collectVisibleNotes`, both of which call `vaultManager.searchOrder(cwd)` → `getProjectVaultIfExists` — which returns null rather than creating when `.mnemonic/` doesn't exist.

- `update` — `findNote` → `getProjectVaultIfExists` (regression test added)
- `forget` — `findNote` → `getProjectVaultIfExists`
- `get` — `findNote` → `getProjectVaultIfExists`
- `where_is_memory` — `findNote` → `getProjectVaultIfExists`
- `relate` / `unrelate` — `findNote` → `getProjectVaultIfExists`
- `list` — `collectVisibleNotes` → `searchOrder` → `getProjectVaultIfExists`
- `recent_memories` — `collectVisibleNotes` → `searchOrder` → `getProjectVaultIfExists`
- `project_memory_summary` — `collectVisibleNotes` → `searchOrder` → `getProjectVaultIfExists`
- `memory_graph` — `collectVisibleNotes` → `searchOrder` → `getProjectVaultIfExists`
- `recall` — `vaultManager.searchOrder` → `getProjectVaultIfExists`
- `sync` — `getProjectVaultIfExists`
- `consolidate` (non-execute-merge strategies) — analysis only, no vault writes

## Intentional creation (by design)

- `remember` — only when `scope` resolves to `"project"` via `resolveWriteVault`
- `move_memory` — only when `target` is explicitly `"project-vault"`

## Fixed bug

`consolidate` strategy `execute-merge` called `getOrCreateProjectVault(cwd)` unconditionally in `executeMerge` (`src/index.ts:3336`), creating `.mnemonic/` in unadopted projects even when all source notes were in main vault. Fixed by switching to `getProjectVaultIfExists`. Regression tests added in `tests/mcp.integration.test.ts`.

## Diagnostic note

If `.mnemonic/` appears unexpectedly in a project, the most likely cause is a prior `consolidate` call with `strategy: "execute-merge"` and `cwd` set — not the tool you happened to be using when you noticed it.

## Key invariant

`getOrCreateProjectVault` must only be called when the user has explicitly expressed intent to write to the project vault (via `scope: "project"` or `move_memory` target). Passing `cwd` for context/lookup must never trigger vault creation.

---

_Generated from 2 design decision note(s) in `.mnemonic/notes/`. Run `/update-pr` to regenerate._