### PR TITLE
Documentation split for README, ARCHITECTURE, and AGENT

### DIFF
--- a/.mnemonic/notes/changelog-writing-principles-87cdbc5b.md
+++ b/.mnemonic/notes/changelog-writing-principles-87cdbc5b.md
@@ -6,9 +6,12 @@ tags:
   - conventions
 lifecycle: permanent
 createdAt: '2026-03-14T13:06:56.354Z'
-updatedAt: '2026-03-14T13:06:56.354Z'
+updatedAt: '2026-03-14T13:09:33.040Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: documentation-split-for-readme-architecture-and-agent-4e20a50b
+    type: related-to
 memoryVersion: 1
 ---
 Keep changelog entries concise — 1-2 sentences max per bullet. Implementation details (retry logic, concurrency protection, internal parameters) belong in commit messages, not changelog. Follow the verbosity level of existing entries: 0.7.0 uses brief 1-sentence bullets, 0.8.0 initially had verbose multi-sentence entries that were trimmed. When trimming verbose entries, preserve API changes as they're useful reference.

--- a/.mnemonic/notes/changelog-writing-principles-87cdbc5b.md
+++ b/.mnemonic/notes/changelog-writing-principles-87cdbc5b.md
@@ -1,0 +1,14 @@
+---
+title: Changelog writing principles
+tags:
+  - changelog
+  - documentation
+  - conventions
+lifecycle: permanent
+createdAt: '2026-03-14T13:06:56.354Z'
+updatedAt: '2026-03-14T13:06:56.354Z'
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+Keep changelog entries concise — 1-2 sentences max per bullet. Implementation details (retry logic, concurrency protection, internal parameters) belong in commit messages, not changelog. Follow the verbosity level of existing entries: 0.7.0 uses brief 1-sentence bullets, 0.8.0 initially had verbose multi-sentence entries that were trimmed. When trimming verbose entries, preserve API changes as they're useful reference.

--- a/.mnemonic/notes/documentation-split-for-readme-architecture-and-agent-4e20a50b.md
+++ b/.mnemonic/notes/documentation-split-for-readme-architecture-and-agent-4e20a50b.md
@@ -7,11 +7,13 @@ tags:
   - decision
 lifecycle: permanent
 createdAt: '2026-03-08T09:22:05.553Z'
-updatedAt: '2026-03-08T09:52:21.423Z'
+updatedAt: '2026-03-14T13:09:33.040Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
   - id: agent-instruction-improvements-session-start-recall-first-an-ecd402c3
+    type: related-to
+  - id: changelog-writing-principles-87cdbc5b
     type: related-to
 memoryVersion: 1
 ---

--- a/AGENT.md
+++ b/AGENT.md
@@ -84,6 +84,13 @@ When calling `update`:
 - `ARCHITECTURE.md` is the canonical high-level map of the system; update it whenever control flow, source layout, vault behavior, data model, CI/MCP operational patterns, or major architectural decisions change
 - Keep `ARCHITECTURE.md`, `AGENT.md`, `README.md`, and `SYSTEM_PROMPT.md` aligned: architecture detail in `ARCHITECTURE.md`, agent workflow rules in `AGENT.md`, reader-facing overview links in `README.md`, and the agent system prompt in `SYSTEM_PROMPT.md`
 - When a new concept is easier to understand visually, add or refresh a Mermaid diagram in `ARCHITECTURE.md`
+
+**Changelog guidelines:**
+- Keep entries concise — 1-2 sentences max per bullet
+- Implementation details (retry logic, concurrency protection, internal parameters) belong in commit messages, not changelog
+- Match the verbosity level of existing entries (e.g., 0.7.0 uses brief 1-sentence bullets)
+- Preserve API changes as brief reference bullets
+
 - `docs/index.html` is the GitHub Pages landing page; keep it current whenever tools, features, or the dogfooding notes change:
   - Tools table in the **Tools** section must reflect the current tool inventory (same as README.md and AGENT.md)
   - The **Dogfooding** section shows real notes from `.mnemonic/notes/` — refresh card content if those notes are updated or replaced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,21 @@ All notable changes to `mnemonic` will be documented in this file.
 
 The format is loosely based on Keep a Changelog and uses semver-style version headings.
 
-## [Unreleased]
+## [0.8.0] - 2026-03-14
 
 ### Changed
 
-- All MCP tool descriptions rewritten for self-contained routing and sub-vault awareness.
+- All MCP tool descriptions rewritten for self-contained routing and sub-vault awareness
 
 ### Added
 
-- Homebrew tap support: Formula file (`Formula/mnemonic-mcp.rb`) published to the repository tap, enabling `brew install danielmarbach/mnemonic/mnemonic-mcp`. The publishing workflow includes retry logic for npm CDN propagation, concurrency protection to prevent parallel releases, and explicit token handling for branch protection rules.
-- Git submodule support: when `cwd` is inside a git submodule, project vault creation and project identity resolution now walk up through submodule boundaries to anchor at the top-level superproject root. This prevents `.mnemonic/` from being created inside a submodule directory and ensures project identity is derived from the superproject's remote URL rather than the submodule's.
-- **Multi-vault support (`sub-vault`):** A project git root can now contain multiple vault folders alongside the primary `.mnemonic/` — any directory named `.mnemonic-<name>` (e.g. `.mnemonic-lib`, `.mnemonic-widget`) is automatically discovered and treated as a sub-vault. All sub-vaults share the same git root and the primary vault's embeddings directory so that embeddings for the whole project stay in one place. Sub-vaults appear in `searchOrder`, `allKnownVaults`, `findNote`, and all list/recall operations. Vault labels in structured MCP output use the format `sub-vault:<folder>` (e.g. `sub-vault:.mnemonic-lib`); `"main-vault"` and `"project-vault"` are unchanged for backward compatibility.
-- `move_memory` gains an optional `vaultFolder` parameter to move a note into a specific sub-vault (e.g. `vaultFolder: ".mnemonic-lib"`) instead of the primary project vault when `target` is `"project-vault"`.
-- `Storage` constructor accepts an optional `embeddingsDirOverride` to redirect where embeddings are stored; used internally so sub-vault notes store their embeddings in the primary vault's `embeddings/` directory.
-- `Vault` interface gains a `vaultFolderName` field (`""` for the main vault, `".mnemonic"` for the primary project vault, `".mnemonic-<name>"` for sub-vaults).
-- `VaultManager` exposes a new `getVaultByFolder(cwd, folderName)` method to retrieve a specific sub-vault by its folder name.
+- Homebrew tap support: `brew install danielmarbach/mnemonic/mnemonic-mcp`.
+- Git submodule support: project vault creation and identity resolution now walk up through submodule boundaries to the superproject root.
+- Multi-vault support: project git roots can contain multiple vault folders (`.mnemonic-<name>`) alongside the primary `.mnemonic/`. Sub-vaults share the primary vault's embeddings directory and appear in `searchOrder`, `allKnownVaults`, and all list/recall operations.
+- `move_memory` accepts optional `vaultFolder` parameter to target specific sub-vaults.
+- `Storage` accepts optional `embeddingsDirOverride` to redirect where embeddings are stored.
+- `Vault` interface gains `vaultFolderName` field.
+- `VaultManager` exposes `getVaultByFolder(cwd, folderName)` method.
 
 ## [0.7.0] - 2026-03-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 
 ## [Unreleased]
 
+### Changed
+
+- All MCP tool descriptions rewritten for self-contained routing and sub-vault awareness.
+
 ### Added
 
 - Homebrew tap support: Formula file (`Formula/mnemonic-mcp.rb`) published to the repository tap, enabling `brew install danielmarbach/mnemonic/mnemonic-mcp`. The publishing workflow includes retry logic for npm CDN propagation, concurrency protection to prevent parallel releases, and explicit token handling for branch protection rules.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "A local MCP memory server backed by markdown + JSON files, synced via git",
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Summary

This PR captures the following design decisions:

- **Documentation split for README, ARCHITECTURE, and AGENT**
- **Changelog writing principles**

## Design Decisions

### Documentation split for README, ARCHITECTURE, and AGENT

**Tags:** documentation, architecture, agent, decision

Established the documentation split for mnemonic.

- `README.md` is the reader-facing overview and setup entry point.
- `ARCHITECTURE.md` is now the canonical high-level system map, including runtime structure, key concepts, and diagrams.
- `AGENT.md` should focus on agent workflow, maintenance rules, and documentation upkeep rather than duplicating full architectural detail.
- When architecture changes, update `ARCHITECTURE.md` first, then keep `AGENT.md` and `README.md` aligned with links and concise guidance instead of repeating the same content.

### Changelog writing principles

**Tags:** changelog, documentation, conventions

Keep changelog entries concise — 1-2 sentences max per bullet. Implementation details (retry logic, concurrency protection, internal parameters) belong in commit messages, not changelog. Follow the verbosity level of existing entries: 0.7.0 uses brief 1-sentence bullets, 0.8.0 initially had verbose multi-sentence entries that were trimmed. When trimming verbose entries, preserve API changes as they're useful reference.

---

_Generated from 2 design decision note(s) in `.mnemonic/notes/`. Run `/update-pr` to regenerate._