### PR TITLE
Update mnemonic-mcp formula to 0.9.0

### DIFF
--- a/Formula/mnemonic-mcp.rb
+++ b/Formula/mnemonic-mcp.rb
@@ -1,8 +1,8 @@
 class MnemonicMcp < Formula
   desc "Local MCP memory server backed by markdown + JSON files, synced via git"
   homepage "https://github.com/danielmarbach/mnemonic"
-  url "https://registry.npmjs.org/@danielmarbach/mnemonic-mcp/-/mnemonic-mcp-0.8.1.tgz"
-  sha256 "0caecab4bb24caa55db7974290b847c10a8488093d82f2ae5792e3ecb1473beb"
+  url "https://registry.npmjs.org/@danielmarbach/mnemonic-mcp/-/mnemonic-mcp-0.9.0.tgz"
+  sha256 "bb75767cbaaa0ac9152a42c2cc8625dfd279037f72d2f064bf751fdc57252355"
   license "Apache-2.0"
 
   depends_on "node"


### PR DESCRIPTION
Automated Homebrew formula update generated by the publish workflow.

- Formula: `Formula/mnemonic-mcp.rb`
- Version: `0.9.0`
- Tarball URL: `https://registry.npmjs.org/@danielmarbach/mnemonic-mcp/-/mnemonic-mcp-0.9.0.tgz`
