### PR TITLE
Sync tool: per-phase git error surfacing with conflict detection

### DIFF
--- a/.mnemonic/notes/design-principle-git-state-detection-must-be-language-indepe-47b795ad.md
+++ b/.mnemonic/notes/design-principle-git-state-detection-must-be-language-indepe-47b795ad.md
@@ -1,0 +1,31 @@
+---
+title: 'Design principle: git state detection must be language-independent'
+tags:
+  - git
+  - design
+  - resilience
+  - portability
+lifecycle: permanent
+createdAt: '2026-03-18T07:28:10.692Z'
+updatedAt: '2026-03-18T07:28:10.692Z'
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+When detecting git state (conflicts, rebase in progress, merge state), never rely on error message keywords. Git error messages are localized — they change under different `LANG`/`LC_ALL` settings.
+
+## Language-independent alternatives
+
+- **`git status --porcelain`** status codes (UU, AA, DD, etc.) are not localized — safe to parse. `simple-git`'s `status().conflicted` uses this.
+- **Git internal state files** are filesystem paths, not text — entirely language-independent:
+  - `.git/rebase-merge/` — interactive or `--merge` rebase in progress
+  - `.git/rebase-apply/` — `--apply` strategy rebase in progress
+  - `.git/MERGE_HEAD` — plain merge conflict
+
+## What to avoid
+
+Do not check error message strings for words like "conflict", "merge", "rebase", "Konflikt", etc. These are locale-dependent and will silently mis-classify on non-English systems.
+
+## Applied in
+
+`GitOps.isConflictInProgress()` in `src/git.ts` replaced a keyword-based fallback (`messageIndicatesConflict`) with `fs.access` checks on the three git state paths above.

--- a/.mnemonic/notes/sync-tool-per-phase-git-error-surfacing-with-conflict-detect-ce15062e.md
+++ b/.mnemonic/notes/sync-tool-per-phase-git-error-surfacing-with-conflict-detect-ce15062e.md
@@ -1,0 +1,37 @@
+---
+title: 'sync tool: per-phase git error surfacing with conflict detection'
+tags:
+  - git
+  - sync
+  - resilience
+  - structured-content
+  - design
+  - completed
+  - schema
+lifecycle: permanent
+createdAt: '2026-03-18T07:25:30.436Z'
+updatedAt: '2026-03-18T07:25:30.436Z'
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+The `sync` tool previously swallowed all git errors inside a single try-catch, returning empty arrays indistinguishable from a clean no-op sync. A merge conflict during `pull --rebase` was completely invisible to callers.
+
+## What changed
+
+- `SyncResult` in `git.ts` now carries an optional `gitError: SyncGitError` with `phase` ("fetch" | "pull" | "push"), `message`, `isConflict`, and `conflictFiles`.
+- `sync()` in `git.ts` handles each phase independently: fetch, pull, push. Each catches its own error and returns `gitError` instead of swallowing.
+- Conflict detection: `getConflictFiles()` calls `git.status()` for conflicted files; `messageIndicatesConflict()` checks for "conflict"/"merge"/"rebase" keywords in the error message. Both are checked on pull failure.
+- Push phase failure is a partial success: pulled notes are still returned alongside the `gitError`.
+- `SyncResult` in `structured-content.ts` has a new `gitError` field per vault entry, and `SyncResultSchema` (Zod) models it with `.optional()`.
+- `formatSyncResult` in `index.ts` now renders conflict messages with vault path and actionable guidance ("resolve conflicts in vault-path, then run sync again").
+- `vaultResults` type now uses `StructuredSyncResult["vaults"][number]` instead of an inline type to stay in sync with the schema.
+
+## Why this matters
+
+Without this, a merge conflict during sync was a silent no-op. Callers had no way to distinguish "nothing to sync" from "sync failed due to conflict." Following the same robustness principles as the retry contract rollout: failures must be first-class structured results.
+
+## Tests added
+
+- `git.test.ts`: fetch failure returns `gitError.phase = "fetch"`, pull failure with conflicted status returns `isConflict: true` with `conflictFiles`, pull failure via keyword returns `isConflict: true`, push failure returns partial success with pulled notes and `gitError.phase = "push"`.
+- `mcp.integration.test.ts`: `SyncResultSchema.parse()` schema audit validates `gitError` optional field is correctly modeled and absent on no-remote vault.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `mnemonic` will be documented in this file.
 
 The format is loosely based on Keep a Changelog and uses semver-style version headings.
 
+## [0.13.0] - 2026-03-18
+
+### Fixed
+
+- `sync` now surfaces git failures as structured, per-phase errors (`fetch`, `pull`, `push`) instead of silently returning empty results. Merge conflicts set `isConflict: true` with conflicted file paths and an actionable resolution hint in the text output.
+- Conflict detection uses language-independent signals: `git status --porcelain` conflict codes and git internal state files (`.git/rebase-merge`, `.git/rebase-apply`, `.git/MERGE_HEAD`) rather than localized error message keywords.
+- `SyncResult` structured output now includes a `gitError` field per vault so MCP clients can distinguish a clean no-op sync from a failed one.
+
 ## [0.12.0] - 2026-03-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,8 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 
 ### Fixed
 
-- `sync` now surfaces git failures as structured, per-phase errors (`fetch`, `pull`, `push`) instead of silently returning empty results. Merge conflicts set `isConflict: true` with conflicted file paths and an actionable resolution hint in the text output.
-- Conflict detection uses language-independent signals: `git status --porcelain` conflict codes and git internal state files (`.git/rebase-merge`, `.git/rebase-apply`, `.git/MERGE_HEAD`) rather than localized error message keywords.
-- `SyncResult` structured output now includes a `gitError` field per vault so MCP clients can distinguish a clean no-op sync from a failed one.
+- `sync` now surfaces git failures as structured per-phase errors (`fetch`, `pull`, `push`) instead of silently swallowing them — merge conflicts include conflicted file paths and an actionable resolution hint.
+- `SyncResult` structured output gains a `gitError` field per vault so callers can distinguish a clean no-op from a failed sync.
 
 ## [0.12.0] - 2026-03-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `mnemonic` will be documented in this file.
 
 The format is loosely based on Keep a Changelog and uses semver-style version headings.
 
-## [0.13.0] - 2026-03-18
+## [0.12.1] - 2026-03-18
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.13.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@danielmarbach/mnemonic-mcp",
-      "version": "0.13.0",
+      "version": "0.12.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.1",
         "gray-matter": "^4.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@danielmarbach/mnemonic-mcp",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.1",
         "gray-matter": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "A local MCP memory server backed by markdown + JSON files, synced via git",
   "type": "module",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.13.0",
+  "version": "0.12.1",
   "description": "A local MCP memory server backed by markdown + JSON files, synced via git",
   "type": "module",
   "repository": {

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,3 +1,5 @@
+import { access } from "fs/promises";
+import path from "path";
 import { simpleGit, SimpleGit } from "simple-git";
 
 export class GitOperationError extends Error {
@@ -8,6 +10,16 @@ export class GitOperationError extends Error {
   }
 }
 
+export interface SyncGitError {
+  /** Which git operation failed */
+  phase: "fetch" | "pull" | "push";
+  message: string;
+  /** True when the failure is a merge/rebase conflict requiring manual resolution */
+  isConflict: boolean;
+  /** Files with conflict markers, when detectable */
+  conflictFiles?: string[];
+}
+
 export interface SyncResult {
   hasRemote: boolean;
   /** Note ids that arrived or changed during pull (need re-embedding) */
@@ -16,6 +28,8 @@ export interface SyncResult {
   deletedNoteIds: string[];
   /** Number of local commits pushed to remote */
   pushedCommits: number;
+  /** Set when any git operation in the sync sequence failed */
+  gitError?: SyncGitError;
 }
 
 export interface CommitResult {
@@ -172,20 +186,99 @@ export class GitOps {
     const remotes = await this.git.getRemotes();
     if (remotes.length === 0) return empty;
 
+    const withRemote: Pick<SyncResult, "hasRemote" | "pulledNoteIds" | "deletedNoteIds" | "pushedCommits"> = {
+      hasRemote: true,
+      pulledNoteIds: [],
+      deletedNoteIds: [],
+      pushedCommits: 0,
+    };
+
+    // Phase 1: fetch
     try {
       await this.git.fetch();
-      const unpushed = await this.countUnpushedCommits();
-      const localHead = await this.currentHead();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`[git] Sync fetch failed: ${message}`);
+      return { ...withRemote, gitError: { phase: "fetch", message, isConflict: false } };
+    }
+
+    const unpushed = await this.countUnpushedCommits();
+    const localHead = await this.currentHead();
+
+    // Phase 2: pull (rebase)
+    try {
       await this.git.pull(["--rebase"]);
       console.error("[git] Pulled (rebase)");
-      const { pulledNoteIds, deletedNoteIds } = await this.diffNotesSince(localHead);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`[git] Sync pull failed: ${message}`);
+      // Use language-independent checks: conflicted files from git status (porcelain codes,
+      // not localized) and git internal state files (.git/rebase-merge, .git/rebase-apply,
+      // .git/MERGE_HEAD) rather than error message keywords.
+      const conflictFiles = await this.getConflictFiles();
+      const isConflict = conflictFiles.length > 0 || await this.isConflictInProgress();
+      return {
+        ...withRemote,
+        gitError: {
+          phase: "pull",
+          message,
+          isConflict,
+          conflictFiles: conflictFiles.length > 0 ? conflictFiles : undefined,
+        },
+      };
+    }
+
+    const { pulledNoteIds, deletedNoteIds } = await this.diffNotesSince(localHead);
+
+    // Phase 3: push
+    try {
       await this.git.push();
       console.error(`[git] Pushed ${unpushed} local commit(s)`);
-      return { hasRemote: true, pulledNoteIds, deletedNoteIds, pushedCommits: unpushed };
     } catch (err) {
-      console.error(`[git] Sync failed: ${err}`);
-      return { hasRemote: true, pulledNoteIds: [], deletedNoteIds: [], pushedCommits: 0 };
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`[git] Sync push failed: ${message}`);
+      // Pull succeeded — return partial success with the pulled notes and the push error
+      return {
+        hasRemote: true,
+        pulledNoteIds,
+        deletedNoteIds,
+        pushedCommits: 0,
+        gitError: { phase: "push", message, isConflict: false },
+      };
     }
+
+    return { hasRemote: true, pulledNoteIds, deletedNoteIds, pushedCommits: unpushed };
+  }
+
+  private async getConflictFiles(): Promise<string[]> {
+    try {
+      const status = await this.git.status();
+      return status.conflicted;
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Checks git's internal state files to detect an in-progress rebase or merge conflict.
+   * Language-independent: these paths are git internals, not localized error messages.
+   */
+  private async isConflictInProgress(): Promise<boolean> {
+    const gitDir = path.join(this.gitRoot, ".git");
+    const statePaths = [
+      path.join(gitDir, "rebase-merge"),   // interactive / --merge rebase
+      path.join(gitDir, "rebase-apply"),   // --apply strategy rebase
+      path.join(gitDir, "MERGE_HEAD"),     // plain merge conflict
+    ];
+    for (const p of statePaths) {
+      try {
+        await access(p);
+        return true;
+      } catch {
+        // not present — try next
+      }
+    }
+    return false;
   }
 
   /** Push only — used after individual remember/update/forget commits */

--- a/src/index.ts
+++ b/src/index.ts
@@ -798,9 +798,28 @@ async function removeStaleEmbeddings(storage: Storage, noteIds: string[]): Promi
   }
 }
 
-function formatSyncResult(result: SyncResult, label: string): string[] {
+function formatSyncResult(result: SyncResult, label: string, vaultPath?: string): string[] {
   if (!result.hasRemote) return [`${label}: no remote configured — git sync skipped.`];
   const lines: string[] = [];
+
+  if (result.gitError) {
+    const { phase, message, isConflict, conflictFiles } = result.gitError;
+    if (isConflict) {
+      lines.push(`${label}: ✗ merge conflict during ${phase}.`);
+      if (conflictFiles && conflictFiles.length > 0) {
+        lines.push(`${label}: conflicted files: ${conflictFiles.join(", ")}`);
+      }
+      const where = vaultPath ?? label;
+      lines.push(`${label}: resolve conflicts in ${where}, then run sync again.`);
+    } else {
+      lines.push(`${label}: ✗ git ${phase} failed: ${message}`);
+    }
+    // Still report any partial pull results that came through before the failure
+    if (result.pulledNoteIds.length > 0)
+      lines.push(`${label}: ↓ ${result.pulledNoteIds.length} note(s) pulled before failure.`);
+    return lines;
+  }
+
   lines.push(result.pushedCommits > 0
     ? `${label}: ↑ pushed ${result.pushedCommits} commit(s).`
     : `${label}: ↑ nothing to push.`);
@@ -3129,11 +3148,12 @@ server.registerTool(
   },
   async ({ cwd, force }) => {
     const lines: string[] = [];
-    const vaultResults: Array<{ vault: "main" | "project"; hasRemote: boolean; pulled: number; deleted: number; pushed: number; embedded: number; failed: string[] }> = [];
+    const vaultResults: Array<StructuredSyncResult["vaults"][number]> = [];
 
     // Always sync main vault
+    const mainVaultPath = vaultManager.main.storage.vaultPath;
     const mainResult = await vaultManager.main.git.sync();
-    lines.push(...formatSyncResult(mainResult, "main vault"));
+    lines.push(...formatSyncResult(mainResult, "main vault", mainVaultPath));
     let mainEmbedded = 0;
     let mainFailed: string[] = [];
     const mainBackfill = await backfillEmbeddingsAfterSync(vaultManager.main.storage, "main vault", lines, force);
@@ -3150,14 +3170,16 @@ server.registerTool(
       pushed: mainResult.pushedCommits,
       embedded: mainEmbedded,
       failed: mainFailed,
+      gitError: mainResult.gitError,
     });
 
     // Optionally sync project vault
     if (cwd) {
       const projectVault = await vaultManager.getProjectVaultIfExists(cwd);
       if (projectVault) {
+        const projectVaultPath = projectVault.storage.vaultPath;
         const projectResult = await projectVault.git.sync();
-        lines.push(...formatSyncResult(projectResult, "project vault"));
+        lines.push(...formatSyncResult(projectResult, "project vault", projectVaultPath));
         let projEmbedded = 0;
         let projFailed: string[] = [];
         const projectBackfill = await backfillEmbeddingsAfterSync(projectVault.storage, "project vault", lines, force);
@@ -3174,6 +3196,7 @@ server.registerTool(
           pushed: projectResult.pushedCommits,
           embedded: projEmbedded,
           failed: projFailed,
+          gitError: projectResult.gitError,
         });
       } else {
         lines.push("project vault: no .mnemonic/ found — skipped.");

--- a/src/structured-content.ts
+++ b/src/structured-content.ts
@@ -170,6 +170,13 @@ export interface ForgetResult extends Record<string, unknown> {
   retry?: MutationRetryContract;
 }
 
+export interface SyncVaultGitError {
+  phase: "fetch" | "pull" | "push";
+  message: string;
+  isConflict: boolean;
+  conflictFiles?: string[];
+}
+
 export interface SyncResult extends Record<string, unknown> {
   action: "synced";
   vaults: Array<{
@@ -179,7 +186,10 @@ export interface SyncResult extends Record<string, unknown> {
     deleted: number;
     pushed: number;
     embedded: number;
+    /** Embedding failures — note ids that could not be re-embedded */
     failed: string[];
+    /** Set when a git operation (fetch/pull/push) failed during sync */
+    gitError?: SyncVaultGitError;
   }>;
 }
 
@@ -518,6 +528,12 @@ export const SyncResultSchema = z.object({
     pushed: z.number(),
     embedded: z.number(),
     failed: z.array(z.string()),
+    gitError: z.object({
+      phase: z.enum(["fetch", "pull", "push"]),
+      message: z.string(),
+      isConflict: z.boolean(),
+      conflictFiles: z.array(z.string()).optional(),
+    }).optional(),
   })),
 });
 

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -12,6 +12,13 @@ const raw = vi.fn();
 const fetch = vi.fn();
 const pull = vi.fn();
 
+// fs/promises access mock — controls which git state paths appear to exist
+const fsAccess = vi.fn();
+
+vi.mock("fs/promises", () => ({
+  access: fsAccess,
+}));
+
 vi.mock("simple-git", () => ({
   simpleGit: vi.fn(() => ({
     add,
@@ -42,10 +49,13 @@ describe("GitOps", () => {
     raw.mockReset();
     fetch.mockReset();
     pull.mockReset();
+    fsAccess.mockReset();
 
     checkIsRepo.mockResolvedValue(true);
     status.mockResolvedValue({ staged: ["notes/test.md"] });
     getRemotes.mockResolvedValue([{ name: "origin" }]);
+    // Default: no git conflict state files present
+    fsAccess.mockRejectedValue(new Error("ENOENT"));
   });
 
   it("throws when commit fails", async () => {
@@ -268,7 +278,7 @@ describe("GitOps", () => {
       expect(result.pulledNoteIds).toEqual(["note"]);
     });
 
-    it("returns hasRemote:true with empty arrays when sync throws", async () => {
+    it("returns gitError with phase:fetch when fetch fails", async () => {
       const { GitOps } = await import("../src/git.js");
       const git = new GitOps("/tmp/repo");
       await git.init();
@@ -277,7 +287,90 @@ describe("GitOps", () => {
 
       const result = await git.sync();
 
-      expect(result).toEqual({ hasRemote: true, pulledNoteIds: [], deletedNoteIds: [], pushedCommits: 0 });
+      expect(result.hasRemote).toBe(true);
+      expect(result.pulledNoteIds).toEqual([]);
+      expect(result.deletedNoteIds).toEqual([]);
+      expect(result.pushedCommits).toBe(0);
+      expect(result.gitError).toEqual({ phase: "fetch", message: "remote unreachable", isConflict: false });
+    });
+
+    it("returns gitError with isConflict:true when pull fails and status shows conflicted files", async () => {
+      const { GitOps } = await import("../src/git.js");
+      const git = new GitOps("/tmp/repo");
+      await git.init();
+
+      fetch.mockResolvedValueOnce(undefined);
+      raw.mockResolvedValueOnce("0\n"); // countUnpushedCommits
+      log.mockResolvedValueOnce({ latest: { hash: "deadbeef" } }); // currentHead
+      pull.mockRejectedValueOnce(new Error("pull failed"));
+      // getConflictFiles calls status()
+      status.mockResolvedValueOnce({ staged: [], conflicted: ["notes/foo.md", "notes/bar.md"] });
+
+      const result = await git.sync();
+
+      expect(result.gitError?.phase).toBe("pull");
+      expect(result.gitError?.isConflict).toBe(true);
+      expect(result.gitError?.conflictFiles).toEqual(["notes/foo.md", "notes/bar.md"]);
+    });
+
+    it("returns gitError with isConflict:true when git state files indicate rebase in progress", async () => {
+      const { GitOps } = await import("../src/git.js");
+      const git = new GitOps("/tmp/repo");
+      await git.init();
+
+      fetch.mockResolvedValueOnce(undefined);
+      raw.mockResolvedValueOnce("0\n");
+      log.mockResolvedValueOnce({ latest: { hash: "deadbeef" } });
+      pull.mockRejectedValueOnce(new Error("error: could not apply abc1234"));
+      // git status shows no conflicted files (edge case) but rebase-merge dir exists
+      status.mockResolvedValueOnce({ staged: [], conflicted: [] });
+      // First access call (.git/rebase-merge) resolves → rebase in progress
+      fsAccess.mockResolvedValueOnce(undefined);
+
+      const result = await git.sync();
+
+      expect(result.gitError?.phase).toBe("pull");
+      expect(result.gitError?.isConflict).toBe(true);
+    });
+
+    it("returns gitError with isConflict:false when pull fails for non-conflict reasons", async () => {
+      const { GitOps } = await import("../src/git.js");
+      const git = new GitOps("/tmp/repo");
+      await git.init();
+
+      fetch.mockResolvedValueOnce(undefined);
+      raw.mockResolvedValueOnce("0\n");
+      log.mockResolvedValueOnce({ latest: { hash: "deadbeef" } });
+      pull.mockRejectedValueOnce(new Error("fatal: repository not found"));
+      // No conflicted files, no git state files
+      status.mockResolvedValueOnce({ staged: [], conflicted: [] });
+      fsAccess.mockRejectedValue(new Error("ENOENT")); // no state files
+
+      const result = await git.sync();
+
+      expect(result.gitError?.phase).toBe("pull");
+      expect(result.gitError?.isConflict).toBe(false);
+    });
+
+    it("returns partial success with gitError when push fails after successful pull", async () => {
+      const { GitOps } = await import("../src/git.js");
+      const git = new GitOps("/tmp/repo");
+      await git.init();
+
+      fetch.mockResolvedValueOnce(undefined);
+      raw.mockResolvedValueOnce("1\n"); // countUnpushedCommits
+      log.mockResolvedValueOnce({ latest: { hash: "aabbccdd" } }); // currentHead
+      pull.mockResolvedValueOnce(undefined);
+      raw.mockResolvedValueOnce("A\tnotes/synced-note.md\n"); // diffNotesSince
+      push.mockRejectedValueOnce(new Error("rejected: non-fast-forward"));
+
+      const result = await git.sync();
+
+      // Pull succeeded — pulled notes should be present
+      expect(result.hasRemote).toBe(true);
+      expect(result.pulledNoteIds).toEqual(["synced-note"]);
+      expect(result.pushedCommits).toBe(0);
+      expect(result.gitError).toEqual({ phase: "push", message: "rejected: non-fast-forward", isConflict: false });
     });
 
     it("uses custom notesRelDir when diffing notes", async () => {

--- a/tests/mcp.integration.test.ts
+++ b/tests/mcp.integration.test.ts
@@ -13,6 +13,7 @@ import {
   MemoryGraphResultSchema,
   MigrationExecuteResultSchema,
   MigrationListResultSchema,
+  SyncResultSchema,
 } from "../src/structured-content.js";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -1858,6 +1859,33 @@ describe("local MCP script", () => {
       const after = await readFile(embeddingPath, "utf-8");
       expect(after).not.toBe("");
       expect(before).not.toBe("");
+    } finally {
+      await embeddingServer.close();
+    }
+  }, 15000);
+
+  it("keeps sync structured output aligned with SyncResultSchema", async () => {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mcp-vault-"));
+    tempDirs.push(vaultDir);
+    const embeddingServer = await startFakeEmbeddingServer();
+
+    try {
+      await callLocalMcp(vaultDir, "remember", {
+        title: "Schema audit sync note",
+        content: "Used to validate SyncResultSchema alignment.",
+        scope: "global",
+        summary: "Seed note for sync schema audit",
+      }, embeddingServer.url);
+
+      const response = await callLocalMcpResponse(vaultDir, "sync", {}, embeddingServer.url);
+
+      // Must parse without throwing — validates gitError optional field is included correctly
+      const parsed = SyncResultSchema.parse(response.structuredContent);
+      expect(parsed.action).toBe("synced");
+      expect(parsed.vaults).toHaveLength(1);
+      expect(parsed.vaults[0]?.vault).toBe("main");
+      // No remote configured so gitError should be absent
+      expect(parsed.vaults[0]?.gitError).toBeUndefined();
     } finally {
       await embeddingServer.close();
     }


### PR DESCRIPTION
## Summary

This PR captures the following design decisions:

- **Design principle: git state detection must be language-independent**
- **sync tool: per-phase git error surfacing with conflict detection**

## Design Decisions

### Design principle: git state detection must be language-independent

**Tags:** git, design, resilience, portability

When detecting git state (conflicts, rebase in progress, merge state), never rely on error message keywords. Git error messages are localized — they change under different `LANG`/`LC_ALL` settings.

## Language-independent alternatives

- **`git status --porcelain`** status codes (UU, AA, DD, etc.) are not localized — safe to parse. `simple-git`'s `status().conflicted` uses this.
- **Git internal state files** are filesystem paths, not text — entirely language-independent:
  - `.git/rebase-merge/` — interactive or `--merge` rebase in progress
  - `.git/rebase-apply/` — `--apply` strategy rebase in progress
  - `.git/MERGE_HEAD` — plain merge conflict

## What to avoid

Do not check error message strings for words like "conflict", "merge", "rebase", "Konflikt", etc. These are locale-dependent and will silently mis-classify on non-English systems.

## Applied in

`GitOps.isConflictInProgress()` in `src/git.ts` replaced a keyword-based fallback (`messageIndicatesConflict`) with `fs.access` checks on the three git state paths above.

### sync tool: per-phase git error surfacing with conflict detection

**Tags:** git, sync, resilience, structured-content, design, completed, schema

The `sync` tool previously swallowed all git errors inside a single try-catch, returning empty arrays indistinguishable from a clean no-op sync. A merge conflict during `pull --rebase` was completely invisible to callers.

## What changed

- `SyncResult` in `git.ts` now carries an optional `gitError: SyncGitError` with `phase` ("fetch" | "pull" | "push"), `message`, `isConflict`, and `conflictFiles`.
- `sync()` in `git.ts` handles each phase independently: fetch, pull, push. Each catches its own error and returns `gitError` instead of swallowing.
- Conflict detection: `getConflictFiles()` calls `git.status()` for conflicted files; `messageIndicatesConflict()` checks for "conflict"/"merge"/"rebase" keywords in the error message. Both are checked on pull failure.
- Push phase failure is a partial success: pulled notes are still returned alongside the `gitError`.
- `SyncResult` in `structured-content.ts` has a new `gitError` field per vault entry, and `SyncResultSchema` (Zod) models it with `.optional()`.
- `formatSyncResult` in `index.ts` now renders conflict messages with vault path and actionable guidance ("resolve conflicts in vault-path, then run sync again").
- `vaultResults` type now uses `StructuredSyncResult["vaults"][number]` instead of an inline type to stay in sync with the schema.

## Why this matters

Without this, a merge conflict during sync was a silent no-op. Callers had no way to distinguish "nothing to sync" from "sync failed due to conflict." Following the same robustness principles as the retry contract rollout: failures must be first-class structured results.

## Tests added

- `git.test.ts`: fetch failure returns `gitError.phase = "fetch"`, pull failure with conflicted status returns `isConflict: true` with `conflictFiles`, pull failure via keyword returns `isConflict: true`, push failure returns partial success with pulled notes and `gitError.phase = "push"`.
- `mcp.integration.test.ts`: `SyncResultSchema.parse()` schema audit validates `gitError` optional field is correctly modeled and absent on no-remote vault.

---

_Generated from 2 design decision note(s) in `.mnemonic/notes/`. Run `/update-pr` to regenerate._