### PR TITLE
Bug fix: loadAllVaultsForRoot creating gitignore on read-only access

### DIFF
--- a/.mnemonic/notes/bug-fix-loadallvaultsforroot-creating-gitignore-on-read-only-bfaa7911.md
+++ b/.mnemonic/notes/bug-fix-loadallvaultsforroot-creating-gitignore-on-read-only-bfaa7911.md
@@ -1,0 +1,46 @@
+---
+title: 'Bug fix: loadAllVaultsForRoot creating gitignore on read-only access'
+tags:
+  - bug
+  - vault-routing
+  - fix
+lifecycle: temporary
+createdAt: '2026-03-19T20:39:15.008Z'
+updatedAt: '2026-03-19T20:39:15.008Z'
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+## Bug
+
+When a project has `.mnemonic/` directory but no `.mnemonic/.gitignore`, calling `getProjectVaultIfExists()` or any read-only operation that triggers `loadAllVaultsForRoot(create: false)` was incorrectly creating and committing `.gitignore`.
+
+This caused unwanted project vault adoption even when the memory policy was set to `global`.
+
+## Root cause
+
+In `src/vault.ts` lines 173-184, the gitignore initialization code ran unconditionally after the early-return check at line 171. The `create` parameter was not being honored for gitignore creation.
+
+## Fix
+
+Wrapped gitignore creation and commit inside `if (create)` block at line 177:
+
+```typescript
+if (create) {
+  const gitignorePath = path.join(mnemonicPath, ".gitignore");
+  const isNew = !(await pathExists(gitignorePath));
+  await ensureGitignore(gitignorePath);
+
+  if (isNew) {
+    await primaryVault.git.commit("chore: initialize .mnemonic vault", [".mnemonic/.gitignore"]);
+  }
+}
+```
+
+## Test coverage
+
+Added regression test in `tests/vault.test.ts`:
+
+- "should not create or commit gitignore when loading existing project vault (getProjectVaultIfExists)"
+
+All 253 tests pass.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `mnemonic` will be documented in this file.
 
 The format is loosely based on Keep a Changelog and uses semver-style version headings.
 
+## [0.12.2] - 2026-03-19
+
+### Fixed
+
+- Project vault gitignore is now only created during intentional vault creation (`getOrCreateProjectVault`), not during read-only access via `getProjectVaultIfExists`.
+
 ## [0.12.1] - 2026-03-18
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "A local MCP memory server backed by markdown + JSON files, synced via git",
   "type": "module",
   "repository": {

--- a/src/vault.ts
+++ b/src/vault.ts
@@ -174,13 +174,15 @@ export class VaultManager {
     await primaryVault.storage.init();
     await primaryVault.git.init();
 
-    const gitignorePath = path.join(mnemonicPath, ".gitignore");
-    const isNew = !(await pathExists(gitignorePath));
-    await ensureGitignore(gitignorePath);
+    if (create) {
+      const gitignorePath = path.join(mnemonicPath, ".gitignore");
+      const isNew = !(await pathExists(gitignorePath));
+      await ensureGitignore(gitignorePath);
 
-    if (isNew) {
-      // Commit the .gitignore so collaborators also ignore embeddings/
-      await primaryVault.git.commit("chore: initialize .mnemonic vault", [".mnemonic/.gitignore"]);
+      if (isNew) {
+        // Commit the .gitignore so collaborators also ignore embeddings/
+        await primaryVault.git.commit("chore: initialize .mnemonic vault", [".mnemonic/.gitignore"]);
+      }
     }
 
     this.primaryProjectVaults.set(resolved, primaryVault);

--- a/tests/vault.test.ts
+++ b/tests/vault.test.ts
@@ -132,6 +132,28 @@ describe("VaultManager", () => {
       
       expect(vault1).toBe(vault2); // Same instance
     });
+
+    it("should not create or commit gitignore when loading existing project vault (getProjectVaultIfExists)", async () => {
+      const projectDir = path.join(tempDir, "project-gitignore-bug");
+      await fs.mkdir(projectDir, { recursive: true });
+      await initGitRepo(projectDir, "# Project Gitignore Bug");
+      
+      const mnemonicDir = path.join(projectDir, ".mnemonic");
+      await fs.mkdir(mnemonicDir, { recursive: true });
+      await fs.mkdir(path.join(mnemonicDir, "notes"), { recursive: true });
+      await fs.mkdir(path.join(mnemonicDir, "embeddings"), { recursive: true });
+      
+      // NO .gitignore file created initially
+      
+      // Load the existing project vault (create: false)
+      const vault = await vaultManager.getProjectVaultIfExists(projectDir);
+      expect(vault).toBeTruthy();
+      
+      // Bug fix verification: gitignore should NOT be created when just loading an existing vault
+      const gitignorePath = path.join(mnemonicDir, ".gitignore");
+      const gitignoreExists = await fs.stat(gitignorePath).then(() => true).catch(() => false);
+      expect(gitignoreExists).toBe(false);
+    });
   });
 
   describe("Note Resolution", () => {


### PR DESCRIPTION
## Summary

When a project has `.mnemonic/` directory but no `.mnemonic/.gitignore`, calling `getProjectVaultIfExists()` or any read-only operation that triggers `loadAllVaultsForRoot(create: false)` was incorrectly creating and committing `.gitignore`.

## Design Decisions

### Bug fix: loadAllVaultsForRoot creating gitignore on read-only access

**Tags:** bug, vault-routing, fix

## Bug

When a project has `.mnemonic/` directory but no `.mnemonic/.gitignore`, calling `getProjectVaultIfExists()` or any read-only operation that triggers `loadAllVaultsForRoot(create: false)` was incorrectly creating and committing `.gitignore`.

This caused unwanted project vault adoption even when the memory policy was set to `global`.

## Root cause

In `src/vault.ts` lines 173-184, the gitignore initialization code ran unconditionally after the early-return check at line 171. The `create` parameter was not being honored for gitignore creation.

## Fix

Wrapped gitignore creation and commit inside `if (create)` block at line 177:

```typescript
if (create) {
  const gitignorePath = path.join(mnemonicPath, ".gitignore");
  const isNew = !(await pathExists(gitignorePath));
  await ensureGitignore(gitignorePath);

  if (isNew) {
    await primaryVault.git.commit("chore: initialize .mnemonic vault", [".mnemonic/.gitignore"]);
  }
}
```

## Test coverage

Added regression test in `tests/vault.test.ts`:

- "should not create or commit gitignore when loading existing project vault (getProjectVaultIfExists)"

All 253 tests pass.

---

_Generated from 1 design decision note(s) in `.mnemonic/notes/`. Run `/update-pr` to regenerate._