### PR TITLE
mnemonic_relate/unrelate reconcile partial git persistence on retry

### DIFF
--- a/.mnemonic/notes/mnemonic-relate-retry-does-not-reconcile-partial-git-persist-fd9d13c9.md
+++ b/.mnemonic/notes/mnemonic-relate-retry-does-not-reconcile-partial-git-persist-fd9d13c9.md
@@ -1,0 +1,58 @@
+---
+title: >-
+  mnemonic_relate retry does not reconcile partial git persistence after
+  index.lock failure
+tags:
+  - mnemonic
+  - bug
+  - retry
+  - git
+  - persistence
+  - mcp
+lifecycle: permanent
+createdAt: '2026-03-19T22:01:11.193Z'
+updatedAt: '2026-03-19T22:01:11.193Z'
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+`mnemonic_relate` can apply a relationship change to note content but fail to fully persist it when git operations hit a transient `.git/index.lock` error in the mnemonic vault.
+
+Observed behavior:
+
+- The semantic mutation succeeds: the `relatedTo` links are written to the note files and the memory graph reflects the new relationships.
+- Persistence is only partially completed: some files may be staged, others remain unstaged, and no commit is created.
+- A subsequent retry of the same `mnemonic_relate` call returns `Relationship already exists` and does not reconcile the partial git state by staging/committing the remaining files.
+
+Why this looks like a bug:
+
+- The retry contract should either finish the interrupted persistence workflow (`git add` / `git commit`) or surface a distinct status such as "mutation applied but persistence incomplete".
+- Current behavior short-circuits on logical relationship existence and skips repository reconciliation.
+- This makes the operation non-atomic across note mutation and vault persistence.
+
+Concrete session evidence:
+
+- Four relationship links were added successfully at the content/model level.
+- The mnemonic tool reported git errors such as `Unable to create '/Users/danielmarbach/mnemonic-vault/.git/index.lock': File exists` during `git add` / `git commit`.
+- Retrying `mnemonic_relate` later reported the relationships already existed, but `/Users/danielmarbach/mnemonic-vault` still showed 2 staged files and 4 modified-but-unstaged files until manually repaired and committed.
+
+Suggested bug report text:
+`mnemonic_relate` leaves the mnemonic vault in a partially persisted state if git persistence fails after note mutation (for example due to a transient `.git/index.lock`). Retrying the same relation call reports `Relationship already exists` but does not resume or reconcile the interrupted git workflow. Expected behavior: retries should complete persistence, or the tool should return a specific "persistence incomplete" status with a recovery path.
+
+Repro outline:
+
+1. Start with a clean mnemonic vault.
+2. Invoke `mnemonic_relate` on two memories stored in the same vault.
+3. Force a transient git failure after note mutation but before persistence completes, for example by creating a competing `.git/index.lock` or otherwise causing `git add` / `git commit` to fail.
+4. Observe that note content and the in-memory graph now show the relationship, but the vault repository is left partially updated (for example some files staged, some unstaged, no commit).
+5. Retry the exact same `mnemonic_relate` call.
+6. Observe that the tool returns `Relationship already exists` and does not repair the partial repository state.
+7. Confirm manual `git status` in the mnemonic vault still shows pending changes that require manual staging/commit.
+
+Expected result:
+
+- The retry resumes and completes persistence, or the first failure returns a dedicated incomplete-persistence outcome that preserves recoverability.
+
+Actual result:
+
+- The retry path uses semantic existence as success and ignores git persistence reconciliation.

--- a/.mnemonic/notes/mnemonic-relate-retry-does-not-reconcile-partial-git-persist-fd9d13c9.md
+++ b/.mnemonic/notes/mnemonic-relate-retry-does-not-reconcile-partial-git-persist-fd9d13c9.md
@@ -1,58 +1,52 @@
 ---
-title: >-
-  mnemonic_relate retry does not reconcile partial git persistence after
-  index.lock failure
+title: mnemonic_relate/unrelate reconcile partial git persistence on retry
 tags:
   - mnemonic
   - bug
-  - retry
+  - fixed
   - git
   - persistence
   - mcp
 lifecycle: permanent
 createdAt: '2026-03-19T22:01:11.193Z'
-updatedAt: '2026-03-19T22:01:11.193Z'
+updatedAt: '2026-03-19T22:10:02.637Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 memoryVersion: 1
 ---
-`mnemonic_relate` can apply a relationship change to note content but fail to fully persist it when git operations hit a transient `.git/index.lock` error in the mnemonic vault.
+## Issue (Fixed)
 
-Observed behavior:
+`mnemonic_relate` and `mnemonic_unrelate` could apply relationship changes to note content but fail to fully persist when git operations hit a transient `.git/index.lock` error. Retrying returned "Relationship already exists" without reconciling the partial git state.
 
-- The semantic mutation succeeds: the `relatedTo` links are written to the note files and the memory graph reflects the new relationships.
-- Persistence is only partially completed: some files may be staged, others remain unstaged, and no commit is created.
-- A subsequent retry of the same `mnemonic_relate` call returns `Relationship already exists` and does not reconcile the partial git state by staging/committing the remaining files.
+## Root Cause
 
-Why this looks like a bug:
+When relationships already existed in note content (from a previous failed attempt where note mutation succeeded but git commit failed), the tools short-circuited on the semantic check (`vaultChanges.size === 0`) and returned an error without checking for uncommitted git changes.
 
-- The retry contract should either finish the interrupted persistence workflow (`git add` / `git commit`) or surface a distinct status such as "mutation applied but persistence incomplete".
-- Current behavior short-circuits on logical relationship existence and skips repository reconciliation.
-- This makes the operation non-atomic across note mutation and vault persistence.
+## Fix Applied
 
-Concrete session evidence:
+Both `relate` and `unrelate` now check git status when no content changes are needed:
 
-- Four relationship links were added successfully at the content/model level.
-- The mnemonic tool reported git errors such as `Unable to create '/Users/danielmarbach/mnemonic-vault/.git/index.lock': File exists` during `git add` / `git commit`.
-- Retrying `mnemonic_relate` later reported the relationships already existed, but `/Users/danielmarbach/mnemonic-vault` still showed 2 staged files and 4 modified-but-unstaged files until manually repaired and committed.
+1. If relationships exist in note content, check `git.status()` for staged or modified files
+2. If pending changes are found, commit them and return success
+3. Only return "already exists" / "not found" error if both content and git are clean
 
-Suggested bug report text:
-`mnemonic_relate` leaves the mnemonic vault in a partially persisted state if git persistence fails after note mutation (for example due to a transient `.git/index.lock`). Retrying the same relation call reports `Relationship already exists` but does not resume or reconcile the interrupted git workflow. Expected behavior: retries should complete persistence, or the tool should return a specific "persistence incomplete" status with a recovery path.
+**Implementation details:**
 
-Repro outline:
+- Added `GitOps.status()` method that returns `{ staged: string[], modified: string[] }` using `simple-git`'s porcelain status (language-independent)
+- Uses `status.staged` and `status.modified` arrays which are porcelain format - safe across locales
+- Matches the same pattern used in `isConflictInProgress()` which uses filesystem paths instead of localized messages
 
-1. Start with a clean mnemonic vault.
-2. Invoke `mnemonic_relate` on two memories stored in the same vault.
-3. Force a transient git failure after note mutation but before persistence completes, for example by creating a competing `.git/index.lock` or otherwise causing `git add` / `git commit` to fail.
-4. Observe that note content and the in-memory graph now show the relationship, but the vault repository is left partially updated (for example some files staged, some unstaged, no commit).
-5. Retry the exact same `mnemonic_relate` call.
-6. Observe that the tool returns `Relationship already exists` and does not repair the partial repository state.
-7. Confirm manual `git status` in the mnemonic vault still shows pending changes that require manual staging/commit.
+## Files Changed
 
-Expected result:
+- `src/git.ts`: Added `status()` method
+- `src/index.ts`: Updated `relate` and `unrelate` handlers with git reconciliation logic
 
-- The retry resumes and completes persistence, or the first failure returns a dedicated incomplete-persistence outcome that preserves recoverability.
+## Test Coverage
 
-Actual result:
+Type check passes. All 255 tests pass.
 
-- The retry path uses semantic existence as success and ignores git persistence reconciliation.
+## Design Principles Followed
+
+- Git state detection uses porcelain format (language-independent)
+- Scoped file paths passed to `commitWithStatus` (only mnemonic-managed files)
+- Retry contract pattern preserved (builds `MutationRetryContract` when recommitting)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `mnemonic` will be documented in this file.
 
 The format is loosely based on Keep a Changelog and uses semver-style version headings.
 
+## [0.13.1] - 2026-03-20
+
+### Fixed
+
+- `relate` and `unrelate` now reconcile pending git changes when relationships already exist in note content. Previously, if git operations failed (e.g., transient `.git/index.lock` errors) after note mutations succeeded, retries returned "relationship already exists" without committing the staged changes, leaving the vault in an inconsistent state.
+
 ## [0.13.0] - 2026-03-19
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@danielmarbach/mnemonic-mcp",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.1",
         "gray-matter": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "A local MCP memory server backed by markdown + JSON files, synced via git",
   "type": "module",
   "repository": {

--- a/src/git.ts
+++ b/src/git.ts
@@ -169,6 +169,23 @@ export class GitOps {
   }
 
   /**
+   * Get git status for checking uncommitted changes.
+   * Returns staged and modified files.
+   */
+  async status(): Promise<{ staged: string[]; modified: string[] }> {
+    if (!this.enabled) return { staged: [], modified: [] };
+    try {
+      const status = await this.git.status();
+      return {
+        staged: status.staged,
+        modified: status.modified,
+      };
+    } catch {
+      return { staged: [], modified: [] };
+    }
+  }
+
+  /**
    * Bidirectional sync: fetch → count unpushed local commits → pull (rebase)
    * → push. Returns details about what changed so callers can trigger
    * re-embedding for notes that arrived from the remote.

--- a/src/index.ts
+++ b/src/index.ts
@@ -3454,24 +3454,80 @@ server.registerTool(
     const vaultChanges = new Map<Vault, string[]>();
 
     const fromRels = fromNote.relatedTo ?? [];
-    if (!fromRels.some((r) => r.id === toId)) {
+    const fromRelExists = fromRels.some((r) => r.id === toId);
+    if (!fromRelExists) {
       await fromVault.storage.writeNote({ ...fromNote, relatedTo: [...fromRels, { id: toId, type }], updatedAt: now });
       const files = vaultChanges.get(fromVault) ?? [];
       files.push(vaultManager.noteRelPath(fromVault, fromId));
       vaultChanges.set(fromVault, files);
     }
 
-    if (bidirectional) {
-      const toRels = toNote.relatedTo ?? [];
-      if (!toRels.some((r) => r.id === fromId)) {
-        await toVault.storage.writeNote({ ...toNote, relatedTo: [...toRels, { id: fromId, type }], updatedAt: now });
-        const files = vaultChanges.get(toVault) ?? [];
-        files.push(vaultManager.noteRelPath(toVault, toId));
-        vaultChanges.set(toVault, files);
-      }
+    const toRels = toNote.relatedTo ?? [];
+    const toRelExists = toRels.some((r) => r.id === fromId);
+    if (bidirectional && !toRelExists) {
+      await toVault.storage.writeNote({ ...toNote, relatedTo: [...toRels, { id: fromId, type }], updatedAt: now });
+      const files = vaultChanges.get(toVault) ?? [];
+      files.push(vaultManager.noteRelPath(toVault, toId));
+      vaultChanges.set(toVault, files);
     }
 
+    // Check for uncommitted changes from a previous failed attempt
     if (vaultChanges.size === 0) {
+      // If relationships exist in note content, check git status for pending changes
+      const allVaults = new Set([fromVault, ...(bidirectional && toVault !== fromVault ? [toVault] : [])]);
+      
+      for (const vault of allVaults) {
+        const noteIds = vault === fromVault
+          ? (bidirectional && vault === toVault ? [fromId, toId] : [fromId])
+          : [toId];
+        const pendingFiles = await vaultManager.getPendingNoteFiles(vault, noteIds);
+        
+        if (pendingFiles.length > 0) {
+          // Commit the pending changes from previous failed attempt
+          const commitBody = formatCommitBody({
+            noteId: fromId,
+            noteTitle: fromNote.title,
+            projectName: fromNote.projectName,
+            relationship: { fromId, toId, type },
+          });
+          const commitMessage = `relate: ${fromNote.title} ↔ ${toNote.title}`;
+          const commitStatus = await vault.git.commitWithStatus(commitMessage, pendingFiles, commitBody);
+          
+          if (commitStatus.status === "committed") {
+            await pushAfterMutation(vault);
+          }
+          
+          const retry = buildMutationRetryContract({
+            commit: commitStatus,
+            commitMessage,
+            commitBody,
+            files: pendingFiles,
+            cwd,
+            vault,
+            mutationApplied: true,
+          });
+          
+          const structuredContent: RelateResult = {
+            action: "related",
+            fromId,
+            toId,
+            type,
+            bidirectional,
+            notesModified: pendingFiles.map((f: string) => path.basename(f, '.md')),
+            retry,
+          };
+          
+          const retrySummary = formatRetrySummary(retry);
+          return {
+            content: [{
+              type: "text",
+              text: `Reconciled pending commit for relationship \`${fromId}\` ${bidirectional ? "↔" : "→"} \`${toId}\` (${type})${retrySummary ? `\n${retrySummary}` : ""}`,
+            }],
+            structuredContent,
+          };
+        }
+      }
+      
       return { content: [{ type: "text", text: `Relationship already exists between '${fromId}' and '${toId}'` }], isError: true };
     }
 
@@ -3577,7 +3633,8 @@ server.registerTool(
     if (foundFrom) {
       const { note: fromNote, vault: fromVault } = foundFrom;
       const filtered = (fromNote.relatedTo ?? []).filter((r) => r.id !== toId);
-      if (filtered.length !== (fromNote.relatedTo?.length ?? 0)) {
+      const fromRelExisted = (fromNote.relatedTo?.length ?? 0) > filtered.length;
+      if (fromRelExisted) {
         await fromVault.storage.writeNote({ ...fromNote, relatedTo: filtered, updatedAt: now });
         const files = vaultChanges.get(fromVault) ?? [];
         files.push(vaultManager.noteRelPath(fromVault, fromId));
@@ -3588,7 +3645,8 @@ server.registerTool(
     if (bidirectional && foundTo) {
       const { note: toNote, vault: toVault } = foundTo;
       const filtered = (toNote.relatedTo ?? []).filter((r) => r.id !== fromId);
-      if (filtered.length !== (toNote.relatedTo?.length ?? 0)) {
+      const toRelExisted = (toNote.relatedTo?.length ?? 0) > filtered.length;
+      if (toRelExisted) {
         await toVault.storage.writeNote({ ...toNote, relatedTo: filtered, updatedAt: now });
         const files = vaultChanges.get(toVault) ?? [];
         files.push(vaultManager.noteRelPath(toVault, toId));
@@ -3596,7 +3654,68 @@ server.registerTool(
       }
     }
 
+    // Check for uncommitted changes from a previous failed attempt
     if (vaultChanges.size === 0) {
+      // If no relationships were found in note content, check git status for pending changes
+      const allVaults = new Set<Vault>();
+      if (foundFrom) allVaults.add(foundFrom.vault);
+      if (bidirectional && foundTo) allVaults.add(foundTo.vault);
+      
+      for (const vault of allVaults) {
+        const noteIds: string[] = [];
+        if (foundFrom && foundFrom.vault === vault) noteIds.push(fromId);
+        if (bidirectional && foundTo && foundTo.vault === vault) noteIds.push(toId);
+        
+        const pendingFiles = await vaultManager.getPendingNoteFiles(vault, noteIds);
+        
+        if (pendingFiles.length > 0) {
+          // Commit the pending changes from previous failed attempt
+          const found = foundFrom?.vault === vault ? foundFrom : foundTo;
+          const commitBody = found
+            ? formatCommitBody({
+                noteId: found.note.id,
+                noteTitle: found.note.title,
+                projectName: found.note.projectName,
+              })
+            : undefined;
+          const commitMessage = `unrelate: ${fromId} ↔ ${toId}`;
+          const commitStatus = await vault.git.commitWithStatus(commitMessage, pendingFiles, commitBody);
+          
+          if (commitStatus.status === "committed") {
+            await pushAfterMutation(vault);
+          }
+          
+          const retry = buildMutationRetryContract({
+            commit: commitStatus,
+            commitMessage,
+            commitBody,
+            files: pendingFiles,
+            cwd,
+            vault,
+            mutationApplied: true,
+          });
+          
+          const structuredContent: RelateResult = {
+            action: "unrelated",
+            fromId,
+            toId,
+            type: "related-to",
+            bidirectional,
+            notesModified: pendingFiles.map((f: string) => path.basename(f, '.md')),
+            retry,
+          };
+          
+          const retrySummary = formatRetrySummary(retry);
+          return {
+            content: [{
+              type: "text",
+              text: `Reconciled pending commit for relationship removal between \`${fromId}\` and \`${toId}\`${retrySummary ? `\n${retrySummary}` : ""}`,
+            }],
+            structuredContent,
+          };
+        }
+      }
+      
       return { content: [{ type: "text", text: `No relationship found between '${fromId}' and '${toId}'` }], isError: true };
     }
 

--- a/src/vault.ts
+++ b/src/vault.ts
@@ -148,6 +148,22 @@ export class VaultManager {
     return `${vault.notesRelDir}/${noteId}.md`;
   }
 
+  /**
+   * Check for pending git changes (staged or modified) for specific notes in a vault.
+   * Returns file paths that have uncommitted changes from a previous failed attempt.
+   */
+  async getPendingNoteFiles(vault: Vault, noteIds: string[]): Promise<string[]> {
+    const status = await vault.git.status();
+    const pendingFiles: string[] = [];
+    for (const noteId of noteIds) {
+      const filePath = this.noteRelPath(vault, noteId);
+      if (status.staged.includes(filePath) || status.modified.includes(filePath)) {
+        pendingFiles.push(filePath);
+      }
+    }
+    return pendingFiles;
+  }
+
   // ── Private ─────────────────────────────────────────────────────────────────
 
   private isMainRepo(gitRoot: string): boolean {

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -389,5 +389,51 @@ describe("GitOps", () => {
 
       expect(result.pulledNoteIds).toEqual(["proj-note"]);
     });
+
+    it("returns staged and modified files from status()", async () => {
+      const { GitOps } = await import("../src/git.js");
+      const git = new GitOps("/tmp/repo");
+      await git.init();
+
+      status.mockResolvedValueOnce({
+        staged: ["notes/note1.md", "notes/note2.md"],
+        modified: ["notes/note3.md"],
+        conflicted: [],
+      });
+
+      const result = await git.status();
+
+      expect(result.staged).toEqual(["notes/note1.md", "notes/note2.md"]);
+      expect(result.modified).toEqual(["notes/note3.md"]);
+    });
+
+    it("returns empty arrays when git is disabled", async () => {
+      process.env.DISABLE_GIT = "true";
+      vi.resetModules();
+
+      const { GitOps } = await import("../src/git.js");
+      const git = new GitOps("/tmp/repo");
+      await git.init();
+
+      const result = await git.status();
+
+      expect(result.staged).toEqual([]);
+      expect(result.modified).toEqual([]);
+
+      delete process.env.DISABLE_GIT;
+    });
+
+    it("returns empty arrays when status() throws", async () => {
+      const { GitOps } = await import("../src/git.js");
+      const git = new GitOps("/tmp/repo");
+      await git.init();
+
+      status.mockRejectedValueOnce(new Error("not a git repository"));
+
+      const result = await git.status();
+
+      expect(result.staged).toEqual([]);
+      expect(result.modified).toEqual([]);
+    });
   });
 });

--- a/tests/vault.test.ts
+++ b/tests/vault.test.ts
@@ -702,6 +702,8 @@ describe("VaultManager", () => {
 async function initGitRepo(projectDir: string, readmeContent: string): Promise<void> {
   const git = simpleGit(projectDir);
   await git.init();
+  await git.addConfig("user.email", "test@example.com");
+  await git.addConfig("user.name", "Test");
   await fs.writeFile(path.join(projectDir, "README.md"), readmeContent);
 }
 

--- a/tests/vault.test.ts
+++ b/tests/vault.test.ts
@@ -564,6 +564,139 @@ describe("VaultManager", () => {
       expect(relPath).toBe(".mnemonic-widget/notes/my-note.md");
     });
   });
+
+  describe("getPendingNoteFiles", () => {
+    it("returns pending files for staged notes", async () => {
+      delete process.env.DISABLE_GIT;
+      const projectDir = path.join(tempDir, "project-pending");
+      await fs.mkdir(projectDir, { recursive: true });
+      await initGitRepo(projectDir, "# Pending Test");
+
+      const vaultMgr = new VaultManager(mainVaultPath);
+      await vaultMgr.initMain();
+      const projectVault = await vaultMgr.getOrCreateProjectVault(projectDir);
+      expect(projectVault).toBeTruthy();
+
+      // Write a note
+      const note: Note = {
+        id: "test-note",
+        title: "Test Note",
+        content: "Test content",
+        tags: [],
+        lifecycle: "permanent",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      await projectVault!.storage.writeNote(note);
+
+      // Stage the file manually
+      const git = simpleGit(projectDir);
+      await git.add(".mnemonic/notes/test-note.md");
+
+      // Check for pending files
+      const pendingFiles = await vaultMgr.getPendingNoteFiles(projectVault!, ["test-note"]);
+      expect(pendingFiles).toContain(".mnemonic/notes/test-note.md");
+      
+      process.env.DISABLE_GIT = "true";
+    });
+
+    it("returns pending files for modified notes", async () => {
+      delete process.env.DISABLE_GIT;
+      const projectDir = path.join(tempDir, "project-pending-mod");
+      await fs.mkdir(projectDir, { recursive: true });
+      await initGitRepoWithCommit(projectDir, "# Pending Mod Test");
+
+      const vaultMgr = new VaultManager(mainVaultPath);
+      await vaultMgr.initMain();
+      const projectVault = await vaultMgr.getOrCreateProjectVault(projectDir);
+      expect(projectVault).toBeTruthy();
+
+      // Write and commit a note first
+      const note: Note = {
+        id: "test-note-mod",
+        title: "Test Note",
+        content: "Original content",
+        tags: [],
+        lifecycle: "permanent",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      await projectVault!.storage.writeNote(note);
+      const git = simpleGit(projectDir);
+      await git.add(".mnemonic/notes/test-note-mod.md");
+      await git.commit("initial note");
+
+      // Modify the note (creates modified file)
+      await projectVault!.storage.writeNote({ ...note, content: "Modified content" });
+
+      // Check for pending files - should pick up modified file
+      const pendingFiles = await vaultMgr.getPendingNoteFiles(projectVault!, ["test-note-mod"]);
+      expect(pendingFiles).toContain(".mnemonic/notes/test-note-mod.md");
+      
+      process.env.DISABLE_GIT = "true";
+    });
+
+    it("returns empty array when git is disabled", async () => {
+      // Git is already disabled in beforeEach
+      // The status() method returns empty arrays when DISABLE_GIT=true
+      const pendingFiles = await vaultManager.getPendingNoteFiles(vaultManager.main, ["any-note"]);
+      expect(pendingFiles).toEqual([]);
+    });
+
+    it("returns empty array when no pending changes", async () => {
+      delete process.env.DISABLE_GIT;
+      const projectDir = path.join(tempDir, "project-clean");
+      await fs.mkdir(projectDir, { recursive: true });
+      await initGitRepo(projectDir, "# Clean Test");
+
+      const vaultMgr = new VaultManager(mainVaultPath);
+      await vaultMgr.initMain();
+      const projectVault = await vaultMgr.getOrCreateProjectVault(projectDir);
+      expect(projectVault).toBeTruthy();
+
+      const pendingFiles = await vaultMgr.getPendingNoteFiles(projectVault!, ["nonexistent"]);
+      expect(pendingFiles).toEqual([]);
+      
+      process.env.DISABLE_GIT = "true";
+    });
+
+    it("returns multiple pending files", async () => {
+      delete process.env.DISABLE_GIT;
+      const projectDir = path.join(tempDir, "project-multi-pending");
+      await fs.mkdir(projectDir, { recursive: true });
+      await initGitRepo(projectDir, "# Multi Pending");
+
+      const vaultMgr = new VaultManager(mainVaultPath);
+      await vaultMgr.initMain();
+      const projectVault = await vaultMgr.getOrCreateProjectVault(projectDir);
+      expect(projectVault).toBeTruthy();
+
+      // Write multiple notes and stage them
+      for (let i = 1; i <= 2; i++) {
+        const note: Note = {
+          id: `note-${i}`,
+          title: `Note ${i}`,
+          content: `Content ${i}`,
+          tags: [],
+          lifecycle: "permanent",
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        };
+        await projectVault!.storage.writeNote(note);
+      }
+
+      const git = simpleGit(projectDir);
+      await git.add(".mnemonic/notes/note-1.md");
+      await git.add(".mnemonic/notes/note-2.md");
+
+      const pendingFiles = await vaultMgr.getPendingNoteFiles(projectVault!, ["note-1", "note-2"]);
+      expect(pendingFiles).toHaveLength(2);
+      expect(pendingFiles).toContain(".mnemonic/notes/note-1.md");
+      expect(pendingFiles).toContain(".mnemonic/notes/note-2.md");
+      
+      process.env.DISABLE_GIT = "true";
+    });
+  });
 });
 
 async function initGitRepo(projectDir: string, readmeContent: string): Promise<void> {


### PR DESCRIPTION
## Summary

`mnemonic_relate` and `mnemonic_unrelate` could apply relationship changes to note content but fail to fully persist when git operations hit a transient `.git/index.lock` error. Retrying returned "Relationship already exists" without reconciling the partial git state.

## Design Decisions

### mnemonic_relate/unrelate reconcile partial git persistence on retry

**Tags:** mnemonic, bug, fixed, git, persistence, mcp

## Issue (Fixed)

`mnemonic_relate` and `mnemonic_unrelate` could apply relationship changes to note content but fail to fully persist when git operations hit a transient `.git/index.lock` error. Retrying returned "Relationship already exists" without reconciling the partial git state.

## Root Cause

When relationships already existed in note content (from a previous failed attempt where note mutation succeeded but git commit failed), the tools short-circuited on the semantic check (`vaultChanges.size === 0`) and returned an error without checking for uncommitted git changes.

## Fix Applied

Both `relate` and `unrelate` now check git status when no content changes are needed:

1. If relationships exist in note content, check `git.status()` for staged or modified files
2. If pending changes are found, commit them and return success
3. Only return "already exists" / "not found" error if both content and git are clean

**Implementation details:**

- Added `GitOps.status()` method that returns `{ staged: string[], modified: string[] }` using `simple-git`'s porcelain status (language-independent)
- Uses `status.staged` and `status.modified` arrays which are porcelain format - safe across locales
- Matches the same pattern used in `isConflictInProgress()` which uses filesystem paths instead of localized messages

## Files Changed

- `src/git.ts`: Added `status()` method
- `src/index.ts`: Updated `relate` and `unrelate` handlers with git reconciliation logic

## Test Coverage

Type check passes. All 255 tests pass.

## Design Principles Followed

- Git state detection uses porcelain format (language-independent)
- Scoped file paths passed to `commitWithStatus` (only mnemonic-managed files)
- Retry contract pattern preserved (builds `MutationRetryContract` when recommitting)

---

_Generated from 1 design decision note(s) in `.mnemonic/notes/`. Run `/update-pr` to regenerate._