### PR TITLE
mnemonic — key design decisions

### DIFF
--- a/.mnemonic/notes/mnemonic-key-design-decisions-3f2a6273.md
+++ b/.mnemonic/notes/mnemonic-key-design-decisions-3f2a6273.md
@@ -7,7 +7,7 @@ tags:
   - rationale
 lifecycle: permanent
 createdAt: '2026-03-07T17:59:12.124Z'
-updatedAt: '2026-03-14T22:14:51.593Z'
+updatedAt: '2026-03-22T11:50:37.396Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
@@ -30,6 +30,8 @@ relatedTo:
   - id: remember-tool-checkedforexisting-is-schema-only-agent-hint-w-a2c94093
     type: related-to
   - id: performance-principles-for-file-first-mcp-and-git-backed-wor-4e7d3bc8
+    type: related-to
+  - id: phase-1-provenance-confidence-implementation-design-c2084fd4
     type: related-to
 memoryVersion: 1
 ---

--- a/.mnemonic/notes/phase-1-provenance-confidence-implementation-design-c2084fd4.md
+++ b/.mnemonic/notes/phase-1-provenance-confidence-implementation-design-c2084fd4.md
@@ -1,0 +1,63 @@
+---
+title: Phase 1 Provenance + Confidence implementation design
+tags:
+  - architecture
+  - design-decisions
+  - provenance
+  - phase-1
+lifecycle: permanent
+createdAt: '2026-03-22T11:45:34.639Z'
+updatedAt: '2026-03-22T11:45:34.639Z'
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+# Phase 1 Provenance + Confidence Design Decision
+
+## What it does
+
+Extends recall and orientation outputs with git-backed provenance metadata and confidence signals.
+
+## Data Shapes
+
+```typescript
+type Provenance = {
+  lastUpdatedAt: string;
+  lastCommitHash: string;
+  lastCommitMessage: string;
+  recentlyChanged: boolean;  // daysSinceUpdate < 5
+};
+
+type Confidence = "high" | "medium" | "low";
+```
+
+## Confidence Heuristic
+
+```text
+if (lifecycle === "permanent" && centrality >= 5 && daysSinceUpdate < 30)
+  → "high"
+else if (daysSinceUpdate < 90)
+  → "medium"
+else
+  → "low"
+```
+
+## Implementation Locations
+
+1. **git.ts** - Added `getLastCommit(filePath)` and `getRecentCommits(filePath, limit)` read-only helpers
+2. **structured-content.ts** - Added `Provenance`, `Confidence` types; extended `RecallResult`, `RecallResultSchema`, `OrientationNote`, `OrientationNoteSchema`
+3. **index.ts** - Enrich recall results and orientation notes with provenance + confidence after scoring
+
+## Key Principles
+
+- Provenance is an **enrichment layer** - does NOT affect semantic scoring
+- Git calls are read-only and scoped to top-N results only
+- `recentlyChanged = daysSinceUpdate < 5` (5 days, not 3-7 - kept simple)
+- Must be robust to: missing git repo, detached HEAD, empty history
+
+## What NOT to do (Phase 1)
+
+- No full history exploration
+- No diff computation by default
+- No probabilistic/ML-based confidence
+- Keep it rule-based and predictable

--- a/.mnemonic/notes/phase-1-provenance-confidence-implementation-design-c2084fd4.md
+++ b/.mnemonic/notes/phase-1-provenance-confidence-implementation-design-c2084fd4.md
@@ -7,9 +7,12 @@ tags:
   - phase-1
 lifecycle: permanent
 createdAt: '2026-03-22T11:45:34.639Z'
-updatedAt: '2026-03-22T11:45:34.639Z'
+updatedAt: '2026-03-22T11:50:37.396Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: mnemonic-key-design-decisions-3f2a6273
+    type: related-to
 memoryVersion: 1
 ---
 # Phase 1 Provenance + Confidence Design Decision

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,16 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 - Notes tagged `anchor` or `alwaysLoad` are prioritized in anchor selection, capped at 10 total.
 - Orientation layer provides actionable guidance: `primaryEntry` (best first note to read with rationale), `suggestedNext` (2-3 follow-ups), and optional `warnings` for taxonomy dilution (>30% in "other" bucket).
 - Project summaries now stay project-scoped: themes, anchors, counts, and empty-project handling ignore unrelated global notes, while tagged anchors are ranked by score instead of alphabetically.
+- `recall` results now include optional `provenance` (git-backed last commit hash, message, timestamp, and `recentlyChanged` flag) and `confidence` (high/medium/low) metadata.
+- `orientation.primaryEntry` and `suggestedNext` entries now include `provenance` and `confidence` metadata.
+- `git.ts` exposes read-only `getLastCommit(filePath)` and `getRecentCommits(filePath, limit)` helpers.
 
 ### Changed
 
 - `ProjectSummaryResult.themes` changed from `Record<string, number>` to `Record<string, ThemeSection>` with `count` and `examples` fields — a breaking change for clients parsing structured content.
 - `ProjectSummaryResult` now includes required `orientation` field with `primaryEntry`, `suggestedNext`, and optional `warnings`.
+- `RecallResult.results` now includes optional `provenance` and `confidence` fields.
+- `OrientationNote` now includes optional `provenance` and `confidence` fields.
 
 ## [0.13.1] - 2026-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 - Project summaries now stay project-scoped: themes, anchors, counts, and empty-project handling ignore unrelated global notes, while tagged anchors are ranked by score instead of alphabetically.
 - `recall` results now include optional `provenance` (git-backed last commit hash, message, timestamp, and `recentlyChanged` flag) and `confidence` (high/medium/low) metadata.
 - `orientation.primaryEntry` and `suggestedNext` entries now include `provenance` and `confidence` metadata.
-- `git.ts` exposes read-only `getLastCommit(filePath)` and `getRecentCommits(filePath, limit)` helpers.
 
 ### Changed
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -20,6 +20,12 @@ export interface SyncGitError {
   conflictFiles?: string[];
 }
 
+export interface LastCommit {
+  hash: string;
+  message: string;
+  timestamp: string;
+}
+
 export interface SyncResult {
   hasRemote: boolean;
   /** Note ids that arrived or changed during pull (need re-embedding) */
@@ -315,6 +321,44 @@ export class GitOps {
       const message = err instanceof Error ? err.message : String(err);
       console.error(`[git] Push failed: ${message}`);
       return { status: "failed", error: message };
+    }
+  }
+
+  /**
+   * Get the last commit that touched a specific file.
+   * Returns null when the file has no git history or the repo is unavailable.
+   */
+  async getLastCommit(filePath: string): Promise<LastCommit | null> {
+    if (!this.enabled) return null;
+    try {
+      const log = await this.git.log({ maxCount: 1, file: filePath });
+      const entry = log.latest;
+      if (!entry) return null;
+      return {
+        hash: entry.hash,
+        message: entry.message,
+        timestamp: entry.date,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Get the most recent commits that touched a specific file.
+   * Returns empty array when the file has no git history or the repo is unavailable.
+   */
+  async getRecentCommits(filePath: string, limit: number = 5): Promise<LastCommit[]> {
+    if (!this.enabled) return [];
+    try {
+      const log = await this.git.log({ maxCount: limit, file: filePath });
+      return log.all.map(entry => ({
+        hash: entry.hash,
+        message: entry.message,
+        timestamp: entry.date,
+      }));
+    } catch {
+      return [];
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { promises as fs } from "fs";
 import { NOTE_LIFECYCLES, Storage, type Note, type NoteLifecycle, type Relationship, type RelationshipType } from "./storage.js";
 import { embed, cosineSimilarity, embedModel } from "./embeddings.js";
 import { type CommitResult, type PushResult, type SyncResult } from "./git.js";
+import { getNoteProvenance, computeConfidence } from "./provenance.js";
 
 import {
   filterRelationships,
@@ -2143,11 +2144,22 @@ server.registerTool(
       tags: string[];
       lifecycle: NoteLifecycle;
       updatedAt: string;
+      provenance?: {
+        lastUpdatedAt: string;
+        lastCommitHash: string;
+        lastCommitMessage: string;
+        recentlyChanged: boolean;
+      };
+      confidence?: "high" | "medium" | "low";
     }> = [];
     for (const { id, score, vault, boosted } of top) {
       const note = await readCachedNote(vault, id);
       if (note) {
         sections.push(formatNote(note, score));
+        const centrality = note.relatedTo?.length ?? 0;
+        const filePath = `${vault.notesRelDir}/${id}.md`;
+        const provenance = await getNoteProvenance(vault.git, filePath, note.updatedAt);
+        const confidence = computeConfidence(note.lifecycle, note.updatedAt, centrality);
         structuredResults.push({
           id,
           title: note.title,
@@ -2159,6 +2171,8 @@ server.registerTool(
           tags: note.tags,
           lifecycle: note.lifecycle,
           updatedAt: note.updatedAt,
+          provenance,
+          confidence,
         });
       }
     }
@@ -3278,12 +3292,46 @@ server.registerTool(
 
     // Compute orientation layer for actionable guidance
     const primaryAnchor = anchors[0];
+
+    // Build noteId -> vault lookup for provenance enrichment
+    const noteVaultMap = new Map<string, Vault>();
+    for (const entry of projectEntries) {
+      noteVaultMap.set(entry.note.id, entry.vault);
+    }
+
+    // Helper to enrich an anchor with provenance and confidence
+    const enrichOrientationNote = async (anchor: AnchorNote) => {
+      const vault = noteVaultMap.get(anchor.id);
+      if (!vault) return {};
+      const filePath = `${vault.notesRelDir}/${anchor.id}.md`;
+      const provenance = await getNoteProvenance(vault.git, filePath, anchor.updatedAt);
+      const confidence = computeConfidence("permanent", anchor.updatedAt, anchor.centrality);
+      return { provenance, confidence };
+    };
+
+    const primaryEnriched = primaryAnchor ? await enrichOrientationNote(primaryAnchor) : {};
+    const suggestedEnriched = await Promise.all(anchors.slice(1, 4).map(enrichOrientationNote));
+
+    // Enrich fallback primaryEntry when no anchors exist
+    let fallbackEnriched: { provenance?: { lastUpdatedAt: string; lastCommitHash: string; lastCommitMessage: string; recentlyChanged: boolean }; confidence?: "high" | "medium" | "low" } = {};
+    if (!primaryAnchor && recent[0]) {
+      const fallbackNote = recent[0].note;
+      const vault = noteVaultMap.get(fallbackNote.id);
+      if (vault) {
+        const filePath = `${vault.notesRelDir}/${fallbackNote.id}.md`;
+        const provenance = await getNoteProvenance(vault.git, filePath, fallbackNote.updatedAt);
+        const confidence = computeConfidence(fallbackNote.lifecycle, fallbackNote.updatedAt, 0);
+        fallbackEnriched = { provenance, confidence };
+      }
+    }
+
     const orientation: ProjectSummaryResult["orientation"] = {
       primaryEntry: primaryAnchor
         ? {
             id: primaryAnchor.id,
             title: primaryAnchor.title,
             rationale: `Centrality ${primaryAnchor.centrality}, connects ${primaryAnchor.connectionDiversity} themes`,
+            ...primaryEnriched,
           }
         : {
             id: recent[0]?.note.id ?? projectEntries[0]?.note.id ?? "",
@@ -3291,11 +3339,13 @@ server.registerTool(
             rationale: recent[0]
               ? "Most recent note — no high-centrality anchors found"
               : "Only note available",
+            ...fallbackEnriched,
           },
-      suggestedNext: anchors.slice(1, 4).map(a => ({
+      suggestedNext: anchors.slice(1, 4).map((a, i) => ({
         id: a.id,
         title: a.title,
         rationale: `Centrality ${a.centrality}, connects ${a.connectionDiversity} themes`,
+        ...suggestedEnriched[i],
       })),
     };
 
@@ -3313,10 +3363,13 @@ server.registerTool(
     sections.push(`\nOrientation:`);
     sections.push(`Start with: ${orientation.primaryEntry.title} (\`${orientation.primaryEntry.id}\`)`);
     sections.push(`  Rationale: ${orientation.primaryEntry.rationale}`);
+    if (orientation.primaryEntry.confidence) {
+      sections.push(`  Confidence: ${orientation.primaryEntry.confidence}`);
+    }
     if (orientation.suggestedNext.length > 0) {
       sections.push(`Then check:`);
       for (const next of orientation.suggestedNext) {
-        sections.push(`  - ${next.title} (\`${next.id}\`) — ${next.rationale}`);
+        sections.push(`  - ${next.title} (\`${next.id}\`) — ${next.rationale}${next.confidence ? ` [${next.confidence}]` : ""}`);
       }
     }
     if (orientation.warnings && orientation.warnings.length > 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2158,7 +2158,7 @@ server.registerTool(
         sections.push(formatNote(note, score));
         const centrality = note.relatedTo?.length ?? 0;
         const filePath = `${vault.notesRelDir}/${id}.md`;
-        const provenance = await getNoteProvenance(vault.git, filePath, note.updatedAt);
+        const provenance = await getNoteProvenance(vault.git, filePath);
         const confidence = computeConfidence(note.lifecycle, note.updatedAt, centrality);
         structuredResults.push({
           id,
@@ -3304,7 +3304,7 @@ server.registerTool(
       const vault = noteVaultMap.get(anchor.id);
       if (!vault) return {};
       const filePath = `${vault.notesRelDir}/${anchor.id}.md`;
-      const provenance = await getNoteProvenance(vault.git, filePath, anchor.updatedAt);
+      const provenance = await getNoteProvenance(vault.git, filePath);
       const confidence = computeConfidence("permanent", anchor.updatedAt, anchor.centrality);
       return { provenance, confidence };
     };
@@ -3319,7 +3319,7 @@ server.registerTool(
       const vault = noteVaultMap.get(fallbackNote.id);
       if (vault) {
         const filePath = `${vault.notesRelDir}/${fallbackNote.id}.md`;
-        const provenance = await getNoteProvenance(vault.git, filePath, fallbackNote.updatedAt);
+        const provenance = await getNoteProvenance(vault.git, filePath);
         const confidence = computeConfidence(fallbackNote.lifecycle, fallbackNote.updatedAt, 0);
         fallbackEnriched = { provenance, confidence };
       }

--- a/src/provenance.ts
+++ b/src/provenance.ts
@@ -1,5 +1,5 @@
 import type { GitOps } from "./git.js";
-import type { Note, NoteLifecycle } from "./storage.js";
+import type { NoteLifecycle } from "./storage.js";
 import type { Confidence, Provenance } from "./structured-content.js";
 
 const RECENTLY_CHANGED_DAYS = 5;
@@ -9,8 +9,7 @@ const HIGH_CONFIDENCE_CENTRALITY = 5;
 
 export async function getNoteProvenance(
   git: GitOps,
-  filePath: string,
-  updatedAt: string
+  filePath: string
 ): Promise<Provenance | undefined> {
   const commit = await git.getLastCommit(filePath);
   if (!commit) return undefined;

--- a/src/provenance.ts
+++ b/src/provenance.ts
@@ -1,0 +1,48 @@
+import type { GitOps } from "./git.js";
+import type { Note, NoteLifecycle } from "./storage.js";
+import type { Confidence, Provenance } from "./structured-content.js";
+
+const RECENTLY_CHANGED_DAYS = 5;
+const HIGH_CONFIDENCE_DAYS = 30;
+const MEDIUM_CONFIDENCE_DAYS = 90;
+const HIGH_CONFIDENCE_CENTRALITY = 5;
+
+export async function getNoteProvenance(
+  git: GitOps,
+  filePath: string,
+  updatedAt: string
+): Promise<Provenance | undefined> {
+  const commit = await git.getLastCommit(filePath);
+  if (!commit) return undefined;
+
+  const commitDate = new Date(commit.timestamp);
+  const now = new Date();
+  const daysSinceUpdate = Math.floor((now.getTime() - commitDate.getTime()) / (1000 * 60 * 60 * 24));
+
+  return {
+    lastUpdatedAt: commit.timestamp,
+    lastCommitHash: commit.hash,
+    lastCommitMessage: commit.message,
+    recentlyChanged: daysSinceUpdate < RECENTLY_CHANGED_DAYS,
+  };
+}
+
+export function computeConfidence(
+  lifecycle: NoteLifecycle,
+  updatedAt: string,
+  centrality: number
+): Confidence {
+  const now = new Date();
+  const updatedDate = new Date(updatedAt);
+  const daysSinceUpdate = Math.floor((now.getTime() - updatedDate.getTime()) / (1000 * 60 * 60 * 24));
+
+  if (lifecycle === "permanent" && centrality >= HIGH_CONFIDENCE_CENTRALITY && daysSinceUpdate < HIGH_CONFIDENCE_DAYS) {
+    return "high";
+  }
+
+  if (daysSinceUpdate < MEDIUM_CONFIDENCE_DAYS) {
+    return "medium";
+  }
+
+  return "low";
+}

--- a/src/structured-content.ts
+++ b/src/structured-content.ts
@@ -79,6 +79,8 @@ export interface RecallResult extends Record<string, unknown> {
     tags: string[];
     lifecycle: NoteLifecycle;
     updatedAt: string;
+    provenance?: Provenance;
+    confidence?: Confidence;
   }>;
 }
 
@@ -339,7 +341,18 @@ export interface OrientationNote {
   id: string;
   title: string;
   rationale: string;
+  provenance?: Provenance;
+  confidence?: Confidence;
 }
+
+export interface Provenance {
+  lastUpdatedAt: string;
+  lastCommitHash: string;
+  lastCommitMessage: string;
+  recentlyChanged: boolean;
+}
+
+export type Confidence = "high" | "medium" | "low";
 
 export interface Orientation {
   primaryEntry: OrientationNote;
@@ -444,6 +457,13 @@ export const RecallResultSchema = z.object({
     tags: z.array(z.string()),
     lifecycle: _NoteLifecycle,
     updatedAt: z.string(),
+    provenance: z.object({
+      lastUpdatedAt: z.string(),
+      lastCommitHash: z.string(),
+      lastCommitMessage: z.string(),
+      recentlyChanged: z.boolean(),
+    }).optional(),
+    confidence: z.enum(["high", "medium", "low"]).optional(),
   })),
 });
 
@@ -590,6 +610,13 @@ export const OrientationNoteSchema = z.object({
   id: z.string(),
   title: z.string(),
   rationale: z.string(),
+  provenance: z.object({
+    lastUpdatedAt: z.string(),
+    lastCommitHash: z.string(),
+    lastCommitMessage: z.string(),
+    recentlyChanged: z.boolean(),
+  }).optional(),
+  confidence: z.enum(["high", "medium", "low"]).optional(),
 });
 
 export const OrientationSchema = z.object({

--- a/tests/git.unit.test.ts
+++ b/tests/git.unit.test.ts
@@ -436,4 +436,130 @@ describe("GitOps", () => {
       expect(result.modified).toEqual([]);
     });
   });
+
+  describe("getLastCommit", () => {
+    it("returns last commit for a file", async () => {
+      const { GitOps } = await import("../src/git.js");
+      const git = new GitOps("/tmp/repo");
+      await git.init();
+
+      log.mockResolvedValueOnce({
+        latest: {
+          hash: "abc123",
+          message: "feat: add test note",
+          date: "2026-03-20T10:00:00Z",
+        },
+      });
+
+      const result = await git.getLastCommit("notes/test.md");
+
+      expect(result).toEqual({
+        hash: "abc123",
+        message: "feat: add test note",
+        timestamp: "2026-03-20T10:00:00Z",
+      });
+      expect(log).toHaveBeenCalledWith({ maxCount: 1, file: "notes/test.md" });
+    });
+
+    it("returns null when file has no git history", async () => {
+      const { GitOps } = await import("../src/git.js");
+      const git = new GitOps("/tmp/repo");
+      await git.init();
+
+      log.mockResolvedValueOnce({ latest: null });
+
+      const result = await git.getLastCommit("notes/new-file.md");
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null when git throws", async () => {
+      const { GitOps } = await import("../src/git.js");
+      const git = new GitOps("/tmp/repo");
+      await git.init();
+
+      log.mockRejectedValueOnce(new Error("not a git repository"));
+
+      const result = await git.getLastCommit("notes/test.md");
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null when git is disabled", async () => {
+      process.env.DISABLE_GIT = "true";
+      vi.resetModules();
+
+      const { GitOps } = await import("../src/git.js");
+      const git = new GitOps("/tmp/repo");
+      await git.init();
+
+      const result = await git.getLastCommit("notes/test.md");
+
+      expect(result).toBeNull();
+
+      delete process.env.DISABLE_GIT;
+    });
+  });
+
+  describe("getRecentCommits", () => {
+    it("returns recent commits for a file", async () => {
+      const { GitOps } = await import("../src/git.js");
+      const git = new GitOps("/tmp/repo");
+      await git.init();
+
+      log.mockResolvedValueOnce({
+        all: [
+          { hash: "abc123", message: "feat: latest", date: "2026-03-20T10:00:00Z" },
+          { hash: "def456", message: "fix: previous", date: "2026-03-19T10:00:00Z" },
+        ],
+      });
+
+      const result = await git.getRecentCommits("notes/test.md", 2);
+
+      expect(result).toEqual([
+        { hash: "abc123", message: "feat: latest", timestamp: "2026-03-20T10:00:00Z" },
+        { hash: "def456", message: "fix: previous", timestamp: "2026-03-19T10:00:00Z" },
+      ]);
+      expect(log).toHaveBeenCalledWith({ maxCount: 2, file: "notes/test.md" });
+    });
+
+    it("returns empty array when file has no git history", async () => {
+      const { GitOps } = await import("../src/git.js");
+      const git = new GitOps("/tmp/repo");
+      await git.init();
+
+      log.mockResolvedValueOnce({ all: [] });
+
+      const result = await git.getRecentCommits("notes/new-file.md");
+
+      expect(result).toEqual([]);
+    });
+
+    it("returns empty array when git throws", async () => {
+      const { GitOps } = await import("../src/git.js");
+      const git = new GitOps("/tmp/repo");
+      await git.init();
+
+      log.mockRejectedValueOnce(new Error("not a git repository"));
+
+      const result = await git.getRecentCommits("notes/test.md");
+
+      expect(result).toEqual([]);
+    });
+
+    it("returns empty array when git is disabled", async () => {
+      process.env.DISABLE_GIT = "true";
+      vi.resetModules();
+
+      const { GitOps } = await import("../src/git.js");
+      const git = new GitOps("/tmp/repo");
+      await git.init();
+
+      const result = await git.getRecentCommits("notes/test.md");
+
+      expect(result).toEqual([]);
+
+      delete process.env.DISABLE_GIT;
+    });
+  });
 });

--- a/tests/mcp.integration.test.ts
+++ b/tests/mcp.integration.test.ts
@@ -13,6 +13,9 @@ import {
   MemoryGraphResultSchema,
   MigrationExecuteResultSchema,
   MigrationListResultSchema,
+  OrientationNoteSchema,
+  ProjectSummaryResultSchema,
+  RecallResultSchema,
   SyncResultSchema,
 } from "../src/structured-content.js";
 
@@ -1085,7 +1088,7 @@ describe("local MCP script", () => {
 
       const summary = await callLocalMcpResponse(vaultDir, "project_memory_summary", {
         cwd: repoDir,
-      }, embeddingServer.url);
+      }, { ollamaUrl: embeddingServer.url, disableGit: false });
 
       const anchors = summary.structuredContent?.["anchors"] as Array<Record<string, unknown>>;
       expect(anchors).toEqual([]);
@@ -1095,6 +1098,8 @@ describe("local MCP script", () => {
       expect(primaryEntry?.["id"]).toBe(recentId);
       expect(primaryEntry?.["title"]).toBe("Most recent project note");
       expect(primaryEntry?.["rationale"]).toBe("Most recent note — no high-centrality anchors found");
+      // provenance is undefined when git is disabled or note has no commits; with git enabled it should be populated
+      expect(primaryEntry).toHaveProperty("confidence");
       expect(orientation?.["suggestedNext"]).toEqual([]);
     } finally {
       await embeddingServer.close();
@@ -2506,6 +2511,75 @@ describe("local MCP script", () => {
       await embeddingServer.close();
     }
   }, 15000);
+
+  describe("schema-audit", () => {
+    it("RecallResultSchema accepts provenance and confidence fields in results", async () => {
+      const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mcp-vault-"));
+      tempDirs.push(vaultDir);
+      const embeddingServer = await startFakeEmbeddingServer();
+
+      try {
+        await callLocalMcp(vaultDir, "remember", {
+          title: "Schema audit recall test",
+          content: "Testing provenance and confidence in recall results.",
+          tags: ["audit"],
+          lifecycle: "permanent",
+          scope: "global",
+          summary: "Seed note for recall schema audit",
+        }, embeddingServer.url);
+
+        const response = await callLocalMcpResponse(vaultDir, "recall", {
+          query: "schema audit recall test",
+        }, embeddingServer.url);
+
+        expect(() => RecallResultSchema.parse(response.structuredContent)).not.toThrow();
+        const parsed = RecallResultSchema.parse(response.structuredContent);
+        expect(parsed.action).toBe("recalled");
+        expect(parsed.results).toHaveLength(1);
+        // provenance and confidence are optional but should be accepted if present
+        expect(parsed.results[0]).toHaveProperty("id");
+        expect(parsed.results[0]).toHaveProperty("title");
+      } finally {
+        await embeddingServer.close();
+      }
+    }, 15000);
+
+    it("OrientationNoteSchema accepts provenance and confidence optional fields", async () => {
+      const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mcp-vault-"));
+      const repoDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mcp-project-"));
+      tempDirs.push(vaultDir, repoDir);
+
+      await initTestRepo(repoDir);
+      const embeddingServer = await startFakeEmbeddingServer();
+
+      try {
+        await callLocalMcp(vaultDir, "remember", {
+          title: "Schema audit orientation test",
+          content: "Testing provenance and confidence in orientation.",
+          tags: ["audit", "orientation"],
+          lifecycle: "permanent",
+          scope: "project",
+          summary: "Seed note for orientation schema audit",
+          cwd: repoDir,
+        }, embeddingServer.url);
+
+        const summary = await callLocalMcpResponse(vaultDir, "project_memory_summary", {
+          cwd: repoDir,
+        }, embeddingServer.url);
+
+        expect(() => ProjectSummaryResultSchema.parse(summary.structuredContent)).not.toThrow();
+        const parsed = ProjectSummaryResultSchema.parse(summary.structuredContent);
+        expect(parsed.action).toBe("project_summary_shown");
+        expect(parsed.orientation).toBeDefined();
+        expect(parsed.orientation.primaryEntry).toBeDefined();
+        expect(parsed.orientation.primaryEntry).toHaveProperty("id");
+        expect(parsed.orientation.primaryEntry).toHaveProperty("title");
+        expect(parsed.orientation.primaryEntry).toHaveProperty("rationale");
+      } finally {
+        await embeddingServer.close();
+      }
+    }, 15000);
+  });
 });
 
 async function callLocalMcp(

--- a/tests/provenance.unit.test.ts
+++ b/tests/provenance.unit.test.ts
@@ -43,7 +43,7 @@ describe("getNoteProvenance", () => {
       timestamp: "2026-03-20T10:00:00Z",
     });
 
-    const result = await getNoteProvenance(mockGit, "notes/test.md", "2026-03-20T12:00:00Z");
+    const result = await getNoteProvenance(mockGit, "notes/test.md");
 
     expect(result).toEqual({
       lastUpdatedAt: "2026-03-20T10:00:00Z",
@@ -57,7 +57,7 @@ describe("getNoteProvenance", () => {
   it("returns undefined when git has no commit for the file", async () => {
     mockGit.getLastCommit.mockResolvedValueOnce(null);
 
-    const result = await getNoteProvenance(mockGit, "notes/new.md", "2026-03-20T12:00:00Z");
+    const result = await getNoteProvenance(mockGit, "notes/new.md");
 
     expect(result).toBeUndefined();
   });
@@ -70,9 +70,7 @@ describe("getNoteProvenance", () => {
       timestamp: oldCommit.toISOString(),
     });
 
-    // Pass recent updatedAt to prove recentlyChanged depends on commit date, not updatedAt
-    const recentUpdatedAt = new Date().toISOString();
-    const result = await getNoteProvenance(mockGit, "notes/old.md", recentUpdatedAt);
+    const result = await getNoteProvenance(mockGit, "notes/old.md");
 
     expect(result?.recentlyChanged).toBe(false);
   });
@@ -85,9 +83,7 @@ describe("getNoteProvenance", () => {
       timestamp: recentCommit.toISOString(),
     });
 
-    // Pass old updatedAt to prove recentlyChanged depends on commit date, not updatedAt
-    const oldUpdatedAt = new Date(Date.now() - 100 * 24 * 60 * 60 * 1000).toISOString();
-    const result = await getNoteProvenance(mockGit, "notes/recent.md", oldUpdatedAt);
+    const result = await getNoteProvenance(mockGit, "notes/recent.md");
 
     expect(result?.recentlyChanged).toBe(true);
   });

--- a/tests/provenance.unit.test.ts
+++ b/tests/provenance.unit.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import { computeConfidence, getNoteProvenance } from "../src/provenance.js";
+
+const mockGit = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getLastCommit: vi.fn() as any,
+} as any;
+
+describe("computeConfidence", () => {
+  it("returns high when lifecycle is permanent, centrality >= 5, and updated within 30 days", () => {
+    const recent = new Date();
+    const updatedAt = recent.toISOString();
+    expect(computeConfidence("permanent", updatedAt, 5)).toBe("high");
+    expect(computeConfidence("permanent", updatedAt, 10)).toBe("high");
+  });
+
+  it("returns medium when updated within 90 days but not meeting high criteria", () => {
+    const recent = new Date();
+    const updatedAt = recent.toISOString();
+    expect(computeConfidence("permanent", updatedAt, 4)).toBe("medium");
+    expect(computeConfidence("temporary", updatedAt, 10)).toBe("medium");
+  });
+
+  it("returns medium when permanent, centrality >= 5, but updated more than 30 days ago", () => {
+    const oldDate = new Date(Date.now() - 45 * 24 * 60 * 60 * 1000);
+    const updatedAt = oldDate.toISOString();
+    expect(computeConfidence("permanent", updatedAt, 5)).toBe("medium");
+  });
+
+  it("returns low when updated more than 90 days ago", () => {
+    const oldDate = new Date(Date.now() - 100 * 24 * 60 * 60 * 1000);
+    const updatedAt = oldDate.toISOString();
+    expect(computeConfidence("permanent", updatedAt, 10)).toBe("low");
+    expect(computeConfidence("temporary", updatedAt, 0)).toBe("low");
+  });
+});
+
+describe("getNoteProvenance", () => {
+  it("returns provenance when git has a commit for the file", async () => {
+    mockGit.getLastCommit.mockResolvedValueOnce({
+      hash: "abc123",
+      message: "feat: add test note",
+      timestamp: "2026-03-20T10:00:00Z",
+    });
+
+    const result = await getNoteProvenance(mockGit, "notes/test.md", "2026-03-20T12:00:00Z");
+
+    expect(result).toEqual({
+      lastUpdatedAt: "2026-03-20T10:00:00Z",
+      lastCommitHash: "abc123",
+      lastCommitMessage: "feat: add test note",
+      recentlyChanged: true,
+    });
+    expect(mockGit.getLastCommit).toHaveBeenCalledWith("notes/test.md");
+  });
+
+  it("returns undefined when git has no commit for the file", async () => {
+    mockGit.getLastCommit.mockResolvedValueOnce(null);
+
+    const result = await getNoteProvenance(mockGit, "notes/new.md", "2026-03-20T12:00:00Z");
+
+    expect(result).toBeUndefined();
+  });
+
+  it("marks recentlyChanged=false when commit is older than 5 days", async () => {
+    const oldCommit = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
+    mockGit.getLastCommit.mockResolvedValueOnce({
+      hash: "def456",
+      message: "old commit",
+      timestamp: oldCommit.toISOString(),
+    });
+
+    // Pass recent updatedAt to prove recentlyChanged depends on commit date, not updatedAt
+    const recentUpdatedAt = new Date().toISOString();
+    const result = await getNoteProvenance(mockGit, "notes/old.md", recentUpdatedAt);
+
+    expect(result?.recentlyChanged).toBe(false);
+  });
+
+  it("marks recentlyChanged=true when commit is within 5 days", async () => {
+    const recentCommit = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+    mockGit.getLastCommit.mockResolvedValueOnce({
+      hash: "ghi789",
+      message: "recent commit",
+      timestamp: recentCommit.toISOString(),
+    });
+
+    // Pass old updatedAt to prove recentlyChanged depends on commit date, not updatedAt
+    const oldUpdatedAt = new Date(Date.now() - 100 * 24 * 60 * 60 * 1000).toISOString();
+    const result = await getNoteProvenance(mockGit, "notes/recent.md", oldUpdatedAt);
+
+    expect(result?.recentlyChanged).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

This PR captures the following design decisions:

- **mnemonic — key design decisions**
- **Phase 1 Provenance + Confidence implementation design**

## Design Decisions

### mnemonic — key design decisions

**Tags:** design, decisions, architecture, rationale

**One file per note:** Critical for git conflict isolation. Never aggregate notes into a single file.

**Embeddings gitignored:** Derived data, always recomputable. Committing them causes unresolvable merge conflicts (can't merge float arrays). `sync` now backfills missing local embeddings for each synced vault, even when no notes were newly pulled, so fresh clones heal automatically once Ollama is available.

**Rebase on pull:** `git pull --rebase` keeps history linear. Don't switch to merge.

**Project ID from git remote URL, not local path:** `project.ts` normalizes remote URLs to stable slugs (e.g. `github-com-acme-myapp`). This makes cross-machine consistency work — local paths differ, remote URLs don't.

**Similarity boost, not hard filter:** `recall` gives project notes +0.15 cosine similarity boost rather than excluding global notes. Global memories (user prefs, cross-project patterns) remain accessible in project context.

**No auto-relationship via LLM:** Decided against using a local Qwen model to auto-build relationships. Small models lack session context, produce spurious edges, and corrupt the graph silently. Instead: agent instructions prompt `relate` immediately after `remember` while session context is warm.

**Metadata-only changes don't re-embed:** Lifecycle migrations and other metadata-only edits do not recompute embeddings. Embeddings refresh when note title/content changes, during sync backfill, or via explicit `reindex`.

### Phase 1 Provenance + Confidence implementation design

**Tags:** architecture, design-decisions, provenance, phase-1

# Phase 1 Provenance + Confidence Design Decision

## What it does

Extends recall and orientation outputs with git-backed provenance metadata and confidence signals.

## Data Shapes

```typescript
type Provenance = {
  lastUpdatedAt: string;
  lastCommitHash: string;
  lastCommitMessage: string;
  recentlyChanged: boolean;  // daysSinceUpdate < 5
};

type Confidence = "high" | "medium" | "low";
```

## Confidence Heuristic

```text
if (lifecycle === "permanent" && centrality >= 5 && daysSinceUpdate < 30)
  → "high"
else if (daysSinceUpdate < 90)
  → "medium"
else
  → "low"
```

## Implementation Locations

1. **git.ts** - Added `getLastCommit(filePath)` and `getRecentCommits(filePath, limit)` read-only helpers
2. **structured-content.ts** - Added `Provenance`, `Confidence` types; extended `RecallResult`, `RecallResultSchema`, `OrientationNote`, `OrientationNoteSchema`
3. **index.ts** - Enrich recall results and orientation notes with provenance + confidence after scoring

## Key Principles

- Provenance is an **enrichment layer** - does NOT affect semantic scoring
- Git calls are read-only and scoped to top-N results only
- `recentlyChanged = daysSinceUpdate < 5` (5 days, not 3-7 - kept simple)
- Must be robust to: missing git repo, detached HEAD, empty history

## What NOT to do (Phase 1)

- No full history exploration
- No diff computation by default
- No probabilistic/ML-based confidence
- Keep it rule-based and predictable

---

_Generated from 2 design decision note(s) in `.mnemonic/notes/`. Run `/update-pr` to regenerate._