### PR TITLE
Temporal recall mode design for Phase 2 on-demand history exploration

### DIFF
--- a/.mnemonic/notes/mnemonic-key-design-decisions-3f2a6273.md
+++ b/.mnemonic/notes/mnemonic-key-design-decisions-3f2a6273.md
@@ -7,7 +7,7 @@ tags:
   - rationale
 lifecycle: permanent
 createdAt: '2026-03-07T17:59:12.124Z'
-updatedAt: '2026-03-22T11:50:37.396Z'
+updatedAt: '2026-03-22T12:42:24.211Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
@@ -32,6 +32,8 @@ relatedTo:
   - id: performance-principles-for-file-first-mcp-and-git-backed-wor-4e7d3bc8
     type: related-to
   - id: phase-1-provenance-confidence-implementation-design-c2084fd4
+    type: related-to
+  - id: temporal-recall-mode-design-for-phase-2-on-demand-history-ex-f8ee504f
     type: related-to
 memoryVersion: 1
 ---

--- a/.mnemonic/notes/mnemonic-key-design-decisions-3f2a6273.md
+++ b/.mnemonic/notes/mnemonic-key-design-decisions-3f2a6273.md
@@ -7,7 +7,7 @@ tags:
   - rationale
 lifecycle: permanent
 createdAt: '2026-03-07T17:59:12.124Z'
-updatedAt: '2026-03-22T12:42:24.211Z'
+updatedAt: '2026-03-22T13:00:19.132Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
@@ -46,6 +46,8 @@ memoryVersion: 1
 **Project ID from git remote URL, not local path:** `project.ts` normalizes remote URLs to stable slugs (e.g. `github-com-acme-myapp`). This makes cross-machine consistency work — local paths differ, remote URLs don't.
 
 **Similarity boost, not hard filter:** `recall` gives project notes +0.15 cosine similarity boost rather than excluding global notes. Global memories (user prefs, cross-project patterns) remain accessible in project context.
+
+**Temporal recall is semantic-first and opt-in:** `recall` supports `mode: "temporal"` for on-demand history exploration, but only after normal semantic selection. Default recall behavior and latency expectations stay unchanged. Temporal enrichment is bounded to top matches and compact commit summaries; `verbose: true` adds richer stats-based context, not raw diffs.
 
 **No auto-relationship via LLM:** Decided against using a local Qwen model to auto-build relationships. Small models lack session context, produce spurious edges, and corrupt the graph silently. Instead: agent instructions prompt `relate` immediately after `remember` while session context is warm.
 

--- a/.mnemonic/notes/phase-1-provenance-confidence-implementation-design-c2084fd4.md
+++ b/.mnemonic/notes/phase-1-provenance-confidence-implementation-design-c2084fd4.md
@@ -7,11 +7,13 @@ tags:
   - phase-1
 lifecycle: permanent
 createdAt: '2026-03-22T11:45:34.639Z'
-updatedAt: '2026-03-22T11:50:37.396Z'
+updatedAt: '2026-03-22T12:42:24.212Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
   - id: mnemonic-key-design-decisions-3f2a6273
+    type: related-to
+  - id: temporal-recall-mode-design-for-phase-2-on-demand-history-ex-f8ee504f
     type: related-to
 memoryVersion: 1
 ---

--- a/.mnemonic/notes/temporal-recall-mode-design-for-phase-2-on-demand-history-ex-f8ee504f.md
+++ b/.mnemonic/notes/temporal-recall-mode-design-for-phase-2-on-demand-history-ex-f8ee504f.md
@@ -9,11 +9,13 @@ tags:
   - architecture
 lifecycle: permanent
 createdAt: '2026-03-22T12:42:10.838Z'
-updatedAt: '2026-03-22T12:42:24.212Z'
+updatedAt: '2026-03-22T12:42:49.200Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
   - id: phase-1-provenance-confidence-implementation-design-c2084fd4
+    type: related-to
+  - id: mnemonic-key-design-decisions-3f2a6273
     type: related-to
 memoryVersion: 1
 ---

--- a/.mnemonic/notes/temporal-recall-mode-design-for-phase-2-on-demand-history-ex-f8ee504f.md
+++ b/.mnemonic/notes/temporal-recall-mode-design-for-phase-2-on-demand-history-ex-f8ee504f.md
@@ -9,9 +9,12 @@ tags:
   - architecture
 lifecycle: permanent
 createdAt: '2026-03-22T12:42:10.838Z'
-updatedAt: '2026-03-22T12:42:10.838Z'
+updatedAt: '2026-03-22T12:42:24.212Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: phase-1-provenance-confidence-implementation-design-c2084fd4
+    type: related-to
 memoryVersion: 1
 ---
 Phase 2 adds an opt-in temporal recall mode for on-demand history exploration without changing default recall behavior.

--- a/.mnemonic/notes/temporal-recall-mode-design-for-phase-2-on-demand-history-ex-f8ee504f.md
+++ b/.mnemonic/notes/temporal-recall-mode-design-for-phase-2-on-demand-history-ex-f8ee504f.md
@@ -1,0 +1,106 @@
+---
+title: Temporal recall mode design for Phase 2 on-demand history exploration
+tags:
+  - design
+  - recall
+  - temporal
+  - git
+  - decision
+  - architecture
+lifecycle: permanent
+createdAt: '2026-03-22T12:42:10.838Z'
+updatedAt: '2026-03-22T12:42:10.838Z'
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+Phase 2 adds an opt-in temporal recall mode for on-demand history exploration without changing default recall behavior.
+
+Core decision:
+
+- Extend `recall` with `mode: "temporal"`.
+- Default recall remains unchanged in behavior, ranking, and latency expectations.
+- Temporal mode is explicit only; do not auto-trigger it from the query yet.
+
+Retrieval pipeline:
+
+1. Run normal semantic recall first, including existing project bias.
+2. Only after semantic selection, fetch git history for the top N matching notes.
+3. Enrich results with a separate `history` field while preserving existing `score`, `provenance`, and `confidence` fields.
+
+History shape:
+
+```ts
+{
+  note: { ...existing fields },
+  provenance: { ...existing Phase 1 fields },
+  history: [
+    {
+      commitHash: string,
+      timestamp: string,
+      message: string,
+      summary?: string
+    }
+  ]
+}
+```
+
+Git design constraints:
+
+- Git is a read-only history source.
+- Add helpers in `git.ts`:
+  - `getFileHistory(filePath: string, limit: number): Commit[]`
+  - `getCommitStats(filePath: string, commitHash: string): { additions: number; deletions: number; filesChanged: number; }`
+- Handle missing repo, missing file history, and command failures gracefully.
+- Avoid locale-dependent parsing.
+- Fail soft and return empty or minimal history data instead of failing recall.
+
+History summarization design:
+
+- Default temporal output must be compact and RTK-inspired rather than raw diffs.
+- Each history item should always include `commitHash`, `timestamp`, and `message`.
+- Add optional compact summaries derived from diff stat style data, such as:
+  - `+42/-10 lines`
+  - `3 files changed`
+  - `minor edit`
+  - `substantial update`
+  - `metadata-only change`
+- Never return large raw diffs from normal temporal recall.
+- If summarization fails, still return usable history entries with hash, timestamp, and message.
+
+Verbose escape hatch:
+
+- Support `verbose: true` only together with `mode: "temporal"`.
+- Verbose mode may include slightly richer summaries such as expanded stats or the first diff hunk.
+- Even in verbose mode, avoid full diffs by default.
+- Primary purpose is debugging and advanced inspection.
+
+Performance constraints:
+
+- Temporal mode must remain bounded.
+- Only inspect history for top N notes, roughly 3-5 notes.
+- Only fetch a small number of commits per note, roughly 3-5 commits.
+- Avoid repo-wide scans.
+- Cache repeated git lookups within a single request if useful.
+- No impact on default semantic recall latency when temporal mode is not used.
+
+Non-goals for Phase 2:
+
+- No repo-wide timelines.
+- No cross-note history stitching.
+- No heavy diff output.
+- No replacement of semantic recall with git traversal.
+- No RTK-style command proxying or interception.
+
+Intended user value:
+Temporal recall should help agents answer questions such as:
+
+- What changed recently?
+- How did this evolve?
+- Why is this note like this?
+
+Future extensions explicitly deferred:
+
+- Semantic change summaries such as shifts from one concept to another.
+- Cross-note temporal correlation.
+- Audit mode built on temporal plus provenance.

--- a/AGENT.md
+++ b/AGENT.md
@@ -162,6 +162,13 @@ Ensures consistency across machines. Default remote is `origin`; for forks, `set
 ### Project-boosted recall
 When `recall` called with `cwd`, project notes get **+0.15 cosine similarity boost** (not hard filter). Keeps global memories accessible while prioritizing project context.
 
+### Temporal recall
+- `recall` supports opt-in temporal enrichment via `mode: "temporal"`
+- Semantic ranking still happens first; git history is fetched only after top matches are selected
+- Default recall behavior and latency expectations stay unchanged when temporal mode is not used
+- Temporal output stays compact: commit hash, timestamp, message, and optional bounded summary
+- `verbose: true` adds richer whole-commit stats-based context only; do not expect raw or partial diffs
+
 ### Multi-vault architecture
 - **Main vault** (`~/mnemonic-vault`): Private global memories, own git repo
 - **Project vault** (`<git-root>/.mnemonic/`): Project-specific memories, committed to project repo
@@ -249,7 +256,7 @@ Keep these high-level anchors in mind:
 | `memory_graph` | Show compact adjacency list of relationships |
 | `move_memory` | Move note between vaults without changing id |
 | `project_memory_summary` | Session-start entrypoint: themed notes, anchors, and orientation for fast project orientation |
-| `recall` | Semantic search with optional project boost |
+| `recall` | Semantic search with optional project boost and opt-in temporal history |
 | `recent_memories` | Show most recently updated notes for scope |
 | `remember` | Write note + embedding; `cwd` sets context, `scope` picks storage, `lifecycle` picks temporary vs permanent |
 | `relate` | Create typed relationship between notes (bidirectional) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 
 ### Added
 
+- `recall` now supports opt-in temporal history via `mode: "temporal"`, preserving semantic-first selection while enriching top matches with compact git-backed history entries.
+- Temporal history entries include commit hash, timestamp, message, and bounded RTK-style summaries; `verbose: true` adds richer stats-only context without returning raw diffs.
 - `project_memory_summary` now returns themed note categories with ranked examples (recent + connected notes first), anchor notes (durable hubs connecting multiple themes), and optional related global notes via anchor similarity — a session-start entrypoint for fast project orientation.
 - Anchors are scored by centrality (log of connection count), connection diversity (distinct themes), and recency — permanent notes with cross-cutting relationships surface first.
 - Notes tagged `anchor` or `alwaysLoad` are prioritized in anchor selection, capped at 10 total.
@@ -21,6 +23,7 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 - `ProjectSummaryResult.themes` changed from `Record<string, number>` to `Record<string, ThemeSection>` with `count` and `examples` fields — a breaking change for clients parsing structured content.
 - `ProjectSummaryResult` now includes required `orientation` field with `primaryEntry`, `suggestedNext`, and optional `warnings`.
 - `RecallResult.results` now includes optional `provenance` and `confidence` fields.
+- `RecallResult.results` now also accepts optional `history` entries for temporal recall, with optional `stats` in verbose mode.
 - `OrientationNote` now includes optional `provenance` and `confidence` fields.
 
 ## [0.13.1] - 2026-03-20

--- a/README.md
+++ b/README.md
@@ -303,6 +303,10 @@ Project identity derives from the **git remote URL**, normalized to a stable slu
 
 `recall` with `cwd` searches both vaults. Project notes get a **+0.15 similarity boost** — a soft signal, not a hard filter — so global memories remain accessible while project context floats to the top.
 
+Temporal recall is opt-in via `mode: "temporal"`. It keeps semantic selection first, then enriches only the top matches with compact git-backed history so agents can inspect how a note evolved without turning recall into raw log or diff output.
+
+Use `verbose: true` together with temporal mode when you want richer change stats such as additions, deletions, files changed, and change classification. Those stats describe the whole commit that touched the note, not a raw diff excerpt, so recall stays bounded and does not return full diffs.
+
 The `scope` parameter on `recall` narrows results:
 
 - `"all"` *(default)* — project memories boosted, then global
@@ -421,7 +425,7 @@ Imported notes are written to the main vault with `lifecycle: permanent` and `sc
 | `memory_graph`              | Show compact adjacency list of relationships                             |
 | `move_memory`               | Move note between vaults without changing id                             |
 | `project_memory_summary`    | Session-start entrypoint: themed notes, anchors, and orientation for fast project orientation |
-| `recall`                    | Semantic search with optional project boost                              |
+| `recall`                    | Semantic search with optional project boost and opt-in temporal history  |
 | `recent_memories`           | Show most recently updated notes for scope                               |
 | `remember`                  | Write note + embedding; `cwd` sets context, `scope` picks storage, `lifecycle` picks temporary vs permanent |
 | `relate`                    | Create typed relationship between notes (bidirectional)                  |

--- a/docs/index.html
+++ b/docs/index.html
@@ -1421,9 +1421,9 @@
             <div class="tool-card-name">remember</div>
             <div class="tool-card-purpose">Save something worth keeping</div>
           </div>
-          <div class="tool-card" data-tip="Finds the most relevant notes for any question. Automatically surfaces project-specific memories first, then broader personal context.">
+          <div class="tool-card" data-tip="Finds the most relevant notes for any question. Automatically surfaces project-specific memories first, then broader personal context. Supports opt-in temporal mode to add compact git-backed note history after semantic selection.">
             <div class="tool-card-name">recall</div>
-            <div class="tool-card-purpose">Ask what you've previously learned</div>
+            <div class="tool-card-purpose">Ask what you've previously learned - or how it evolved</div>
           </div>
           <div class="tool-card" data-tip="Edit an existing note's content, title, or tags. Keeps your memory base tidy instead of letting outdated notes pile up alongside fresh ones.">
             <div class="tool-card-name">update</div>

--- a/src/git.ts
+++ b/src/git.ts
@@ -26,6 +26,12 @@ export interface LastCommit {
   timestamp: string;
 }
 
+export interface CommitStats {
+  additions: number;
+  deletions: number;
+  filesChanged: number;
+}
+
 export interface SyncResult {
   hasRemote: boolean;
   /** Note ids that arrived or changed during pull (need re-embedding) */
@@ -349,16 +355,79 @@ export class GitOps {
    * Returns empty array when the file has no git history or the repo is unavailable.
    */
   async getRecentCommits(filePath: string, limit: number = 5): Promise<LastCommit[]> {
+    return this.getFileHistory(filePath, limit);
+  }
+
+  /**
+   * Get the most recent commits that touched a specific file.
+   * Returns empty array when the file has no git history or the repo is unavailable.
+   */
+  async getFileHistory(filePath: string, limit: number = 5): Promise<LastCommit[]> {
     if (!this.enabled) return [];
     try {
-      const log = await this.git.log({ maxCount: limit, file: filePath });
-      return log.all.map(entry => ({
-        hash: entry.hash,
-        message: entry.message,
-        timestamp: entry.date,
-      }));
+      const output = await this.git.raw([
+        "log",
+        "--follow",
+        "--format=%H%x09%cI%x09%s",
+        "-n",
+        String(limit),
+        "--",
+        filePath,
+      ]);
+
+      return output
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .map((line) => {
+          const [hash, timestamp, ...messageParts] = line.split("\t");
+          return {
+            hash: hash ?? "",
+            timestamp: timestamp ?? "",
+            message: messageParts.join("\t"),
+          };
+        })
+        .filter((entry) => entry.hash && entry.timestamp && entry.message);
     } catch {
       return [];
+    }
+  }
+
+  /**
+   * Get compact diff stats for a specific commit and file path.
+   * Returns null when stats cannot be derived.
+   */
+  async getCommitStats(filePath: string, commitHash: string): Promise<CommitStats | null> {
+    if (!this.enabled) return null;
+    void filePath;
+
+    try {
+      const output = await this.git.raw([
+        "show",
+        "--format=",
+        "--numstat",
+        commitHash,
+      ]);
+
+      let additions = 0;
+      let deletions = 0;
+      let filesChanged = 0;
+
+      for (const line of output.split("\n")) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+
+        const [addedRaw, deletedRaw] = trimmed.split("\t");
+        if (addedRaw === undefined || deletedRaw === undefined) continue;
+
+        additions += addedRaw === "-" ? 0 : parseInt(addedRaw, 10) || 0;
+        deletions += deletedRaw === "-" ? 0 : parseInt(deletedRaw, 10) || 0;
+        filesChanged += 1;
+      }
+
+      return { additions, deletions, filesChanged };
+    } catch {
+      return null;
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { promises as fs } from "fs";
 import { NOTE_LIFECYCLES, Storage, type Note, type NoteLifecycle, type Relationship, type RelationshipType } from "./storage.js";
 import { embed, cosineSimilarity, embedModel } from "./embeddings.js";
 import { type CommitResult, type PushResult, type SyncResult } from "./git.js";
-import { getNoteProvenance, computeConfidence } from "./provenance.js";
+import { buildTemporalHistoryEntry, computeConfidence, getNoteProvenance } from "./provenance.js";
 
 import {
   filterRelationships,
@@ -396,6 +396,8 @@ const VAULT_PATH = process.env["VAULT_PATH"]
 
 const DEFAULT_RECALL_LIMIT = 5;
 const DEFAULT_MIN_SIMILARITY = 0.3;
+const TEMPORAL_HISTORY_NOTE_LIMIT = 5;
+const TEMPORAL_HISTORY_COMMIT_LIMIT = 5;
 
 async function readPackageVersion(): Promise<string> {
   const packageJsonPath = path.resolve(import.meta.dirname, "../package.json");
@@ -537,6 +539,26 @@ function formatNote(note: Note, score?: number): string {
     `**tags:** ${note.tags.join(", ") || "none"} | **${describeLifecycle(note.lifecycle)}** | **updated:** ${note.updatedAt}${relStr}\n\n` +
     note.content
   );
+}
+
+function formatTemporalHistory(
+  history: Array<{
+    commitHash: string;
+    timestamp: string;
+    message: string;
+    summary?: string;
+  }>
+): string {
+  if (history.length === 0) {
+    return "**history:** no git history found";
+  }
+
+  const lines = ["**history:**"];
+  for (const entry of history) {
+    const summary = entry.summary ? ` — ${entry.summary}` : "";
+    lines.push(`- \`${entry.commitHash.slice(0, 7)}\` ${entry.timestamp} — ${entry.message}${summary}`);
+  }
+  return lines.join("\n");
 }
 
 // ── Git commit message helpers ────────────────────────────────────────────────
@@ -2027,15 +2049,18 @@ server.registerTool(
     title: "Recall",
     description:
       "Semantic search over stored memories using embeddings.\n\n" +
+      "Supports opt-in temporal mode (`mode: \"temporal\"`) to enrich top semantic matches with compact git-backed history.\n\n" +
       "Use this when:\n" +
       "- You know the topic but not the exact memory id\n" +
       "- You are starting a session and want relevant prior context\n" +
-      "- You want to check whether a memory already exists before creating another one\n\n" +
+      "- You want to check whether a memory already exists before creating another one\n" +
+      "- You explicitly want to inspect how a note evolved over time\n\n" +
       "Do not use this when:\n" +
       "- You already know the exact id; use `get`\n" +
       "- You just want to browse by tags or scope; use `list`\n\n" +
       "Returns:\n" +
-      "- Ranked memory matches with scores, vault label, tags, lifecycle, and updated time\n\n" +
+      "- Ranked memory matches with scores, vault label, tags, lifecycle, and updated time\n" +
+      "- In temporal mode, optional compact history entries for top matches\n\n" +
       "Read-only.\n\n" +
       "Typical next step:\n" +
       "- Use `get`, `update`, `relate`, or `consolidate` based on the results.",
@@ -2049,6 +2074,8 @@ server.registerTool(
       cwd: projectParam,
       limit: z.number().int().min(1).max(20).optional().default(DEFAULT_RECALL_LIMIT),
       minSimilarity: z.number().min(0).max(1).optional().default(DEFAULT_MIN_SIMILARITY),
+      mode: z.enum(["default", "temporal"]).optional().default("default").describe("Temporal history is opt-in. Use `temporal` to enrich top semantic matches with compact git-backed history."),
+      verbose: z.boolean().optional().default(false).describe("Only meaningful with `mode: \"temporal\"`. Adds richer stats-based history context without returning raw diffs."),
       tags: z.array(z.string()).optional().describe("Filter results to notes with all of these tags."),
       scope: z
         .enum(["project", "global", "all"])
@@ -2062,7 +2089,7 @@ server.registerTool(
     }),
     outputSchema: RecallResultSchema,
   },
-  async ({ query, cwd, limit, minSimilarity, tags, scope }) => {
+  async ({ query, cwd, limit, minSimilarity, mode, verbose, tags, scope }) => {
     await ensureBranchSynced(cwd);
 
     const project = await resolveProject(cwd);
@@ -2151,15 +2178,56 @@ server.registerTool(
         recentlyChanged: boolean;
       };
       confidence?: "high" | "medium" | "low";
+      history?: Array<{
+        commitHash: string;
+        timestamp: string;
+        message: string;
+        summary?: string;
+        stats?: {
+          additions: number;
+          deletions: number;
+          filesChanged: number;
+          changeType: "metadata-only change" | "minor edit" | "substantial update";
+        };
+      }>;
     }> = [];
-    for (const { id, score, vault, boosted } of top) {
+    for (const [index, { id, score, vault, boosted }] of top.entries()) {
       const note = await readCachedNote(vault, id);
       if (note) {
-        sections.push(formatNote(note, score));
         const centrality = note.relatedTo?.length ?? 0;
         const filePath = `${vault.notesRelDir}/${id}.md`;
         const provenance = await getNoteProvenance(vault.git, filePath);
         const confidence = computeConfidence(note.lifecycle, note.updatedAt, centrality);
+        let history: Array<{
+          commitHash: string;
+          timestamp: string;
+          message: string;
+          summary?: string;
+          stats?: {
+            additions: number;
+            deletions: number;
+            filesChanged: number;
+            changeType: "metadata-only change" | "minor edit" | "substantial update";
+          };
+        }> | undefined;
+
+        if (mode === "temporal") {
+          if (index < TEMPORAL_HISTORY_NOTE_LIMIT) {
+            const commits = await vault.git.getFileHistory(filePath, TEMPORAL_HISTORY_COMMIT_LIMIT);
+            history = await Promise.all(
+              commits.map(async (commit) => {
+                const stats = await vault.git.getCommitStats(filePath, commit.hash);
+                return buildTemporalHistoryEntry(commit, stats, verbose);
+              })
+            );
+          }
+        }
+
+        const formattedHistory = mode === "temporal" && history !== undefined
+          ? `\n\n${formatTemporalHistory(history)}`
+          : "";
+        sections.push(`${formatNote(note, score)}${formattedHistory}`);
+
         structuredResults.push({
           id,
           title: note.title,
@@ -2173,6 +2241,7 @@ server.registerTool(
           updatedAt: note.updatedAt,
           provenance,
           confidence,
+          history,
         });
       }
     }

--- a/src/provenance.ts
+++ b/src/provenance.ts
@@ -1,4 +1,4 @@
-import type { GitOps } from "./git.js";
+import type { CommitStats, GitOps, LastCommit } from "./git.js";
 import type { NoteLifecycle } from "./storage.js";
 import type { Confidence, Provenance } from "./structured-content.js";
 
@@ -6,6 +6,84 @@ const RECENTLY_CHANGED_DAYS = 5;
 const HIGH_CONFIDENCE_DAYS = 30;
 const MEDIUM_CONFIDENCE_DAYS = 90;
 const HIGH_CONFIDENCE_CENTRALITY = 5;
+
+function classifyTemporalChange(
+  commit: LastCommit,
+  stats: CommitStats
+): "metadata-only change" | "minor edit" | "substantial update" {
+  const metadataPrefixes = ["relate:", "unrelate:", "move:", "migrate:", "forget:"];
+  if (stats.additions === 0 && stats.deletions === 0) {
+    return "metadata-only change";
+  }
+
+  if (metadataPrefixes.some((prefix) => commit.message.startsWith(prefix))) {
+    return "metadata-only change";
+  }
+
+  const totalChangedLines = stats.additions + stats.deletions;
+  if (stats.filesChanged >= 3 || totalChangedLines >= 25) {
+    return "substantial update";
+  }
+
+  return "minor edit";
+}
+
+function formatTemporalSummary(stats: CommitStats, changeType: string, verbose: boolean): string {
+  const lineSummary = `+${stats.additions}/-${stats.deletions} lines`;
+  if (!verbose) {
+    return changeType === "metadata-only change"
+      ? changeType
+      : `${changeType} (${lineSummary})`;
+  }
+
+  const fileSummary = `${stats.filesChanged} ${stats.filesChanged === 1 ? "file" : "files"} changed`;
+  return changeType === "metadata-only change"
+    ? `${changeType} (${fileSummary})`
+    : `${changeType} (${lineSummary}, ${fileSummary})`;
+}
+
+export function buildTemporalHistoryEntry(
+  commit: LastCommit,
+  stats: CommitStats | null,
+  verbose: boolean
+): {
+  commitHash: string;
+  timestamp: string;
+  message: string;
+  summary?: string;
+  stats?: {
+    additions: number;
+    deletions: number;
+    filesChanged: number;
+    changeType: "metadata-only change" | "minor edit" | "substantial update";
+  };
+} {
+  const base = {
+    commitHash: commit.hash,
+    timestamp: commit.timestamp,
+    message: commit.message,
+  };
+
+  if (!stats) {
+    return base;
+  }
+
+  const changeType = classifyTemporalChange(commit, stats);
+  return {
+    ...base,
+    summary: formatTemporalSummary(stats, changeType, verbose),
+    ...(verbose
+      ? {
+          stats: {
+            additions: stats.additions,
+            deletions: stats.deletions,
+            filesChanged: stats.filesChanged,
+            changeType,
+          },
+        }
+      : {}),
+  };
+}
 
 export async function getNoteProvenance(
   git: GitOps,

--- a/src/structured-content.ts
+++ b/src/structured-content.ts
@@ -81,6 +81,18 @@ export interface RecallResult extends Record<string, unknown> {
     updatedAt: string;
     provenance?: Provenance;
     confidence?: Confidence;
+    history?: Array<{
+      commitHash: string;
+      timestamp: string;
+      message: string;
+      summary?: string;
+      stats?: {
+        additions: number;
+        deletions: number;
+        filesChanged: number;
+        changeType: "metadata-only change" | "minor edit" | "substantial update";
+      };
+    }>;
   }>;
 }
 
@@ -464,6 +476,18 @@ export const RecallResultSchema = z.object({
       recentlyChanged: z.boolean(),
     }).optional(),
     confidence: z.enum(["high", "medium", "low"]).optional(),
+    history: z.array(z.object({
+      commitHash: z.string(),
+      timestamp: z.string(),
+      message: z.string(),
+      summary: z.string().optional(),
+      stats: z.object({
+        additions: z.number(),
+        deletions: z.number(),
+        filesChanged: z.number(),
+        changeType: z.enum(["metadata-only change", "minor edit", "substantial update"]),
+      }).optional(),
+    })).optional(),
   })),
 });
 

--- a/tests/git.unit.test.ts
+++ b/tests/git.unit.test.ts
@@ -507,12 +507,10 @@ describe("GitOps", () => {
       const git = new GitOps("/tmp/repo");
       await git.init();
 
-      log.mockResolvedValueOnce({
-        all: [
-          { hash: "abc123", message: "feat: latest", date: "2026-03-20T10:00:00Z" },
-          { hash: "def456", message: "fix: previous", date: "2026-03-19T10:00:00Z" },
-        ],
-      });
+      raw.mockResolvedValueOnce([
+        "abc123\t2026-03-20T10:00:00Z\tfeat: latest",
+        "def456\t2026-03-19T10:00:00Z\tfix: previous",
+      ].join("\n"));
 
       const result = await git.getRecentCommits("notes/test.md", 2);
 
@@ -520,7 +518,15 @@ describe("GitOps", () => {
         { hash: "abc123", message: "feat: latest", timestamp: "2026-03-20T10:00:00Z" },
         { hash: "def456", message: "fix: previous", timestamp: "2026-03-19T10:00:00Z" },
       ]);
-      expect(log).toHaveBeenCalledWith({ maxCount: 2, file: "notes/test.md" });
+      expect(raw).toHaveBeenCalledWith([
+        "log",
+        "--follow",
+        "--format=%H%x09%cI%x09%s",
+        "-n",
+        "2",
+        "--",
+        "notes/test.md",
+      ]);
     });
 
     it("returns empty array when file has no git history", async () => {
@@ -528,7 +534,7 @@ describe("GitOps", () => {
       const git = new GitOps("/tmp/repo");
       await git.init();
 
-      log.mockResolvedValueOnce({ all: [] });
+      raw.mockResolvedValueOnce("");
 
       const result = await git.getRecentCommits("notes/new-file.md");
 
@@ -540,7 +546,7 @@ describe("GitOps", () => {
       const git = new GitOps("/tmp/repo");
       await git.init();
 
-      log.mockRejectedValueOnce(new Error("not a git repository"));
+      raw.mockRejectedValueOnce(new Error("not a git repository"));
 
       const result = await git.getRecentCommits("notes/test.md");
 
@@ -560,6 +566,79 @@ describe("GitOps", () => {
       expect(result).toEqual([]);
 
       delete process.env.DISABLE_GIT;
+    });
+  });
+
+  describe("getFileHistory", () => {
+    it("returns recent commits for a file using --follow and the requested limit", async () => {
+      const { GitOps } = await import("../src/git.js");
+      const git = new GitOps("/tmp/repo");
+      await git.init();
+
+      raw.mockResolvedValueOnce([
+        "abc123\t2026-03-20T10:00:00Z\tfeat: latest",
+        "def456\t2026-03-19T10:00:00Z\tfix: previous",
+      ].join("\n"));
+
+      const result = await git.getFileHistory("notes/test.md", 2);
+
+      expect(result).toEqual([
+        { hash: "abc123", message: "feat: latest", timestamp: "2026-03-20T10:00:00Z" },
+        { hash: "def456", message: "fix: previous", timestamp: "2026-03-19T10:00:00Z" },
+      ]);
+      expect(raw).toHaveBeenCalledWith([
+        "log",
+        "--follow",
+        "--format=%H%x09%cI%x09%s",
+        "-n",
+        "2",
+        "--",
+        "notes/test.md",
+      ]);
+    });
+
+    it("returns empty array when git history lookup fails", async () => {
+      const { GitOps } = await import("../src/git.js");
+      const git = new GitOps("/tmp/repo");
+      await git.init();
+
+      raw.mockRejectedValueOnce(new Error("not a git repository"));
+
+      const result = await git.getFileHistory("notes/test.md", 3);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getCommitStats", () => {
+    it("parses whole-commit numstat output into compact commit stats", async () => {
+      const { GitOps } = await import("../src/git.js");
+      const git = new GitOps("/tmp/repo");
+      await git.init();
+
+      raw.mockResolvedValueOnce("12\t3\tnotes/test.md\n5\t0\tnotes/other.md\n");
+
+      const result = await git.getCommitStats("notes/test.md", "abc123");
+
+      expect(result).toEqual({ additions: 17, deletions: 3, filesChanged: 2 });
+      expect(raw).toHaveBeenCalledWith([
+        "show",
+        "--format=",
+        "--numstat",
+        "abc123",
+      ]);
+    });
+
+    it("returns null when stats lookup fails", async () => {
+      const { GitOps } = await import("../src/git.js");
+      const git = new GitOps("/tmp/repo");
+      await git.init();
+
+      raw.mockRejectedValueOnce(new Error("bad revision"));
+
+      const result = await git.getCommitStats("notes/test.md", "abc123");
+
+      expect(result).toBeNull();
     });
   });
 });

--- a/tests/mcp.integration.test.ts
+++ b/tests/mcp.integration.test.ts
@@ -2513,6 +2513,102 @@ describe("local MCP script", () => {
   }, 15000);
 
   describe("schema-audit", () => {
+    it("recall temporal mode returns compact history and verbose stats", async () => {
+      const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mcp-vault-"));
+      tempDirs.push(vaultDir);
+      const embeddingServer = await startFakeEmbeddingServer();
+
+      try {
+        await callLocalMcp(vaultDir, "remember", {
+          title: "Temporal recall schema audit test",
+          content: "Testing temporal recall history output.",
+          tags: ["audit", "temporal"],
+          lifecycle: "permanent",
+          scope: "global",
+          summary: "Seed note for temporal recall schema audit",
+        }, { ollamaUrl: embeddingServer.url, disableGit: false });
+
+        const response = await callLocalMcpResponse(vaultDir, "recall", {
+          query: "temporal recall schema audit test",
+          mode: "temporal",
+          verbose: true,
+        }, { ollamaUrl: embeddingServer.url, disableGit: false });
+
+        expect(() => RecallResultSchema.parse(response.structuredContent)).not.toThrow();
+        const parsed = RecallResultSchema.parse(response.structuredContent);
+        expect(parsed.results).toHaveLength(1);
+        expect(parsed.results[0]?.history).toBeDefined();
+        expect(parsed.results[0]?.history?.length).toBeGreaterThan(0);
+        expect(parsed.results[0]?.history?.[0]).toHaveProperty("commitHash");
+        expect(parsed.results[0]?.history?.[0]).toHaveProperty("message");
+        expect(parsed.results[0]?.history?.[0]).toHaveProperty("timestamp");
+        expect(parsed.results[0]?.history?.[0]).toHaveProperty("stats");
+      } finally {
+        await embeddingServer.close();
+      }
+    }, 15000);
+
+    it("recall temporal mode omits history beyond the enrichment cap instead of claiming no history", async () => {
+      const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mcp-vault-"));
+      tempDirs.push(vaultDir);
+      const embeddingServer = await startFakeEmbeddingServer();
+
+      try {
+        for (let i = 1; i <= 6; i++) {
+          await callLocalMcp(vaultDir, "remember", {
+            title: `Temporal recall cap test ${i}`,
+            content: `Testing temporal recall enrichment cap item ${i}.`,
+            tags: ["audit", "temporal", "cap-test"],
+            lifecycle: "permanent",
+            scope: "global",
+            summary: `Seed note ${i} for temporal recall cap audit`,
+          }, { ollamaUrl: embeddingServer.url, disableGit: false });
+        }
+
+        const response = await callLocalMcpResponse(vaultDir, "recall", {
+          query: "temporal recall cap test",
+          mode: "temporal",
+          limit: 6,
+        }, { ollamaUrl: embeddingServer.url, disableGit: false });
+
+        const parsed = RecallResultSchema.parse(response.structuredContent);
+        expect(parsed.results).toHaveLength(6);
+        expect(parsed.results[4]?.history).toBeDefined();
+        expect(parsed.results[5]?.history).toBeUndefined();
+        expect(response.text).not.toContain("no git history found");
+      } finally {
+        await embeddingServer.close();
+      }
+    }, 25000);
+
+    it("plain recall leaves temporal history absent", async () => {
+      const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mcp-vault-"));
+      tempDirs.push(vaultDir);
+      const embeddingServer = await startFakeEmbeddingServer();
+
+      try {
+        await callLocalMcp(vaultDir, "remember", {
+          title: "Plain recall schema audit test",
+          content: "Testing that default recall does not include temporal history.",
+          tags: ["audit", "recall"],
+          lifecycle: "permanent",
+          scope: "global",
+          summary: "Seed note for plain recall schema audit",
+        }, { ollamaUrl: embeddingServer.url, disableGit: false });
+
+        const response = await callLocalMcpResponse(vaultDir, "recall", {
+          query: "plain recall schema audit test",
+        }, { ollamaUrl: embeddingServer.url, disableGit: false });
+
+        const parsed = RecallResultSchema.parse(response.structuredContent);
+        expect(parsed.results).toHaveLength(1);
+        expect(parsed.results[0]?.history).toBeUndefined();
+        expect(response.text).not.toContain("**history:**");
+      } finally {
+        await embeddingServer.close();
+      }
+    }, 15000);
+
     it("RecallResultSchema accepts provenance and confidence fields in results", async () => {
       const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mcp-vault-"));
       tempDirs.push(vaultDir);

--- a/tests/mcp.integration.test.ts
+++ b/tests/mcp.integration.test.ts
@@ -28,6 +28,14 @@ const tempDirs: string[] = [];
 async function initTestRepo(repoDir: string, branch = "feature/test"): Promise<void> {
   await execFileAsync("git", ["init"], { cwd: repoDir });
   await execFileAsync("git", ["checkout", "-B", branch], { cwd: repoDir });
+  await execFileAsync("git", ["config", "user.name", "Test User"], { cwd: repoDir });
+  await execFileAsync("git", ["config", "user.email", "test@example.com"], { cwd: repoDir });
+}
+
+async function initTestVaultRepo(vaultDir: string): Promise<void> {
+  await execFileAsync("git", ["init"], { cwd: vaultDir });
+  await execFileAsync("git", ["config", "user.name", "Test User"], { cwd: vaultDir });
+  await execFileAsync("git", ["config", "user.email", "test@example.com"], { cwd: vaultDir });
 }
 
 afterEach(async () => {
@@ -250,9 +258,7 @@ describe("local MCP script", () => {
     const embeddingServer = await startFakeEmbeddingServer();
 
     try {
-      await execFileAsync("git", ["init"], { cwd: vaultDir });
-      await execFileAsync("git", ["config", "user.name", "Test User"], { cwd: vaultDir });
-      await execFileAsync("git", ["config", "user.email", "test@example.com"], { cwd: vaultDir });
+      await initTestVaultRepo(vaultDir);
 
       const first = await callLocalMcp(vaultDir, "remember", {
         title: "Relate retry first",
@@ -601,8 +607,6 @@ describe("local MCP script", () => {
 
     await execFileAsync("git", ["init", "--bare"], { cwd: remoteDir });
     await initTestRepo(repoDir);
-    await execFileAsync("git", ["config", "user.name", "Test User"], { cwd: repoDir });
-    await execFileAsync("git", ["config", "user.email", "test@example.com"], { cwd: repoDir });
     await execFileAsync("git", ["remote", "add", "origin", remoteDir], { cwd: repoDir });
 
     const embeddingServer = await startFakeEmbeddingServer();
@@ -2519,6 +2523,8 @@ describe("local MCP script", () => {
       const embeddingServer = await startFakeEmbeddingServer();
 
       try {
+        await initTestVaultRepo(vaultDir);
+
         await callLocalMcp(vaultDir, "remember", {
           title: "Temporal recall schema audit test",
           content: "Testing temporal recall history output.",
@@ -2554,6 +2560,8 @@ describe("local MCP script", () => {
       const embeddingServer = await startFakeEmbeddingServer();
 
       try {
+        await initTestVaultRepo(vaultDir);
+
         for (let i = 1; i <= 6; i++) {
           await callLocalMcp(vaultDir, "remember", {
             title: `Temporal recall cap test ${i}`,
@@ -2587,6 +2595,8 @@ describe("local MCP script", () => {
       const embeddingServer = await startFakeEmbeddingServer();
 
       try {
+        await initTestVaultRepo(vaultDir);
+
         await callLocalMcp(vaultDir, "remember", {
           title: "Plain recall schema audit test",
           content: "Testing that default recall does not include temporal history.",

--- a/tests/provenance.unit.test.ts
+++ b/tests/provenance.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { computeConfidence, getNoteProvenance } from "../src/provenance.js";
+import { buildTemporalHistoryEntry, computeConfidence, getNoteProvenance } from "../src/provenance.js";
 
 const mockGit = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -86,5 +86,113 @@ describe("getNoteProvenance", () => {
     const result = await getNoteProvenance(mockGit, "notes/recent.md");
 
     expect(result?.recentlyChanged).toBe(true);
+  });
+});
+
+describe("buildTemporalHistoryEntry", () => {
+  it("builds a compact summary for a minor edit by default", () => {
+    const result = buildTemporalHistoryEntry(
+      {
+        hash: "abc123",
+        message: "docs: clarify recall behavior",
+        timestamp: "2026-03-20T10:00:00Z",
+      },
+      { additions: 4, deletions: 1, filesChanged: 1 },
+      false
+    );
+
+    expect(result).toEqual({
+      commitHash: "abc123",
+      message: "docs: clarify recall behavior",
+      timestamp: "2026-03-20T10:00:00Z",
+      summary: "minor edit (+4/-1 lines)",
+    });
+  });
+
+  it("returns richer structured stats in verbose mode without raw diffs", () => {
+    const result = buildTemporalHistoryEntry(
+      {
+        hash: "def456",
+        message: "feat: add temporal recall",
+        timestamp: "2026-03-21T10:00:00Z",
+      },
+      { additions: 42, deletions: 10, filesChanged: 3 },
+      true
+    );
+
+    expect(result).toEqual({
+      commitHash: "def456",
+      message: "feat: add temporal recall",
+      timestamp: "2026-03-21T10:00:00Z",
+      summary: "substantial update (+42/-10 lines, 3 files changed)",
+      stats: {
+        additions: 42,
+        deletions: 10,
+        filesChanged: 3,
+        changeType: "substantial update",
+      },
+    });
+  });
+
+  it("falls back to minimal history when stats are unavailable", () => {
+    const result = buildTemporalHistoryEntry(
+      {
+        hash: "ghi789",
+        message: "chore: touch note metadata",
+        timestamp: "2026-03-22T10:00:00Z",
+      },
+      null,
+      true
+    );
+
+    expect(result).toEqual({
+      commitHash: "ghi789",
+      message: "chore: touch note metadata",
+      timestamp: "2026-03-22T10:00:00Z",
+    });
+  });
+
+  it("classifies relationship commits as metadata-only change", () => {
+    const result = buildTemporalHistoryEntry(
+      {
+        hash: "jkl012",
+        message: "relate: A ↔ B",
+        timestamp: "2026-03-22T11:00:00Z",
+      },
+      { additions: 3, deletions: 1, filesChanged: 1 },
+      true
+    );
+
+    expect(result).toEqual({
+      commitHash: "jkl012",
+      message: "relate: A ↔ B",
+      timestamp: "2026-03-22T11:00:00Z",
+      summary: "metadata-only change (1 file changed)",
+      stats: {
+        additions: 3,
+        deletions: 1,
+        filesChanged: 1,
+        changeType: "metadata-only change",
+      },
+    });
+  });
+
+  it("classifies forget commits as metadata-only change for surviving notes", () => {
+    const result = buildTemporalHistoryEntry(
+      {
+        hash: "mno345",
+        message: "forget: remove obsolete note",
+        timestamp: "2026-03-22T11:05:00Z",
+      },
+      { additions: 2, deletions: 3, filesChanged: 1 },
+      false
+    );
+
+    expect(result).toEqual({
+      commitHash: "mno345",
+      message: "forget: remove obsolete note",
+      timestamp: "2026-03-22T11:05:00Z",
+      summary: "metadata-only change",
+    });
   });
 });


### PR DESCRIPTION
## Summary

This PR captures the following design decisions:

- **mnemonic — key design decisions**
- **Phase 1 Provenance + Confidence implementation design**
- **Temporal recall mode design for Phase 2 on-demand history exploration**

## Design Decisions

### mnemonic — key design decisions

**Tags:** design, decisions, architecture, rationale

**One file per note:** Critical for git conflict isolation. Never aggregate notes into a single file.

**Embeddings gitignored:** Derived data, always recomputable. Committing them causes unresolvable merge conflicts (can't merge float arrays). `sync` now backfills missing local embeddings for each synced vault, even when no notes were newly pulled, so fresh clones heal automatically once Ollama is available.

**Rebase on pull:** `git pull --rebase` keeps history linear. Don't switch to merge.

**Project ID from git remote URL, not local path:** `project.ts` normalizes remote URLs to stable slugs (e.g. `github-com-acme-myapp`). This makes cross-machine consistency work — local paths differ, remote URLs don't.

**Similarity boost, not hard filter:** `recall` gives project notes +0.15 cosine similarity boost rather than excluding global notes. Global memories (user prefs, cross-project patterns) remain accessible in project context.

**Temporal recall is semantic-first and opt-in:** `recall` supports `mode: "temporal"` for on-demand history exploration, but only after normal semantic selection. Default recall behavior and latency expectations stay unchanged. Temporal enrichment is bounded to top matches and compact commit summaries; `verbose: true` adds richer stats-based context, not raw diffs.

**No auto-relationship via LLM:** Decided against using a local Qwen model to auto-build relationships. Small models lack session context, produce spurious edges, and corrupt the graph silently. Instead: agent instructions prompt `relate` immediately after `remember` while session context is warm.

**Metadata-only changes don't re-embed:** Lifecycle migrations and other metadata-only edits do not recompute embeddings. Embeddings refresh when note title/content changes, during sync backfill, or via explicit `reindex`.

### Phase 1 Provenance + Confidence implementation design

**Tags:** architecture, design-decisions, provenance, phase-1

# Phase 1 Provenance + Confidence Design Decision

## What it does

Extends recall and orientation outputs with git-backed provenance metadata and confidence signals.

## Data Shapes

```typescript
type Provenance = {
  lastUpdatedAt: string;
  lastCommitHash: string;
  lastCommitMessage: string;
  recentlyChanged: boolean;  // daysSinceUpdate < 5
};

type Confidence = "high" | "medium" | "low";
```

## Confidence Heuristic

```text
if (lifecycle === "permanent" && centrality >= 5 && daysSinceUpdate < 30)
  → "high"
else if (daysSinceUpdate < 90)
  → "medium"
else
  → "low"
```

## Implementation Locations

1. **git.ts** - Added `getLastCommit(filePath)` and `getRecentCommits(filePath, limit)` read-only helpers
2. **structured-content.ts** - Added `Provenance`, `Confidence` types; extended `RecallResult`, `RecallResultSchema`, `OrientationNote`, `OrientationNoteSchema`
3. **index.ts** - Enrich recall results and orientation notes with provenance + confidence after scoring

## Key Principles

- Provenance is an **enrichment layer** - does NOT affect semantic scoring
- Git calls are read-only and scoped to top-N results only
- `recentlyChanged = daysSinceUpdate < 5` (5 days, not 3-7 - kept simple)
- Must be robust to: missing git repo, detached HEAD, empty history

## What NOT to do (Phase 1)

- No full history exploration
- No diff computation by default
- No probabilistic/ML-based confidence
- Keep it rule-based and predictable

### Temporal recall mode design for Phase 2 on-demand history exploration

**Tags:** design, recall, temporal, git, decision, architecture

Phase 2 adds an opt-in temporal recall mode for on-demand history exploration without changing default recall behavior.

Core decision:

- Extend `recall` with `mode: "temporal"`.
- Default recall remains unchanged in behavior, ranking, and latency expectations.
- Temporal mode is explicit only; do not auto-trigger it from the query yet.

Retrieval pipeline:

1. Run normal semantic recall first, including existing project bias.
2. Only after semantic selection, fetch git history for the top N matching notes.
3. Enrich results with a separate `history` field while preserving existing `score`, `provenance`, and `confidence` fields.

History shape:

```ts
{
  note: { ...existing fields },
  provenance: { ...existing Phase 1 fields },
  history: [
    {
      commitHash: string,
      timestamp: string,
      message: string,
      summary?: string
    }
  ]
}
```

Git design constraints:

- Git is a read-only history source.
- Add helpers in `git.ts`:
  - `getFileHistory(filePath: string, limit: number): Commit[]`
  - `getCommitStats(filePath: string, commitHash: string): { additions: number; deletions: number; filesChanged: number; }`
- Handle missing repo, missing file history, and command failures gracefully.
- Avoid locale-dependent parsing.
- Fail soft and return empty or minimal history data instead of failing recall.

History summarization design:

- Default temporal output must be compact and RTK-inspired rather than raw diffs.
- Each history item should always include `commitHash`, `timestamp`, and `message`.
- Add optional compact summaries derived from diff stat style data, such as:
  - `+42/-10 lines`
  - `3 files changed`
  - `minor edit`
  - `substantial update`
  - `metadata-only change`
- Never return large raw diffs from normal temporal recall.
- If summarization fails, still return usable history entries with hash, timestamp, and message.

Verbose escape hatch:

- Support `verbose: true` only together with `mode: "temporal"`.
- Verbose mode may include slightly richer summaries such as expanded stats or the first diff hunk.
- Even in verbose mode, avoid full diffs by default.
- Primary purpose is debugging and advanced inspection.

Performance constraints:

- Temporal mode must remain bounded.
- Only inspect history for top N notes, roughly 3-5 notes.
- Only fetch a small number of commits per note, roughly 3-5 commits.
- Avoid repo-wide scans.
- Cache repeated git lookups within a single request if useful.
- No impact on default semantic recall latency when temporal mode is not used.

Non-goals for Phase 2:

- No repo-wide timelines.
- No cross-note history stitching.
- No heavy diff output.
- No replacement of semantic recall with git traversal.
- No RTK-style command proxying or interception.

Intended user value:
Temporal recall should help agents answer questions such as:

- What changed recently?
- How did this evolve?
- Why is this note like this?

Future extensions explicitly deferred:

- Semantic change summaries such as shifts from one concept to another.
- Cross-note temporal correlation.
- Audit mode built on temporal plus provenance.

---

_Generated from 3 design decision note(s) in `.mnemonic/notes/`. Run `/update-pr` to regenerate._