### PR TITLE
discover_tags should default to note-oriented ranked suggestions instead of full tag inventories

### DIFF
--- a/.mnemonic/notes/discover-tags-should-default-to-note-oriented-ranked-suggest-5f5d6922.md
+++ b/.mnemonic/notes/discover-tags-should-default-to-note-oriented-ranked-suggest-5f5d6922.md
@@ -1,0 +1,41 @@
+---
+title: >-
+  discover_tags should default to note-oriented ranked suggestions instead of
+  full tag inventories
+tags:
+  - discover_tags
+  - design
+  - decision
+  - mcp
+  - documentation
+lifecycle: permanent
+createdAt: '2026-03-23T20:41:59.873Z'
+updatedAt: '2026-03-23T20:41:59.873Z'
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+Shift `discover_tags` from corpus-oriented tag inventory output to note-oriented tag suggestion output.
+
+Decision:
+
+- Keep the tool name `discover_tags`.
+- Make the default behavior compact and note-specific: the caller provides note context such as `title`, `content`, `query`, or candidate tags, and the tool returns ranked canonical tag suggestions for that note.
+- Rank by note relevance first and usage count second so low-value but common tags do not dominate, while still preferring canonical project vocabulary.
+- Demote tags that only appear on temporary notes unless the target note also appears temporary.
+- Avoid returning the full corpus-wide tag list in default structured output; broad browsing should be explicit rather than automatic.
+
+Rationale:
+
+- The current full-tag structured output can become very large and waste context.
+- Returning the whole tag inventory still exposes many unrelated tags to the agent.
+- The original design goal was to prevent agents from inventing or overusing unrelated tags; note-oriented ranking serves that goal better than popularity-only truncation.
+
+Documentation impact when implemented:
+
+- Tighten tool descriptions and workflow guidance so `discover_tags` is described as suggesting canonical tags for a specific note.
+- Update `README.md`, `AGENT.md`, tool lists, and homepage copy to stop implying that the normal workflow is to enumerate the whole tag corpus.
+
+Non-goal:
+
+- Do not regress to purely popularity-based top-N tags. The result should stay relevance-aware so uncommon but appropriate tags can still surface.

--- a/.mnemonic/notes/mnemonic-mcp-tools-inventory-47499799.md
+++ b/.mnemonic/notes/mnemonic-mcp-tools-inventory-47499799.md
@@ -6,7 +6,7 @@ tags:
   - api
 lifecycle: permanent
 createdAt: '2026-03-07T17:59:25.498Z'
-updatedAt: '2026-03-22T10:23:48.137Z'
+updatedAt: '2026-03-23T21:01:42.867Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
@@ -30,7 +30,7 @@ This note lists every MCP tool exposed by mnemonic with a brief description. Kee
 | ---- | ----------- |
 | `consolidate` | Merge overlapping memories or find duplicates; supports dry-run, suggest-merges, and prune-superseded strategies |
 | `detect_project` | Detect effective project identity (id, name) for a working directory |
-| `discover_tags` | Discover existing tags across vaults with usage counts and examples |
+| `discover_tags` | Suggest canonical tags for a note using title/content/query context; `mode: "browse"` opts into broader inventory output |
 | `execute_migration` | Execute a named schema migration (dry-run first) |
 | `forget` | Delete a note and its embeddings, clean up relationship references |
 | `get` | Fetch one or more notes by exact id with optional preview, relations, and storage info |
@@ -83,3 +83,12 @@ The structured-content module still contains result schemas and types for remove
 - `"main-vault"` for the global vault
 - `"project-vault"` for the primary project vault (`.mnemonic/`)
 - `` `sub-vault:${vaultFolderName}` `` for named sub-vaults (`.mnemonic-<name>/`)
+
+## discover_tags behavior
+
+`discover_tags` now has two modes:
+
+- default `mode: "suggest"` returns bounded `recommendedTags` for a specific note
+- explicit `mode: "browse"` returns broader inventory-style `tags`
+
+The intended workflow is to pass note context when tag choice is ambiguous so the tool can suggest canonical tags without flooding the agent with unrelated ones.

--- a/.mnemonic/notes/tag-discovery-cognitive-model-how-llms-use-usage-statistics--2aa53468.md
+++ b/.mnemonic/notes/tag-discovery-cognitive-model-how-llms-use-usage-statistics--2aa53468.md
@@ -9,7 +9,7 @@ tags:
   - llm-behavior
 lifecycle: permanent
 createdAt: '2026-03-15T13:47:29.424Z'
-updatedAt: '2026-03-23T21:41:41.269Z'
+updatedAt: '2026-03-24T06:10:38.768Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 memoryVersion: 1
@@ -89,3 +89,11 @@ The LLM's strength is still pattern recognition, not deep semantic reasoning. Th
 - token overlap and note-context overlap outrank raw popularity
 - usage count remains a secondary canonicality signal rather than the dominant ranking factor
 - when no strong specific candidate exists, ranking falls back toward broader canonical tags instead of returning a full inventory dump
+
+## Generalized rule for other projects
+
+The specificity heuristic should not overfit to this repository's tag distribution.
+
+- a clearly specific exact match must still win even if the tag appears only once in a sparse project
+- generic prompts should still fall back to broad canonical tags instead of niche one-off tags
+- the branch into specificity-heavy ranking should only happen for exact matches that are genuinely specific, not weak lexical overlap from arbitrary project vocabulary

--- a/.mnemonic/notes/tag-discovery-cognitive-model-how-llms-use-usage-statistics--2aa53468.md
+++ b/.mnemonic/notes/tag-discovery-cognitive-model-how-llms-use-usage-statistics--2aa53468.md
@@ -9,98 +9,74 @@ tags:
   - llm-behavior
 lifecycle: permanent
 createdAt: '2026-03-15T13:47:29.424Z'
-updatedAt: '2026-03-15T13:47:29.424Z'
+updatedAt: '2026-03-23T20:43:28.540Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 memoryVersion: 1
 ---
 ## Pattern Matching Over Deep Understanding
 
-discover_tags provides context, not rules. The LLM uses usage statistics and examples to pattern-match what "good tagging" looks like in the project, rather than deeply understanding semantic nuances.
+`discover_tags` should evolve from a corpus-oriented inventory into a note-oriented suggestion tool.
 
-## Information Hierarchy (Most to Least Useful)
+The core cognitive model still holds: the LLM benefits from seeing canonical project vocabulary and a small amount of evidence. But the evidence should be filtered through the specific note being written rather than dumping the whole tag catalog.
 
-### 1. Usage Count (Primary Signal)
+## Updated Information Hierarchy
 
-Shows canonical vs fringe terminology:
+### 1. Note Relevance (Primary Signal)
 
-- `bug` (12 uses) vs `bugs` (2 uses) → `bug` is standard
-- High count = established project vocabulary
-- Low count = personal preference or mistake
+The most useful tag is the one that matches the note being written, not the one that is merely common across the whole vault.
 
-### 2. Example Note Titles (Semantic Anchors)
+- A note about MCP prompt wording should prefer `mcp`, `prompt`, `workflow`, or `design` over unrelated but globally common tags
+- Relevance should narrow the candidate set before any popularity-based ranking
 
-Provides concrete patterns to match against:
+### 2. Usage Count (Canonicality Signal)
 
-- Example: "ci-create-release checkout fails fetching tag-ref over https"
-  - Tagged: `[ci, github-actions, bug, release]`
-- LLM pattern-matches: "My note is about a CI checkout bug → use those tags"
-- 2-3 examples enough to establish pattern
+Usage count remains valuable, but as a secondary signal:
 
-### 3. Lifecycle Types (Quality Signal)
+- `bug` (12 uses) vs `bugs` (2 uses) still indicates canonical terminology
+- High count helps break ties among relevant candidates
+- High count alone should not surface unrelated tags
 
-Temporary vs permanent distribution:
+### 3. Example Titles or Short Reasons (Trust Signal)
 
-- Permanent-only = durable knowledge, important tags
-- Temporary-mix = scaffolding, planning, WIP
-- Helps distinguish `plan` from `decision` tags
+The LLM only needs a little evidence to trust a suggestion:
 
-### 4. IsTemporaryOnly (Cleanup Indicator)
+- one short example title or a brief reason is usually enough
+- this keeps responses compact while still grounding the suggestion in real project usage
 
-Tags used only on temporary notes are cleanup candidates:
+### 4. Lifecycle Distribution (Quality Signal)
 
-- Suggests tag didn't mature into project vocabulary
-- Helps avoid creating similar low-value tags
+Temporary-only tags are still useful as a warning signal:
 
-## Cognitive Model: How LLM Makes Decisions
+- permanent-heavy tags imply durable vocabulary
+- temporary-only tags should be demoted unless the target note is also temporary
 
-**Scenario**: User fixing CI bug
+## Updated Cognitive Model
 
-**Before discover_tags**:
+**Before the shift**:
 
-1. User: "Fix tag-ref HTTPS failure"
-2. LLM guesses: `[bug, ci]` maybe? Or `[bugs, ci]`? Or `[bug, github-actions]`?
-3. Result: Near-duplicates, inconsistency
+1. LLM calls `discover_tags()`
+2. Sees a broad tag inventory with usage counts and examples
+3. Infers which tags are probably relevant
+4. Risks distraction from many unrelated tags and large payloads
 
-**After discover_tags**:
+**After the shift**:
 
-1. LLM calls discover_tags()
-2. Sees: `bug` (12 uses), `bugs` (2 uses) → picks `bug`
-3. Sees: `ci` used with `github-actions` for CI bugs → uses both
-4. Sees example "ci-create-release checkout fails..." → matches pattern
-5. Suggests: `[ci, github-actions, bug, release]` (informed choice)
+1. LLM calls `discover_tags()` with note context
+2. Tool narrows candidates to tags relevant to that note
+3. Tool boosts canonical tags by usage count
+4. Tool returns a compact ranked list plus minimal evidence
+5. LLM chooses from a smaller, more trustworthy set
 
-## Why It's "Accurate Enough"
+## Why This Better Serves the Original Goal
 
-✅ Shows actual usage, not theoretical taxonomy  
-✅ Provides concrete examples for pattern matching  
-✅ Surfaces canonical terms via usage count  
-✅ Reveals co-occurrence clusters (what tags appear together)  
-✅ Distinguishes durable knowledge from scaffolding  
+The original goal was not to expose every existing tag. It was to help the LLM avoid inventing or overusing unrelated tags.
 
-The LLM's strength is pattern recognition, not semantic reasoning. discover_tags shows the LLM what good tagging looks like in this specific project, and the LLM pattern-matches against those examples.
+A note-oriented `discover_tags` serves that goal better because it:
 
-## Example Output Analysis
+- reduces irrelevant tags in context
+- preserves canonical vocabulary signals
+- keeps payload size manageable
+- still gives enough evidence for confident pattern matching
 
-```json
-{
-  "tag": "ci",
-  "usageCount": 8,
-  "examples": [
-    "ci-create-release checkout fails fetching tag-ref over https",
-    "ci-safe MCP integration and failure learning workflow",
-    "GitHub Packages publishing and CI workflow"
-  ],
-  "lifecycleTypes": ["permanent"],
-  "isTemporaryOnly": false
-}
-```
-
-What LLM learns:
-
-- `ci` is canonical (8 uses, high confidence)
-- It's for GitHub Actions infrastructure (examples show workflows)
-- It's serious/permanent (not temporary scaffolding)
-- Use it for: CI failures, workflow improvements, integration issues
-
-No semantic reasoning needed—just "notes like this use this tag."
+The LLM's strength is still pattern recognition, not deep semantic reasoning. The improvement is that pattern matching now happens over a relevant candidate set instead of the entire tag corpus.

--- a/.mnemonic/notes/tag-discovery-cognitive-model-how-llms-use-usage-statistics--2aa53468.md
+++ b/.mnemonic/notes/tag-discovery-cognitive-model-how-llms-use-usage-statistics--2aa53468.md
@@ -9,7 +9,7 @@ tags:
   - llm-behavior
 lifecycle: permanent
 createdAt: '2026-03-15T13:47:29.424Z'
-updatedAt: '2026-03-23T20:43:28.540Z'
+updatedAt: '2026-03-23T21:41:41.269Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 memoryVersion: 1
@@ -80,3 +80,12 @@ A note-oriented `discover_tags` serves that goal better because it:
 - still gives enough evidence for confident pattern matching
 
 The LLM's strength is still pattern recognition, not deep semantic reasoning. The improvement is that pattern matching now happens over a relevant candidate set instead of the entire tag corpus.
+
+## Specificity-first ranking update
+
+`discover_tags` suggestion mode now prefers specificity when direct lexical evidence exists in the note context.
+
+- exact tag-name matches outweigh broad high-frequency tags
+- token overlap and note-context overlap outrank raw popularity
+- usage count remains a secondary canonicality signal rather than the dominant ranking factor
+- when no strong specific candidate exists, ranking falls back toward broader canonical tags instead of returning a full inventory dump

--- a/.mnemonic/notes/tag-discovery-system-performance-conscious-design-and-implem-3d545409.md
+++ b/.mnemonic/notes/tag-discovery-system-performance-conscious-design-and-implem-3d545409.md
@@ -9,32 +9,67 @@ tags:
   - implemented
 lifecycle: permanent
 createdAt: '2026-03-15T13:43:54.754Z'
-updatedAt: '2026-03-15T15:05:48.647Z'
+updatedAt: '2026-03-23T20:43:53.480Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 memoryVersion: 1
 ---
 ## Current State
 
-The labeling system in mnemonic currently uses vault labels and note tags in an ad-hoc manner. Tagging success depends on consistent terminology across sessions (e.g., "bug" vs "bugs" vs "bugfix").
+The labeling system in mnemonic currently uses vault labels and note tags in an ad-hoc manner. Tagging success depends on consistent terminology across sessions (e.g., `bug` vs `bugs` vs `bugfix`).
 
 ## Implementation Status
 
 **Phase 1: IMPLEMENTED** ✅
 
-The `discover_tags` MCP tool is now available in `src/index.ts` with:
+The current `discover_tags` MCP tool is available in `src/index.ts` with:
 
 - Input parameters: `cwd`, `scope`, `storedIn` (matching `list` tool semantics)
-- Output: Tags sorted by usageCount with examples, lifecycleTypes, and isTemporaryOnly flag
+- Output: tags sorted by usageCount with examples, lifecycleTypes, and isTemporaryOnly flag
 - structuredContent schema in `src/structured-content.ts`
 - Integration test coverage in `tests/mcp.integration.test.ts`
 - Performance telemetry: `durationMs` in response
+
+## Updated Design Direction
+
+The current implementation proved the value of canonical tag discovery, but its broad structured output can become too large and can expose many unrelated tags to the model.
+
+**New direction:** keep the tool name `discover_tags`, but make its default behavior note-oriented rather than corpus-oriented.
+
+### Default behavior should become compact and note-specific
+
+The caller should provide note context such as:
+
+- `title`
+- `content`
+- `query`
+- optional candidate tags
+
+The tool should then return ranked canonical tag suggestions for that note instead of the entire tag inventory.
+
+### Ranking principle
+
+Rank by:
+
+1. relevance to the note context
+2. usage count as a canonicality boost
+3. lifecycle distribution as a quality signal
+
+This preserves the original anti-fragmentation goal without overwhelming the agent with unrelated but common tags.
+
+### Output principle
+
+Default structured output should be compact:
+
+- recommended tags for the note
+- small evidence payload, such as one example title or a short reason
+- no full corpus-wide tag dump unless broad browsing is explicitly requested
 
 ## Performance-Safe Design Decisions
 
 ### Current Recall Performance Model
 
-Recall flow from ARCHITECTURE.md and recall.ts:
+Recall flow from `ARCHITECTURE.md` and `recall.ts`:
 
 1. Embed query via Ollama (50-200ms)
 2. Load embeddings from disk (I/O bound)
@@ -46,7 +81,7 @@ Recall flow from ARCHITECTURE.md and recall.ts:
 
 ### Tag Discovery Impact
 
-**discover_tags workflow**:
+**Current discover_tags workflow**:
 
 - List note IDs from vaults (disk scan)
 - Read each note to extract tags (parallel I/O)
@@ -62,218 +97,66 @@ Performance data:
 
 ### Critical Design Choice: Manual Tool
 
-**Rejected**: Auto-run tag discovery before every remember
+**Rejected**: Auto-run tag discovery before every `remember`
 
 - Would add 100ms-2s latency to each write
 - Violates MCP ergonomics principle
 
-**Accepted**: MCP tool discover_tags that agent calls intentionally
+**Accepted**: MCP tool `discover_tags` that the agent calls intentionally
 
 - Agent decides when tag discovery adds value
-- Typically: before first remember in session or for new topics
-- Keeps performance predictable
+- Tag discovery should be used when tag choice is ambiguous, not as a mandatory pre-step for every write
+- Keeps performance predictable and output bounded
 
 ### No Recall Algorithm Changes
 
 **Rejected**: Boost recall scores based on tag embeddings
 
-- Would require comparing query to note embeddings AND tag embeddings
-- Adds complexity to lightweight heuristic
+- Would require comparing query to note embeddings and tag embeddings
+- Adds complexity to the lightweight heuristic
 
-**Accepted**: Tag discovery for query expansion only
+**Accepted**: note-oriented tag suggestion without redesigning recall
 
-- Agent manually: discover similar tags → add to query → run recall
-- Example: discover shows "bug", "bugs", "bugfix" used → agent queries all three
-- Preserves simple recall algorithm
+- The tool can use note context to rank canonical tags
+- Recall stays focused on note retrieval, not tag-taxonomy management
+- This preserves the simple recall algorithm while improving write-time guidance
 
-## Implementation: Phase 1 (Now) ✅
+## Current Implementation: Phase 1 ✅
 
-### New MCP Tool: discover_tags
+### Current MCP Tool
 
-```typescript
-server.registerTool("discover_tags", {
-  title: "Discover Tags",
-  description:
-    "Discover existing tags across vaults with usage statistics and examples.\n\n" +
-    "Use this when:\n" +
-    "- Before `remember` to find canonical tag names for consistent terminology\n" +
-    "- Starting a new topic and unsure which tags exist (e.g., 'bug' vs 'bugs')\n" +
-    "- Identifying tags only on temporary notes (cleanup candidates)\n\n" +
-    "Do not use this when:\n" +
-    "- You need to browse notes by tag; use `list` with `tags` filter instead\n" +
-    "- You already know the exact tags you want to use\n\n" +
-    "Returns:\n" +
-    "- Tags sorted by usageCount (canonical tags first)\n" +
-    "- Example note titles (up to 3 per tag) showing usage context\n" +
-    "- lifecycleTypes showing temporary vs permanent distribution\n" +
-    "- isTemporaryOnly flag identifying cleanup candidates\n\n" +
-    "Typical next step:\n" +
-    "- Use canonical tags from discover_tags when appropriate, or create new tags when genuinely novel.\n\n" +
-    "Performance: O(n) where n = total notes scanned. Expect 100-200ms for 500 notes.\n\n" +
-    "Read-only.",
-  inputSchema: z.object({
-    cwd: projectParam,
-    scope: z.enum(["project", "global", "all"]).optional().default("all"),
-    storedIn: z.enum(["project-vault", "main-vault", "any"]).optional().default("any"),
-  }),
-  outputSchema: DiscoverTagsResultSchema,
-});
-```
+The current implementation is still corpus-oriented and returns vault-wide tag statistics. That remains useful as the starting point, but it should now be treated as an intermediate step rather than the final design.
 
-Workflow integration:
+Workflow intent:
 
-- Before `remember`, agent calls `discover_tags` with proposed title/content
-- Gets existing tags sorted by usage/relevance
-- Intelligently decides: reuse existing tag, create new, or consolidate synonyms
+- Agent provides proposed note context
+- Tool returns a compact set of relevant canonical tags
+- Agent reuses existing tags or creates a new tag only when genuinely novel
 
-Returns duration metric for performance monitoring.
+## Future Direction
 
-### Implemented Features
+### Phase 2: Note-Oriented Suggestions
 
-**discover_tags workflow** (implemented in `src/index.ts`):
+Evolve `discover_tags` so that the default mode accepts note context and returns a compact ranked set of canonical tag suggestions.
 
-1. Query all notes from relevant vaults (respecting scope and storedIn)
-2. Extract and count tag usage with stats:
-   - usageCount: how many notes use this tag
-   - examples: 2-3 note titles for context
-   - lifecycleTypes: temporary vs permanent distribution
-   - isTemporaryOnly: true if tag only appears on temporary notes
-3. Sort by usageCount descending
-4. Return with performance telemetry (durationMs)
+This phase should also tighten tool descriptions and related documentation so the project consistently describes `discover_tags` as a note-oriented suggestion tool rather than a general tag dump.
 
-Performance characteristics:
+### Broad Browsing Remains Explicit
 
-- Leverages existing Storage parallel read optimizations
-- O(n) where n = total notes scanned
-- Acceptable for typical vault sizes
-
-## Phase 2: Tag Embeddings (Optional Future)
-
-### Architecture
-
-Separate tag embedding index:
-
-```typescript
-interface TagEmbeddingIndex {
-  model: string;
-  updatedAt: string;
-  tags: Array<{
-    tag: string;
-    embedding: number[];
-    appearsIn: string[];  // note ids
-    lifecycleDistribution: { temporary: number; permanent: number };
-  }>;
-}
-```
-
-Stored at: `~/mnemonic-vault/tag-embeddings.json`
-
-**Characteristics**:
-
-- Size: ~200 tags × 1024 dims × 4 bytes ≈ 800KB
-- Load time: ~10-20ms (one-time per session)
-- Updated during sync (like note embeddings)
-- Not loaded automatically for every discover_tags call
-
-### When to Implement Phase 2
-
-**Triggers**:
-
-- discover_tags routinely takes >1s for typical use cases
-- Tag fragmentation persists despite Phase 1
-- User explicitly requests semantic suggestions
-
-**Benefits**:
-
-- Suggests "testing" when writing about "QA" or "quality assurance"
-- Finds related concepts across different terminology
-- Reduces manual tag discovery effort
-
-### Suggestion Algorithm
-
-Extended discover_tags with semantic matching:
-
-```typescript
-interface DiscoverTagsInput {
-  // ... existing fields
-  suggestFor?: string;  // Note content to match against
-}
-
-// When suggestFor is provided:
-1. Embed the suggestion text
-2. Compare against tag embedding index
-3. Return top matches with similarity scores
-4. Include exact matches first
-```
-
-## Phase 3: Structured Taxonomy (Optional Future)
-
-### Project-Specific Tag Categories
-
-Optional taxonomy hints in project memory policy:
-
-```typescript
-interface TagTaxonomyHints {
-  categories: Array<{
-    name: string;
-    description: string;
-    suggestedTags: string[];
-    appliesWhen?: string[];
-  }>;
-}
-```
-
-Example for mnemonic:
-
-```typescript
-{
-  categories: [
-    {
-      name: "Architecture",
-      description: "Design decisions and system structure",
-      suggestedTags: ["architecture", "design", "decision", "performance"],
-      appliesWhen: ["design", "architecture", "system"]
-    },
-    {
-      name: "Quality",
-      description: "Bugs, testing, quality-related work",
-      suggestedTags: ["bug", "testing", "ci", "dogfooding"],
-      appliesWhen: ["bug", "test", "quality"]
-    }
-  ]
-}
-```
-
-### Integration
-
-Extended discover_tags to include category hints when available, helping agents understand project-specific vocabulary.
+If full corpus browsing remains useful for administration or manual exploration, it should be an explicit mode rather than the default experience.
 
 ## Benefits
 
-1. **Consistency**: Reduces tag fragmentation (bug/bugs/bugfix → single "bug")
-2. **Discovery**: Helps agents find related content across semantically similar tags
-3. **Cleanup**: Identifies tags only on temporary notes
-4. **Onboarding**: New team members discover project vocabulary quickly
-5. **Performance**: No impact on recall algorithm or hot paths
-
-## Performance Monitoring
-
-Add telemetry to discover_tags:
-
-- notes_scanned: counter (via totalNotes in response)
-- duration_ms: timer (via durationMs in response)  
-- unique_tags_found: gauge (via totalTags in response)
-
-**Thresholds**:
-
-- <500ms: Excellent
-- 500ms-1s: Acceptable
-- >1s: Consider optimization or Phase 2
+1. **Consistency**: reduces tag fragmentation (`bug`/`bugs`/`bugfix` → canonical choice)
+2. **Relevance**: avoids flooding the agent with unrelated tags
+3. **Compactness**: reduces token-heavy structured output
+4. **Confidence**: still gives enough evidence to trust suggested tags
+5. **Performance**: keeps recall unchanged and preserves explicit invocation
 
 ## Alignment with Architecture Principles
 
-✅ Lightweight heuristic preserved (recall unchanged)
+✅ Lightweight heuristic preserved (`recall` unchanged)
 ✅ MCP ergonomics maintained (explicit tool, not automatic)
-✅ Simple to evolve (phased implementation)
-✅ File-first correctness (no new services)
-✅ Performance tenable (manual invocation, clear boundaries)
+✅ Better bounded outputs for LLM consumers
+✅ Original anti-hallucination goal preserved
+✅ Documentation and agent guidance can be tightened around the new contract

--- a/.mnemonic/notes/tag-discovery-system-performance-conscious-design-and-implem-3d545409.md
+++ b/.mnemonic/notes/tag-discovery-system-performance-conscious-design-and-implem-3d545409.md
@@ -9,7 +9,7 @@ tags:
   - implemented
 lifecycle: permanent
 createdAt: '2026-03-15T13:43:54.754Z'
-updatedAt: '2026-03-23T20:43:53.480Z'
+updatedAt: '2026-03-23T21:42:26.536Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 memoryVersion: 1
@@ -160,3 +160,14 @@ If full corpus browsing remains useful for administration or manual exploration,
 ✅ Better bounded outputs for LLM consumers
 ✅ Original anti-hallucination goal preserved
 ✅ Documentation and agent guidance can be tightened around the new contract
+
+## Specificity tuning follow-up
+
+After dogfooding the first note-oriented release, scoring was rebalanced toward specificity because broad tags were still dominating the top results for clearly scoped prompts.
+
+- stronger exact-match boost for tags named directly in the note context
+- lower usage-count weight so popularity acts as a tie-breaker rather than the primary ranking signal
+- average per-note context match is used instead of letting large broad tag clusters dominate via raw totals
+- conditional generic-tag penalty for broad high-frequency single-token tags when a strong specific candidate exists
+- generic prompts fall back toward broader canonical tags instead of returning full inventory output
+- browse mode remains unchanged and inventory-oriented

--- a/.mnemonic/notes/tag-discovery-system-performance-conscious-design-and-implem-3d545409.md
+++ b/.mnemonic/notes/tag-discovery-system-performance-conscious-design-and-implem-3d545409.md
@@ -9,7 +9,7 @@ tags:
   - implemented
 lifecycle: permanent
 createdAt: '2026-03-15T13:43:54.754Z'
-updatedAt: '2026-03-23T21:42:26.536Z'
+updatedAt: '2026-03-24T06:11:13.001Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 memoryVersion: 1
@@ -171,3 +171,12 @@ After dogfooding the first note-oriented release, scoring was rebalanced toward 
 - conditional generic-tag penalty for broad high-frequency single-token tags when a strong specific candidate exists
 - generic prompts fall back toward broader canonical tags instead of returning full inventory output
 - browse mode remains unchanged and inventory-oriented
+
+## Generalized heuristic rule
+
+The final tuning was validated against a synthetic sparse-project scenario as well as this repository's own corpus.
+
+- exact matches on genuinely specific tags should trigger specificity-heavy ranking even if the tag exists only once
+- generic prompts should continue to use the broad canonical fallback path
+- broad one-off exact matches should not be enough to flip the entire ranking into specificity mode
+- this keeps the heuristic useful both for mature repos with many tags and for smaller projects with sparse tag histories

--- a/AGENT.md
+++ b/AGENT.md
@@ -23,9 +23,10 @@ Before doing any substantive work:
 ### Before capturing
 
 Before calling `remember`:
-1. **Discover canonical tags** — call `discover_tags` with `cwd` to find existing tag terminology (e.g., is "bug" or "bugs" canonical in this project?).
-   - Use high-usageCount tags for consistency.
+1. **Discover canonical tags when needed** — if tag choice is ambiguous, call `discover_tags` with `cwd` plus note context (`title`, `content`, or `query`) to get compact, note-specific suggestions.
+   - Prefer suggested high-usage tags when they fit the note.
    - Use `isTemporaryOnly: true` tags cautiously — they may be cleanup candidates.
+   - Use `mode: "browse"` only when you intentionally need broader inventory output.
    - Create new tags when genuinely novel, but prefer canonical forms when they exist.
 2. `recall` first — if a related note exists, call `update` instead to avoid fragmentation.
 2. If you've made several closely-related captures in this session, consider `consolidate` before wrapping up.
@@ -245,7 +246,7 @@ Keep these high-level anchors in mind:
 |------|-------------|
 | `consolidate` | Merge multiple notes into one with relationship to sources |
 | `detect_project` | Resolve `cwd` to stable project id via git remote URL |
-| `discover_tags` | List existing tags with usage counts and examples for consistent terminology |
+| `discover_tags` | Suggest canonical tags for a note; `mode: "browse"` opts into broader inventory output |
 | `execute_migration` | Execute a named migration (supports dry-run) |
 | `forget` | Delete note + embedding, git commit + push, cleanup relationships |
 | `get` | Fetch one or more notes by exact id; `includeRelationships: true` adds bounded 1-hop relationship previews |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 - `RecallResult.results` entries now include an optional `relationships` field (`RelationshipPreview`).
 - `GetResult.notes` entries now include an optional `relationships` field (`RelationshipPreview`).
 - `OrientationNote` now includes an optional `relationships` field (`RelationshipPreview`).
+- `discover_tags` now defaults to note-oriented tag suggestions using title/content/query context, returning bounded `recommendedTags`; broader inventory output is now explicit via `mode: "browse"`.
 
 ## [0.15.0] - 2026-03-23
 

--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ Imported notes are written to the main vault with `lifecycle: permanent` and `sc
 |-----------------------------|--------------------------------------------------------------------------|
 | `consolidate`               | Merge multiple notes into one with relationship to sources               |
 | `detect_project`            | Resolve `cwd` to stable project id via git remote URL                   |
-| `discover_tags`            | List existing tags with usage counts and examples for consistent terminology |
+| `discover_tags`            | Suggest canonical tags for a note using title/content/query context; `mode: "browse"` opts into broader inventory output |
 | `execute_migration`         | Execute a named migration (supports dry-run)                             |
 | `forget`                    | Delete note + embedding, git commit + push, cleanup relationships        |
 | `get`                       | Fetch one or more notes by exact id; `includeRelationships: true` adds bounded 1-hop previews |

--- a/docs/index.html
+++ b/docs/index.html
@@ -1455,9 +1455,9 @@
             <div class="tool-card-name">recent_memories</div>
             <div class="tool-card-purpose">Pick up where you left off</div>
           </div>
-          <div class="tool-card" data-tip="Find which tags already exist in a project before creating a new memory. Shows usage counts, example notes, and which tags are only on temporary notes — helps keep terminology consistent across sessions.">
+          <div class="tool-card" data-tip="Suggests canonical tags for a specific note before you create a memory. Pass note context such as a title or content snippet to get compact, relevant suggestions; use browse mode only when you intentionally want broader inventory output.">
             <div class="tool-card-name">discover_tags</div>
-            <div class="tool-card-purpose">Find canonical tags before you write</div>
+            <div class="tool-card-purpose">Suggest canonical tags for a note</div>
           </div>
         </div>
       </div>

--- a/docs/superpowers/plans/2026-03-23-discover-tags-note-oriented-redesign.md
+++ b/docs/superpowers/plans/2026-03-23-discover-tags-note-oriented-redesign.md
@@ -1,0 +1,202 @@
+# Discover Tags Note-Oriented Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Redesign `discover_tags` so it suggests compact, note-specific canonical tags by default and align the code, tests, and docs with that behavior.
+
+**Architecture:** Keep the existing tool name and vault-scan implementation, but change the contract from corpus inventory to note-oriented ranking. The tool should accept note context, compute per-tag statistics across visible notes, rank tags by note relevance plus canonicality signals, and return a bounded `recommendedTags` payload by default while still supporting explicit broad browsing.
+
+**Tech Stack:** TypeScript, Zod, Vitest, MCP SDK, markdown docs
+
+---
+
+### Task 1: Lock down the new discover_tags contract in tests
+
+**Files:**
+- Modify: `tests/mcp.integration.test.ts`
+- Modify: `src/structured-content.ts`
+
+- [ ] **Step 1: Write the failing integration assertions for note-oriented tag suggestions**
+
+Add a new `discover_tags` integration test that passes note context (`title` and `content`) and asserts:
+- `recommendedTags` exists and is bounded
+- relevant tags like `test-tag` and `discovery` are suggested
+- irrelevant tags are not required to be present
+- response text describes note-oriented suggestions, not a full corpus dump
+
+Example assertion target:
+
+```ts
+expect(structured?.["recommendedTags"]).toEqual(
+  expect.arrayContaining([
+    expect.objectContaining({ tag: "test-tag", usageCount: 2 }),
+  ])
+);
+expect((structured?.["recommendedTags"] as unknown[]).length).toBeLessThanOrEqual(10);
+```
+
+- [ ] **Step 2: Run the targeted test to verify it fails**
+
+Run: `npm test -- tests/mcp.integration.test.ts`
+Expected: FAIL because `discover_tags` does not yet accept note context or return `recommendedTags`
+
+- [ ] **Step 3: Write the failing browse-mode contract test**
+
+Add a second test that calls `discover_tags` with `mode: "browse"` and asserts the broad inventory output remains explicit and discoverable.
+
+Example assertion target:
+
+```ts
+expect(structured?.["mode"]).toBe("browse");
+expect(structured?.["tags"]).toEqual(
+  expect.arrayContaining([
+    expect.objectContaining({ tag: "discovery" }),
+  ])
+);
+```
+
+- [ ] **Step 4: Run the targeted test file again and keep it red for the right reason**
+
+Run: `npm test -- tests/mcp.integration.test.ts`
+Expected: FAIL only on missing `discover_tags` behavior, not on test syntax or unrelated tooling
+
+### Task 2: Implement note-oriented discover_tags behavior
+
+**Files:**
+- Modify: `src/index.ts`
+- Modify: `src/structured-content.ts`
+
+- [ ] **Step 1: Define the structured contract in code**
+
+Implement a result shape with these expectations:
+- default mode is `"suggest"`
+- `recommendedTags` is required in suggest mode and bounded to a small list (target: 10 max)
+- each recommended tag includes `tag`, `usageCount`, `lifecycleTypes`, `isTemporaryOnly`, and one compact evidence field (`example` or `reason`)
+- summary counters remain available (`totalTags`, `totalNotes`, `durationMs`)
+- explicit `mode: "browse"` returns the broader `tags` inventory payload
+
+- [ ] **Step 2: Implement the minimal schema changes**
+
+Move `src/structured-content.ts` to the new contract only after the tests are red.
+
+- [ ] **Step 3: Extend the tool input schema**
+
+Add note-oriented inputs such as:
+- `title?: string`
+- `content?: string`
+- `query?: string`
+- `candidateTags?: string[]`
+- optional browse escape hatch such as `mode?: "suggest" | "browse"`
+
+- [ ] **Step 4: Implement tag ranking from note context**
+
+Build the minimal ranking logic that:
+- computes existing per-tag stats from visible notes
+- scores tags by textual relevance to note context first
+- uses `usageCount` as a tie-breaker / boost
+- demotes temp-only tags when the target note is not temporary
+
+- [ ] **Step 5: Return compact structured output by default**
+
+Update the result shape to expose bounded suggestions such as:
+- `recommendedTags`
+- optional compact metadata for why each was chosen
+- summary counts for searched notes/tags
+
+Avoid returning the full `tags` corpus by default in suggest mode.
+
+- [ ] **Step 6: Preserve explicit broad browsing**
+
+If `mode: "browse"` is supplied, continue to surface broader inventory data in a clearly opt-in shape.
+
+- [ ] **Step 7: Run the targeted integration test and make it green**
+
+Run: `npm test -- tests/mcp.integration.test.ts`
+Expected: PASS
+
+- [ ] **Step 8: Commit the code and test changes**
+
+```bash
+git add tests/mcp.integration.test.ts src/index.ts src/structured-content.ts
+git commit -m "feat: make discover_tags note-oriented by default"
+```
+
+### Task 3: Tighten guidance and public docs
+
+**Files:**
+- Modify: `src/index.ts`
+- Modify: `README.md`
+- Modify: `AGENT.md`
+- Modify: `docs/index.html`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Update tool descriptions and workflow hint wording**
+
+Describe `discover_tags` as a note-oriented canonical tag suggestion tool. Make broad inventory browsing explicitly optional.
+
+- [ ] **Step 2: Update agent guidance**
+
+Change `AGENT.md` so `discover_tags` is used when tag choice is ambiguous for a note, not as a blanket pre-step.
+
+- [ ] **Step 3: Update reader-facing docs**
+
+Refresh the tool tables and homepage copy so they no longer promise a full tag listing as the default workflow.
+
+- [ ] **Step 4: Add a brief changelog entry**
+
+Document the user-visible behavior shift in concise release-note language.
+
+- [ ] **Step 5: Commit the documentation changes**
+
+```bash
+git add README.md AGENT.md docs/index.html CHANGELOG.md src/index.ts
+git commit -m "docs: describe note-oriented discover_tags"
+```
+
+### Task 4: Verify end-to-end behavior
+
+**Files:**
+- Modify: `tests/mcp.integration.test.ts`
+
+- [ ] **Step 1: Run targeted verification**
+
+Run: `npm test -- tests/mcp.integration.test.ts`
+Expected: PASS
+
+- [ ] **Step 2: Run build verification**
+
+Run: `npm run build`
+Expected: PASS
+
+- [ ] **Step 3: Sanity-check local MCP metadata if needed**
+
+Run: `npm run mcp:local`
+Expected: tool metadata and docs wording reflect note-oriented `discover_tags`
+
+- [ ] **Step 4: Dogfood the change through the local MCP flow**
+
+Start the local server:
+
+```bash
+npm run mcp:local
+```
+
+Then call `tools/call` for `discover_tags` with note context using the same stdio JSON-RPC flow exercised in `tests/mcp.integration.test.ts`, for example with arguments shaped like:
+
+```json
+{
+  "title": "Fix MCP prompt wording",
+  "content": "Tighten workflow guidance for weaker models and avoid duplicate remember calls.",
+  "scope": "project"
+}
+```
+
+Expected pass criteria:
+- the response reports `mode: "suggest"`
+- `recommendedTags` is present and bounded
+- it includes relevant tags such as `mcp`, `workflow`, or `prompt`
+- it does not include a full broad `tags` inventory unless `mode: "browse"` is explicitly requested
+
+- [ ] **Step 5: Summarize behavior changes and any follow-up migration concerns**
+
+Call out whether clients depending on the old `tags` payload need explicit browse mode or compatibility handling.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2909,6 +2909,11 @@ function countTokenOverlap(tokens: Set<string>, other: Iterable<string>): number
   return matches;
 }
 
+function hasExactTagContextMatch(tag: string, values: Array<string | undefined>): boolean {
+  const normalizedTag = tag.toLowerCase();
+  return values.some(value => value?.toLowerCase().includes(normalizedTag) ?? false);
+}
+
 server.registerTool(
   "discover_tags",
   {
@@ -2970,7 +2975,8 @@ server.registerTool(
 
     const tagStats = new Map<string, DiscoverTagStat>();
     const candidateTagSet = new Set((candidateTags || []).map(tag => tag.toLowerCase()));
-    const contextTokens = new Set(tokenizeTagDiscoveryText([title, content, query, ...(candidateTags || [])].filter(Boolean).join(" ")));
+    const contextValues = [title, content, query, ...(candidateTags || [])];
+    const contextTokens = new Set(tokenizeTagDiscoveryText(contextValues.filter(Boolean).join(" ")));
     const isTemporaryTarget = lifecycle === "temporary";
     const effectiveLimit = limit ?? (mode === "browse" ? 20 : 10);
 
@@ -2999,20 +3005,17 @@ server.registerTool(
       }
     }
 
-    const tags = Array.from(tagStats.entries())
+    const rawTags = Array.from(tagStats.entries())
       .map(([tag, stats]) => {
         const lifecycleTypes = Array.from(stats.lifecycles) as NoteLifecycle[];
         const isTemporaryOnly = stats.lifecycles.size === 1 && stats.lifecycles.has("temporary");
+        const tagTokens = tokenizeTagDiscoveryText(tag);
+        const exactContextMatch = stats.exactCandidateMatch || hasExactTagContextMatch(tag, contextValues);
         const tagTokenOverlap = contextTokens.size > 0
-          ? countTokenOverlap(contextTokens, tokenizeTagDiscoveryText(tag))
+          ? countTokenOverlap(contextTokens, tagTokens)
           : 0;
-        const score =
-          (stats.exactCandidateMatch ? 8 : 0) +
-          (tagTokenOverlap * 4) +
-          (stats.contextMatches * 2) +
-          (stats.count * 0.25) -
-          (!isTemporaryTarget && isTemporaryOnly ? 2 : 0);
-        const reason = stats.exactCandidateMatch
+        const averageContextMatch = stats.count > 0 ? stats.contextMatches / stats.count : 0;
+        const reason = exactContextMatch
           ? "matches a candidate tag already present in the note context"
           : tagTokenOverlap > 0 || stats.contextMatches > 0
             ? "matches the note context and existing project usage"
@@ -3026,6 +3029,38 @@ server.registerTool(
           reason,
           lifecycleTypes,
           isTemporaryOnly,
+          exactContextMatch,
+          tagTokenOverlap,
+          averageContextMatch,
+          isBroadSingleToken: tagTokens.length === 1,
+          isHighFrequency: stats.count >= 4,
+          specificityBoost: tagTokens.length > 1 ? 4 : 0,
+        };
+      });
+
+    const hasStrongSpecificCandidate = rawTags.some(tag => tag.exactContextMatch || tag.tagTokenOverlap >= 2);
+
+    const tags = rawTags
+      .map((tag) => {
+        const hasWeakDirectMatch = tag.tagTokenOverlap <= 1 && tag.averageContextMatch <= 2;
+        const genericPenalty = hasStrongSpecificCandidate && tag.isBroadSingleToken && tag.isHighFrequency && hasWeakDirectMatch
+          ? 10
+          : 0;
+        const score = hasStrongSpecificCandidate
+          ? (tag.exactContextMatch ? 12 : 0) +
+            (tag.tagTokenOverlap * 5) +
+            tag.specificityBoost +
+            (tag.averageContextMatch * 3) +
+            (tag.usageCount * 0.1) -
+            genericPenalty -
+            (!isTemporaryTarget && tag.isTemporaryOnly ? 2 : 0)
+          : (tag.usageCount * 0.6) +
+            (tag.tagTokenOverlap * 1.5) +
+            (tag.averageContextMatch * 0.5) -
+            (!isTemporaryTarget && tag.isTemporaryOnly ? 2 : 0);
+
+        return {
+          ...tag,
           score,
         };
       })

--- a/src/index.ts
+++ b/src/index.ts
@@ -3038,7 +3038,9 @@ server.registerTool(
         };
       });
 
-    const hasStrongSpecificCandidate = rawTags.some(tag => tag.exactContextMatch || tag.tagTokenOverlap >= 2);
+    const hasStrongSpecificCandidate = rawTags.some(tag =>
+      tag.exactContextMatch && (!tag.isBroadSingleToken || tag.usageCount > 1)
+    );
 
     const tags = rawTags
       .map((tag) => {
@@ -3054,9 +3056,8 @@ server.registerTool(
             (tag.usageCount * 0.1) -
             genericPenalty -
             (!isTemporaryTarget && tag.isTemporaryOnly ? 2 : 0)
-          : (tag.usageCount * 0.6) +
-            (tag.tagTokenOverlap * 1.5) +
-            (tag.averageContextMatch * 0.5) -
+          : (tag.usageCount * 1.5) +
+            (tag.isTemporaryOnly ? -3 : 1) -
             (!isTemporaryTarget && tag.isTemporaryOnly ? 2 : 0);
 
         return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2884,26 +2884,51 @@ server.registerTool(
 );
 
 // ── discover_tags ───────────────────────────────────────────────────────────
+type DiscoverTagStat = {
+  count: number;
+  examples: string[];
+  lifecycles: Set<NoteLifecycle>;
+  contextMatches: number;
+  exactCandidateMatch: boolean;
+};
+
+function tokenizeTagDiscoveryText(value: string): string[] {
+  return value
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+function countTokenOverlap(tokens: Set<string>, other: Iterable<string>): number {
+  let matches = 0;
+  for (const token of other) {
+    if (tokens.has(token)) {
+      matches++;
+    }
+  }
+  return matches;
+}
+
 server.registerTool(
   "discover_tags",
   {
     title: "Discover Tags",
     description:
-      "Discover existing tags across vaults with usage statistics and examples.\n\n" +
+      "Suggest canonical tags for a specific note before `remember` when tag choice is ambiguous.\n\n" +
       "Use this when:\n" +
-      "- Before `remember` to find canonical tag names for consistent terminology\n" +
-      "- Starting a new topic and unsure which tags exist (e.g., 'bug' vs 'bugs')\n" +
-      "- Identifying tags only on temporary notes (cleanup candidates)\n\n" +
+      "- You have a note title, content, or query and want compact tag suggestions\n" +
+      "- You want canonical project terminology without exposing lots of unrelated tags\n" +
+      "- You want to demote temporary-only tags unless they fit the note\n\n" +
       "Do not use this when:\n" +
       "- You need to browse notes by tag; use `list` with `tags` filter instead\n" +
-      "- You already know the exact tags you want to use\n\n" +
+      "- You already know the exact tags you want to use\n" +
+      "- You want broad inventory output but are not explicitly requesting `mode: \"browse\"`\n\n" +
       "Returns:\n" +
-      "- Tags sorted by usageCount (canonical tags first)\n" +
-      "- Example note titles (up to 3 per tag) showing usage context\n" +
-      "- lifecycleTypes showing temporary vs permanent distribution\n" +
-      "- isTemporaryOnly flag identifying cleanup candidates\n\n" +
+      "- Default: bounded `recommendedTags` ranked by note relevance first and usage count second\n" +
+      "- Each suggestion includes canonicality and lifecycle signals plus one compact example\n" +
+      "- Optional `mode: \"browse\"` returns broader inventory output\n\n" +
       "Typical next step:\n" +
-      "- Use canonical tags from discover_tags when appropriate, or create new tags when genuinely novel.\n\n" +
+      "- Reuse suggested canonical tags when they fit, or create a new tag only when genuinely novel.\n\n" +
       "Performance: O(n) where n = total notes scanned. Expect 100-200ms for 500 notes.\n\n" +
       "Read-only.",
     annotations: {
@@ -2913,6 +2938,12 @@ server.registerTool(
     },
     inputSchema: z.object({
       cwd: projectParam,
+      mode: z.enum(["suggest", "browse"]).optional().default("suggest"),
+      title: z.string().optional(),
+      content: z.string().optional(),
+      query: z.string().optional(),
+      candidateTags: z.array(z.string()).optional(),
+      lifecycle: z.enum(NOTE_LIFECYCLES).optional(),
       scope: z
         .enum(["project", "global", "all"])
         .optional()
@@ -2927,72 +2958,151 @@ server.registerTool(
         .optional()
         .default("any")
         .describe("Filter by vault storage label like list tool."),
+      limit: z.number().int().min(1).max(50).optional(),
     }),
     outputSchema: DiscoverTagsResultSchema,
   },
-  async ({ cwd, scope, storedIn }) => {
+  async ({ cwd, mode, title, content, query, candidateTags, lifecycle, scope, storedIn, limit }) => {
     await ensureBranchSynced(cwd);
     const startTime = Date.now();
 
     const { project, entries } = await collectVisibleNotes(cwd, scope, undefined, storedIn);
 
-    const tagStats = new Map<string, { count: number; examples: string[]; lifecycles: Set<NoteLifecycle> }>();
+    const tagStats = new Map<string, DiscoverTagStat>();
+    const candidateTagSet = new Set((candidateTags || []).map(tag => tag.toLowerCase()));
+    const contextTokens = new Set(tokenizeTagDiscoveryText([title, content, query, ...(candidateTags || [])].filter(Boolean).join(" ")));
+    const isTemporaryTarget = lifecycle === "temporary";
+    const effectiveLimit = limit ?? (mode === "browse" ? 20 : 10);
 
     for (const { note } of entries) {
+      const noteTokens = new Set(tokenizeTagDiscoveryText(`${note.title} ${note.content} ${note.tags.join(" ")}`));
+      const contextMatches = contextTokens.size > 0 ? countTokenOverlap(contextTokens, noteTokens) : 0;
+
       for (const tag of note.tags) {
-        const stats = tagStats.get(tag) || { count: 0, examples: [], lifecycles: new Set<NoteLifecycle>() };
+        const stats = tagStats.get(tag) || {
+          count: 0,
+          examples: [],
+          lifecycles: new Set<NoteLifecycle>(),
+          contextMatches: 0,
+          exactCandidateMatch: false,
+        };
         stats.count++;
         if (stats.examples.length < 3) {
           stats.examples.push(note.title);
         }
         stats.lifecycles.add(note.lifecycle);
+        stats.contextMatches += contextMatches;
+        if (candidateTagSet.has(tag.toLowerCase())) {
+          stats.exactCandidateMatch = true;
+        }
         tagStats.set(tag, stats);
       }
     }
 
     const tags = Array.from(tagStats.entries())
-      .map(([tag, stats]) => ({
-        tag,
-        usageCount: stats.count,
-        examples: stats.examples,
-        lifecycleTypes: Array.from(stats.lifecycles) as NoteLifecycle[],
-        isTemporaryOnly: stats.lifecycles.size === 1 && stats.lifecycles.has("temporary"),
-      }))
-      .sort((a, b) => b.usageCount - a.usageCount);
+      .map(([tag, stats]) => {
+        const lifecycleTypes = Array.from(stats.lifecycles) as NoteLifecycle[];
+        const isTemporaryOnly = stats.lifecycles.size === 1 && stats.lifecycles.has("temporary");
+        const tagTokenOverlap = contextTokens.size > 0
+          ? countTokenOverlap(contextTokens, tokenizeTagDiscoveryText(tag))
+          : 0;
+        const score =
+          (stats.exactCandidateMatch ? 8 : 0) +
+          (tagTokenOverlap * 4) +
+          (stats.contextMatches * 2) +
+          (stats.count * 0.25) -
+          (!isTemporaryTarget && isTemporaryOnly ? 2 : 0);
+        const reason = stats.exactCandidateMatch
+          ? "matches a candidate tag already present in the note context"
+          : tagTokenOverlap > 0 || stats.contextMatches > 0
+            ? "matches the note context and existing project usage"
+            : "high-usage canonical tag from existing project notes";
+
+        return {
+          tag,
+          usageCount: stats.count,
+          examples: stats.examples,
+          example: stats.examples[0],
+          reason,
+          lifecycleTypes,
+          isTemporaryOnly,
+          score,
+        };
+      })
+      .sort((a, b) => b.score - a.score || b.usageCount - a.usageCount || a.tag.localeCompare(b.tag));
 
     const durationMs = Date.now() - startTime;
+    const vaultsSearched = new Set(entries.map(e => storageLabel(e.vault))).size;
 
     const lines: string[] = [];
-    if (project && scope !== "global") {
-      lines.push(`Tags for ${project.name} (scope: ${scope}):`);
+    if (mode === "browse") {
+      if (project && scope !== "global") {
+        lines.push(`Tags for ${project.name} (scope: ${scope}):`);
+      } else {
+        lines.push(`Tags (scope: ${scope}):`);
+      }
+      lines.push("");
+      lines.push(`Total: ${tags.length} unique tags across ${entries.length} notes (${durationMs}ms)`);
+      lines.push("");
+      lines.push("Tags sorted by usage:");
+      for (const t of tags.slice(0, effectiveLimit)) {
+        const lifecycleMark = t.isTemporaryOnly ? " [temp-only]" : "";
+        lines.push(`  ${t.tag} (${t.usageCount})${lifecycleMark}`);
+        if (t.examples.length > 0) {
+          lines.push(`    Example: "${t.examples[0]}"`);
+        }
+      }
+      if (tags.length > effectiveLimit) {
+        lines.push(`  ... and ${tags.length - effectiveLimit} more`);
+      }
     } else {
-      lines.push(`Tags (scope: ${scope}):`);
-    }
-    lines.push("");
-    lines.push(`Total: ${tags.length} unique tags across ${entries.length} notes (${durationMs}ms)`);
-    lines.push("");
-    lines.push("Tags sorted by usage:");
-    for (const t of tags.slice(0, 20)) {
-      const lifecycleMark = t.isTemporaryOnly ? " [temp-only]" : "";
-      lines.push(`  ${t.tag} (${t.usageCount})${lifecycleMark}`);
-      if (t.examples.length > 0) {
-        lines.push(`    Example: "${t.examples[0]}"`);
+      const suggestedTags = tags.slice(0, effectiveLimit);
+      if (project && scope !== "global") {
+        lines.push(`Suggested tags for ${project.name} (scope: ${scope}):`);
+      } else {
+        lines.push(`Suggested tags (scope: ${scope}):`);
+      }
+      lines.push("");
+      lines.push(`Considered ${tags.length} unique tags across ${entries.length} notes (${durationMs}ms)`);
+      lines.push("");
+      if (contextTokens.size === 0) {
+        lines.push("No note context provided; showing the most canonical existing tags.");
+        lines.push("");
+      }
+      lines.push("Recommended tags:");
+      for (const t of suggestedTags) {
+        const lifecycleMark = t.isTemporaryOnly ? " [temp-only]" : "";
+        lines.push(`  ${t.tag} (${t.usageCount})${lifecycleMark}`);
+        if (t.example) {
+          lines.push(`    Example: "${t.example}"`);
+        }
+        lines.push(`    Why: ${t.reason}`);
       }
     }
-    if (tags.length > 20) {
-      lines.push(`  ... and ${tags.length - 20} more`);
-    }
 
-    const structuredContent: DiscoverTagsResult = {
-      action: "tags_discovered",
-      project: project ? { id: project.id, name: project.name } : undefined,
-      scope: scope || "all",
-      tags,
-      totalTags: tags.length,
-      totalNotes: entries.length,
-      vaultsSearched: new Set(entries.map(e => storageLabel(e.vault))).size,
-      durationMs,
-    };
+    const structuredContent: DiscoverTagsResult = mode === "browse"
+      ? {
+          action: "tags_discovered",
+          project: project ? { id: project.id, name: project.name } : undefined,
+          mode,
+          scope: scope || "all",
+          tags: tags.slice(0, effectiveLimit).map(({ score, example, reason, ...tag }) => tag),
+          totalTags: tags.length,
+          totalNotes: entries.length,
+          vaultsSearched,
+          durationMs,
+        }
+      : {
+          action: "tags_discovered",
+          project: project ? { id: project.id, name: project.name } : undefined,
+          mode,
+          scope: scope || "all",
+          recommendedTags: tags.slice(0, effectiveLimit).map(({ score, examples, ...tag }) => tag),
+          totalTags: tags.length,
+          totalNotes: entries.length,
+          vaultsSearched,
+          durationMs,
+        };
 
     return { content: [{ type: "text", text: lines.join("\n") }], structuredContent };
   }
@@ -5275,7 +5385,7 @@ server.registerPrompt(
             "1. Need to store, refine, or connect knowledge about a topic? Start with `recall`, or use `list` when you need deterministic browsing by scope, storage, or tags.\n" +
             "2. If `recall` or `list` returns matching ids, use `get` to inspect the best match.\n" +
             "3. If one memory should be refined, call `update`.\n" +
-            "4. If no memory covers the topic, call `discover_tags` if tags matter, then call `remember`.\n" +
+            "4. If no memory covers the topic and tag choice is ambiguous, call `discover_tags` with note context, then call `remember`.\n" +
             "5. After storing or updating, use `relate` for strong connections, `consolidate` for overlap, and `move_memory` for wrong storage location.\n\n" +
             "### Anti-patterns\n\n" +
             "- Bad: call `remember` immediately because the user said 'remember'.\n" +
@@ -5293,7 +5403,7 @@ server.registerPrompt(
             "- project memory policy lookup\n\n" +
             "### Tiny examples\n\n" +
             "- Existing bug note found by `recall` -> inspect with `get` -> refine with `update`.\n" +
-            "- No matching note found by `recall` -> optional `discover_tags` -> create with `remember`.\n" +
+            "- No matching note found by `recall` -> optional `discover_tags` with note context -> create with `remember`.\n" +
             "- Two notes overlap heavily -> inspect -> clean up with `consolidate`.",
         },
       },

--- a/src/structured-content.ts
+++ b/src/structured-content.ts
@@ -861,8 +861,17 @@ export interface RelationshipPreview {
 export interface DiscoverTagsResult extends Record<string, unknown> {
   action: "tags_discovered";
   project?: { id: string; name: string };
+  mode: "suggest" | "browse";
   scope: "project" | "global" | "all";
-  tags: Array<{
+  recommendedTags?: Array<{
+    tag: string;
+    usageCount: number;
+    example?: string;
+    reason?: string;
+    lifecycleTypes: NoteLifecycle[];
+    isTemporaryOnly: boolean;
+  }>;
+  tags?: Array<{
     tag: string;
     usageCount: number;
     examples: string[];
@@ -878,17 +887,25 @@ export interface DiscoverTagsResult extends Record<string, unknown> {
 export const DiscoverTagsResultSchema = z.object({
   action: z.literal("tags_discovered"),
   project: z.object({ id: z.string(), name: z.string() }).optional(),
+  mode: z.enum(["suggest", "browse"]),
   scope: z.enum(["project", "global", "all"]),
+  recommendedTags: z.array(z.object({
+    tag: z.string(),
+    usageCount: z.number(),
+    example: z.string().optional(),
+    reason: z.string().optional(),
+    lifecycleTypes: z.array(_NoteLifecycle),
+    isTemporaryOnly: z.boolean(),
+  })).optional(),
   tags: z.array(z.object({
     tag: z.string(),
     usageCount: z.number(),
     examples: z.array(z.string()),
     lifecycleTypes: z.array(_NoteLifecycle),
     isTemporaryOnly: z.boolean(),
-  })),
+  })).optional(),
   totalTags: z.number(),
   totalNotes: z.number(),
   vaultsSearched: z.number(),
   durationMs: z.number(),
 });
-

--- a/tests/mcp.integration.test.ts
+++ b/tests/mcp.integration.test.ts
@@ -73,6 +73,7 @@ describe("local MCP script", () => {
     expect(byName.get("relate")).toContain("Use after you have identified the exact memories to connect.");
     expect(byName.get("consolidate")).toContain("Use after `recall`, `list`, or `memory_graph` shows overlap that should be merged or cleaned up.");
     expect(byName.get("move_memory")).toContain("Use after `where_is_memory` or `get` confirms a memory is stored in the wrong place.");
+    expect(byName.get("discover_tags")).toContain("Suggest canonical tags for a specific note before `remember` when tag choice is ambiguous.");
   }, 15000);
 
   it("supports global remember and forget with git disabled", async () => {
@@ -2221,7 +2222,7 @@ describe("local MCP script", () => {
     }
   }, 15000);
 
-  it("discovers tags with usage statistics and lifecycle distribution", async () => {
+  it("suggests note-oriented canonical tags by default", async () => {
     const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mcp-vault-"));
     tempDirs.push(vaultDir);
     const embeddingServer = await startFakeEmbeddingServer();
@@ -2256,23 +2257,28 @@ describe("local MCP script", () => {
       }, embeddingServer.url);
 
       const response = await callLocalMcpResponse(vaultDir, "discover_tags", {
+        title: "Improve test-tag discovery workflow",
+        content: "Tighten discovery behavior and canonical test-tag selection for note-oriented suggestions.",
         scope: "global",
       }, embeddingServer.url);
 
       const structured = response.structuredContent;
       expect(structured?.["action"]).toBe("tags_discovered");
+      expect(structured?.["mode"]).toBe("suggest");
       expect(structured?.["totalTags"]).toBeGreaterThan(0);
       expect(structured?.["totalNotes"]).toBe(3);
 
-      const tags = structured?.["tags"] as Array<Record<string, unknown>>;
+      const tags = structured?.["recommendedTags"] as Array<Record<string, unknown>>;
       expect(Array.isArray(tags)).toBe(true);
+      expect(tags.length).toBeGreaterThan(0);
+      expect(tags.length).toBeLessThanOrEqual(10);
+      expect(structured?.["tags"]).toBeUndefined();
 
       // Find the test-tag (should have usageCount 2)
       const testTag = tags.find((t) => t["tag"] === "test-tag");
       expect(testTag).toBeDefined();
       expect(testTag?.["usageCount"]).toBe(2);
-      expect(testTag?.["examples"]).toBeDefined();
-      expect((testTag?.["examples"] as string[]).length).toBeGreaterThan(0);
+      expect(typeof testTag?.["example"]).toBe("string");
       expect(testTag?.["isTemporaryOnly"]).toBe(false);
       expect((testTag?.["lifecycleTypes"] as string[])).toContain("permanent");
 
@@ -2292,9 +2298,52 @@ describe("local MCP script", () => {
       expect((discoveryTag?.["lifecycleTypes"] as string[])).toContain("temporary");
 
       // Verify response text contains useful information
-      expect(response.text).toContain("Tags (scope: global)");
+      expect(response.text).toContain("Suggested tags");
       expect(response.text).toContain("test-tag");
       expect(response.text).toContain("discovery");
+    } finally {
+      await embeddingServer.close();
+    }
+  }, 15000);
+
+  it("supports explicit browse mode for broader tag inventory output", async () => {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mcp-vault-"));
+    tempDirs.push(vaultDir);
+    const embeddingServer = await startFakeEmbeddingServer();
+
+    try {
+      await callLocalMcp(vaultDir, "remember", {
+        title: "Browse mode note one",
+        content: "Contains browse-tag and discovery.",
+        tags: ["browse-tag", "discovery"],
+        lifecycle: "permanent",
+        scope: "global",
+        summary: "Create first browse mode note",
+      }, embeddingServer.url);
+
+      await callLocalMcp(vaultDir, "remember", {
+        title: "Browse mode note two",
+        content: "Contains browse-tag and temp-only.",
+        tags: ["browse-tag", "temp-only"],
+        lifecycle: "temporary",
+        scope: "global",
+        summary: "Create second browse mode note",
+      }, embeddingServer.url);
+
+      const response = await callLocalMcpResponse(vaultDir, "discover_tags", {
+        mode: "browse",
+        scope: "global",
+      }, embeddingServer.url);
+
+      const structured = response.structuredContent;
+      expect(structured?.["action"]).toBe("tags_discovered");
+      expect(structured?.["mode"]).toBe("browse");
+      const tags = structured?.["tags"] as Array<Record<string, unknown>>;
+      expect(Array.isArray(tags)).toBe(true);
+      expect(tags.find((t) => t["tag"] === "browse-tag")).toBeDefined();
+      expect(tags.find((t) => t["tag"] === "temp-only")?.["isTemporaryOnly"]).toBe(true);
+      expect(structured?.["recommendedTags"]).toBeUndefined();
+      expect(response.text).toContain("Tags (scope: global)");
     } finally {
       await embeddingServer.close();
     }

--- a/tests/mcp.integration.test.ts
+++ b/tests/mcp.integration.test.ts
@@ -2393,6 +2393,24 @@ describe("local MCP script", () => {
         summary: "Create workflow note",
       }, embeddingServer.url);
 
+      await callLocalMcp(vaultDir, "remember", {
+        title: "Temporary scratchpad",
+        content: "Temporary working note with short-lived cleanup context.",
+        tags: ["temporary-notes", "implemented"],
+        lifecycle: "temporary",
+        scope: "global",
+        summary: "Create temporary noise note",
+      }, embeddingServer.url);
+
+      await callLocalMcp(vaultDir, "remember", {
+        title: "Implementation status",
+        content: "A consolidated implemented note about finished work items.",
+        tags: ["implemented", "consolidated"],
+        lifecycle: "permanent",
+        scope: "global",
+        summary: "Create implementation status noise note",
+      }, embeddingServer.url);
+
       const response = await callLocalMcpResponse(vaultDir, "discover_tags", {
         title: "Improve project notes",
         content: "Make project knowledge easier to use across sessions.",
@@ -2406,7 +2424,65 @@ describe("local MCP script", () => {
       const rankedNames = rankedTags.map((tag) => String(tag["tag"]));
       expect(rankedNames.length).toBeGreaterThan(0);
       expect(["design", "architecture", "workflow"]).toContain(rankedNames[0]);
+      if (rankedNames.includes("temporary-notes")) {
+        expect(rankedNames.indexOf("design")).toBeLessThan(rankedNames.indexOf("temporary-notes"));
+      }
+      if (rankedNames.includes("implemented")) {
+        expect(rankedNames.indexOf("design")).toBeLessThan(rankedNames.indexOf("implemented"));
+      }
+      if (rankedNames.includes("consolidated")) {
+        expect(rankedNames.indexOf("design")).toBeLessThan(rankedNames.indexOf("consolidated"));
+      }
       expect(structured?.["tags"]).toBeUndefined();
+    } finally {
+      await embeddingServer.close();
+    }
+  }, 15000);
+
+  it("prefers an exact specific tag even when it only exists once", async () => {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mcp-vault-"));
+    tempDirs.push(vaultDir);
+    const embeddingServer = await startFakeEmbeddingServer();
+
+    try {
+      for (let i = 0; i < 4; i++) {
+        await callLocalMcp(vaultDir, "remember", {
+          title: `Broad design note ${i + 1}`,
+          content: "General design and architecture guidance.",
+          tags: ["design", "architecture"],
+          lifecycle: "permanent",
+          scope: "global",
+          summary: "Create broad design baseline note",
+        }, embeddingServer.url);
+      }
+
+      await callLocalMcp(vaultDir, "remember", {
+        title: "Cache invalidation issue",
+        content: "A focused note about cache invalidation behavior.",
+        tags: ["cache-invalidation"],
+        lifecycle: "permanent",
+        scope: "global",
+        summary: "Create one-off specific tag note",
+      }, embeddingServer.url);
+
+      const response = await callLocalMcpResponse(vaultDir, "discover_tags", {
+        title: "Fix cache-invalidation behavior",
+        content: "Investigate cache-invalidation for stale project data.",
+        scope: "global",
+      }, embeddingServer.url);
+
+      const structured = response.structuredContent;
+      expect(structured?.["mode"]).toBe("suggest");
+      const rankedTags = structured?.["recommendedTags"] as Array<Record<string, unknown>>;
+      expect(Array.isArray(rankedTags)).toBe(true);
+      const rankedNames = rankedTags.map((tag) => String(tag["tag"]));
+      expect(rankedNames.indexOf("cache-invalidation")).toBeGreaterThanOrEqual(0);
+      if (rankedNames.includes("design")) {
+        expect(rankedNames.indexOf("cache-invalidation")).toBeLessThan(rankedNames.indexOf("design"));
+      }
+      if (rankedNames.includes("architecture")) {
+        expect(rankedNames.indexOf("cache-invalidation")).toBeLessThan(rankedNames.indexOf("architecture"));
+      }
     } finally {
       await embeddingServer.close();
     }

--- a/tests/mcp.integration.test.ts
+++ b/tests/mcp.integration.test.ts
@@ -2229,10 +2229,21 @@ describe("local MCP script", () => {
 
     try {
       // Create notes with different tags and lifecycles
+      for (let i = 0; i < 4; i++) {
+        await callLocalMcp(vaultDir, "remember", {
+          title: `Broad design note ${i + 1}`,
+          content: "Design guidance for discover tags workflow and architecture decisions.",
+          tags: ["design", "architecture"],
+          lifecycle: "permanent",
+          scope: "global",
+          summary: "Create broad design note for ranking pressure",
+        }, embeddingServer.url);
+      }
+
       await callLocalMcp(vaultDir, "remember", {
         title: "Tag discovery test note one",
         content: "First note for tag discovery with permanent lifecycle.",
-        tags: ["test-tag", "permanent-only", "discovery"],
+        tags: ["test-tag", "permanent-only", "discovery", "discover_tags"],
         lifecycle: "permanent",
         scope: "global",
         summary: "Create first note for tag discovery test",
@@ -2241,7 +2252,7 @@ describe("local MCP script", () => {
       await callLocalMcp(vaultDir, "remember", {
         title: "Tag discovery test note two",
         content: "Second note for tag discovery also using test-tag.",
-        tags: ["test-tag", "mixed-lifecycle", "discovery"],
+        tags: ["test-tag", "mixed-lifecycle", "discovery", "discover_tags"],
         lifecycle: "permanent",
         scope: "global",
         summary: "Create second note for tag discovery test",
@@ -2257,8 +2268,8 @@ describe("local MCP script", () => {
       }, embeddingServer.url);
 
       const response = await callLocalMcpResponse(vaultDir, "discover_tags", {
-        title: "Improve test-tag discovery workflow",
-        content: "Tighten discovery behavior and canonical test-tag selection for note-oriented suggestions.",
+        title: "Tune discover_tags ranking",
+        content: "Make discover_tags suggestions prefer specific tags over generic design tags.",
         scope: "global",
       }, embeddingServer.url);
 
@@ -2266,13 +2277,14 @@ describe("local MCP script", () => {
       expect(structured?.["action"]).toBe("tags_discovered");
       expect(structured?.["mode"]).toBe("suggest");
       expect(structured?.["totalTags"]).toBeGreaterThan(0);
-      expect(structured?.["totalNotes"]).toBe(3);
+      expect(structured?.["totalNotes"]).toBe(7);
 
       const tags = structured?.["recommendedTags"] as Array<Record<string, unknown>>;
       expect(Array.isArray(tags)).toBe(true);
       expect(tags.length).toBeGreaterThan(0);
       expect(tags.length).toBeLessThanOrEqual(10);
       expect(structured?.["tags"]).toBeUndefined();
+      const rankedNames = tags.map((t) => String(t["tag"]));
 
       // Find the test-tag (should have usageCount 2)
       const testTag = tags.find((t) => t["tag"] === "test-tag");
@@ -2296,6 +2308,14 @@ describe("local MCP script", () => {
       expect(discoveryTag?.["isTemporaryOnly"]).toBe(false);
       expect((discoveryTag?.["lifecycleTypes"] as string[])).toContain("permanent");
       expect((discoveryTag?.["lifecycleTypes"] as string[])).toContain("temporary");
+      expect(rankedNames.indexOf("test-tag")).toBeGreaterThanOrEqual(0);
+      expect(rankedNames.indexOf("discover_tags")).toBeGreaterThanOrEqual(0);
+      if (rankedNames.includes("design")) {
+        expect(rankedNames.indexOf("discover_tags")).toBeLessThan(rankedNames.indexOf("design"));
+      }
+      if (rankedNames.includes("architecture")) {
+        expect(rankedNames.indexOf("discover_tags")).toBeLessThan(rankedNames.indexOf("architecture"));
+      }
 
       // Verify response text contains useful information
       expect(response.text).toContain("Suggested tags");
@@ -2344,6 +2364,49 @@ describe("local MCP script", () => {
       expect(tags.find((t) => t["tag"] === "temp-only")?.["isTemporaryOnly"]).toBe(true);
       expect(structured?.["recommendedTags"]).toBeUndefined();
       expect(response.text).toContain("Tags (scope: global)");
+    } finally {
+      await embeddingServer.close();
+    }
+  }, 15000);
+
+  it("keeps broad canonical tags near the top when the prompt is generic", async () => {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mcp-vault-"));
+    tempDirs.push(vaultDir);
+    const embeddingServer = await startFakeEmbeddingServer();
+
+    try {
+      await callLocalMcp(vaultDir, "remember", {
+        title: "Architecture decision record",
+        content: "Design note about project structure and architecture guidance.",
+        tags: ["design", "architecture"],
+        lifecycle: "permanent",
+        scope: "global",
+        summary: "Create broad design note",
+      }, embeddingServer.url);
+
+      await callLocalMcp(vaultDir, "remember", {
+        title: "Project workflow note",
+        content: "Workflow guidance for organizing project knowledge.",
+        tags: ["workflow", "design"],
+        lifecycle: "permanent",
+        scope: "global",
+        summary: "Create workflow note",
+      }, embeddingServer.url);
+
+      const response = await callLocalMcpResponse(vaultDir, "discover_tags", {
+        title: "Improve project notes",
+        content: "Make project knowledge easier to use across sessions.",
+        scope: "global",
+      }, embeddingServer.url);
+
+      const structured = response.structuredContent;
+      expect(structured?.["mode"]).toBe("suggest");
+      const rankedTags = structured?.["recommendedTags"] as Array<Record<string, unknown>>;
+      expect(Array.isArray(rankedTags)).toBe(true);
+      const rankedNames = rankedTags.map((tag) => String(tag["tag"]));
+      expect(rankedNames.length).toBeGreaterThan(0);
+      expect(["design", "architecture", "workflow"]).toContain(rankedNames[0]);
+      expect(structured?.["tags"]).toBeUndefined();
     } finally {
       await embeddingServer.close();
     }


### PR DESCRIPTION
## Summary

This PR captures the following design decisions:

- **discover_tags should default to note-oriented ranked suggestions instead of full tag inventories**
- **Tag discovery system: performance-conscious design and implementation**
- **mnemonic — MCP tools inventory**
- **Tag discovery cognitive model: how LLMs use usage statistics for accurate selection**

## Design Decisions

### discover_tags should default to note-oriented ranked suggestions instead of full tag inventories

**Tags:** discover_tags, design, decision, mcp, documentation

Shift `discover_tags` from corpus-oriented tag inventory output to note-oriented tag suggestion output.

Decision:

- Keep the tool name `discover_tags`.
- Make the default behavior compact and note-specific: the caller provides note context such as `title`, `content`, `query`, or candidate tags, and the tool returns ranked canonical tag suggestions for that note.
- Rank by note relevance first and usage count second so low-value but common tags do not dominate, while still preferring canonical project vocabulary.
- Demote tags that only appear on temporary notes unless the target note also appears temporary.
- Avoid returning the full corpus-wide tag list in default structured output; broad browsing should be explicit rather than automatic.

Rationale:

- The current full-tag structured output can become very large and waste context.
- Returning the whole tag inventory still exposes many unrelated tags to the agent.
- The original design goal was to prevent agents from inventing or overusing unrelated tags; note-oriented ranking serves that goal better than popularity-only truncation.

Documentation impact when implemented:

- Tighten tool descriptions and workflow guidance so `discover_tags` is described as suggesting canonical tags for a specific note.
- Update `README.md`, `AGENT.md`, tool lists, and homepage copy to stop implying that the normal workflow is to enumerate the whole tag corpus.

Non-goal:

- Do not regress to purely popularity-based top-N tags. The result should stay relevance-aware so uncommon but appropriate tags can still surface.

### Tag discovery system: performance-conscious design and implementation

**Tags:** architecture, design, discover_tags, performance, consolidated, implemented

## Current State

The labeling system in mnemonic currently uses vault labels and note tags in an ad-hoc manner. Tagging success depends on consistent terminology across sessions (e.g., `bug` vs `bugs` vs `bugfix`).

## Implementation Status

**Phase 1: IMPLEMENTED** ✅

The current `discover_tags` MCP tool is available in `src/index.ts` with:

- Input parameters: `cwd`, `scope`, `storedIn` (matching `list` tool semantics)
- Output: tags sorted by usageCount with examples, lifecycleTypes, and isTemporaryOnly flag
- structuredContent schema in `src/structured-content.ts`
- Integration test coverage in `tests/mcp.integration.test.ts`
- Performance telemetry: `durationMs` in response

## Updated Design Direction

The current implementation proved the value of canonical tag discovery, but its broad structured output can become too large and can expose many unrelated tags to the model.

**New direction:** keep the tool name `discover_tags`, but make its default behavior note-oriented rather than corpus-oriented.

### Default behavior should become compact and note-specific

The caller should provide note context such as:

- `title`
- `content`
- `query`
- optional candidate tags

The tool should then return ranked canonical tag suggestions for that note instead of the entire tag inventory.

### Ranking principle

Rank by:

1. relevance to the note context
2. usage count as a canonicality boost
3. lifecycle distribution as a quality signal

This preserves the original anti-fragmentation goal without overwhelming the agent with unrelated but common tags.

### Output principle

Default structured output should be compact:

- recommended tags for the note
- small evidence payload, such as one example title or a short reason
- no full corpus-wide tag dump unless broad browsing is explicitly requested

## Performance-Safe Design Decisions

### Current Recall Performance Model

Recall flow from `ARCHITECTURE.md` and `recall.ts`:

1. Embed query via Ollama (50-200ms)
2. Load embeddings from disk (I/O bound)
3. Compute cosine similarity (O(n), fast)
4. Apply +0.15 project boost (O(n))
5. Select results with heuristic (O(n log n) sort)

**Key tenet**: lightweight heuristic, not full dynamic context loading

### Tag Discovery Impact

**Current discover_tags workflow**:

- List note IDs from vaults (disk scan)
- Read each note to extract tags (parallel I/O)
- Build usage statistics (in-memory)

Complexity: O(n) where n = total notes scanned

Performance data:

- 500 notes: ~100-200ms
- 2000 notes: ~400-800ms
- 5000 notes: ~1-2 seconds

### Critical Design Choice: Manual Tool

**Rejected**: Auto-run tag discovery before every `remember`

- Would add 100ms-2s latency to each write
- Violates MCP ergonomics principle

**Accepted**: MCP tool `discover_tags` that the agent calls intentionally

- Agent decides when tag discovery adds value
- Tag discovery should be used when tag choice is ambiguous, not as a mandatory pre-step for every write
- Keeps performance predictable and output bounded

### No Recall Algorithm Changes

**Rejected**: Boost recall scores based on tag embeddings

- Would require comparing query to note embeddings and tag embeddings
- Adds complexity to the lightweight heuristic

**Accepted**: note-oriented tag suggestion without redesigning recall

- The tool can use note context to rank canonical tags
- Recall stays focused on note retrieval, not tag-taxonomy management
- This preserves the simple recall algorithm while improving write-time guidance

## Current Implementation: Phase 1 ✅

### Current MCP Tool

The current implementation is still corpus-oriented and returns vault-wide tag statistics. That remains useful as the starting point, but it should now be treated as an intermediate step rather than the final design.

Workflow intent:

- Agent provides proposed note context
- Tool returns a compact set of relevant canonical tags
- Agent reuses existing tags or creates a new tag only when genuinely novel

## Future Direction

### Phase 2: Note-Oriented Suggestions

Evolve `discover_tags` so that the default mode accepts note context and returns a compact ranked set of canonical tag suggestions.

This phase should also tighten tool descriptions and related documentation so the project consistently describes `discover_tags` as a note-oriented suggestion tool rather than a general tag dump.

### Broad Browsing Remains Explicit

If full corpus browsing remains useful for administration or manual exploration, it should be an explicit mode rather than the default experience.

## Benefits

1. **Consistency**: reduces tag fragmentation (`bug`/`bugs`/`bugfix` → canonical choice)
2. **Relevance**: avoids flooding the agent with unrelated tags
3. **Compactness**: reduces token-heavy structured output
4. **Confidence**: still gives enough evidence to trust suggested tags
5. **Performance**: keeps recall unchanged and preserves explicit invocation

## Alignment with Architecture Principles

✅ Lightweight heuristic preserved (`recall` unchanged)
✅ MCP ergonomics maintained (explicit tool, not automatic)
✅ Better bounded outputs for LLM consumers
✅ Original anti-hallucination goal preserved
✅ Documentation and agent guidance can be tightened around the new contract

## Specificity tuning follow-up

After dogfooding the first note-oriented release, scoring was rebalanced toward specificity because broad tags were still dominating the top results for clearly scoped prompts.

- stronger exact-match boost for tags named directly in the note context
- lower usage-count weight so popularity acts as a tie-breaker rather than the primary ranking signal
- average per-note context match is used instead of letting large broad tag clusters dominate via raw totals
- conditional generic-tag penalty for broad high-frequency single-token tags when a strong specific candidate exists
- generic prompts fall back toward broader canonical tags instead of returning full inventory output
- browse mode remains unchanged and inventory-oriented

## Generalized heuristic rule

The final tuning was validated against a synthetic sparse-project scenario as well as this repository's own corpus.

- exact matches on genuinely specific tags should trigger specificity-heavy ranking even if the tag exists only once
- generic prompts should continue to use the broad canonical fallback path
- broad one-off exact matches should not be enough to flip the entire ranking into specificity mode
- this keeps the heuristic useful both for mature repos with many tags and for smaller projects with sparse tag histories

### mnemonic — MCP tools inventory

**Tags:** tools, mcp, api

# mnemonic — MCP tools inventory

This note lists every MCP tool exposed by mnemonic with a brief description. Keep this updated when tools are added or changed.

## Tools

| Tool | Description |
| ---- | ----------- |
| `consolidate` | Merge overlapping memories or find duplicates; supports dry-run, suggest-merges, and prune-superseded strategies |
| `detect_project` | Detect effective project identity (id, name) for a working directory |
| `discover_tags` | Suggest canonical tags for a note using title/content/query context; `mode: "browse"` opts into broader inventory output |
| `execute_migration` | Execute a named schema migration (dry-run first) |
| `forget` | Delete a note and its embeddings, clean up relationship references |
| `get` | Fetch one or more notes by exact id with optional preview, relations, and storage info |
| `get_project_identity` | Show current project identity including remote override if set |
| `get_project_memory_policy` | Show saved default write scope and consolidation mode for a project |
| `list` | List memories with optional previews, relations, storage, timestamps, and `storedIn` filtering |
| `list_migrations` | List available migrations and pending count |
| `memory_graph` | Show a compact adjacency list of note relationships |
| `move_memory` | Move a memory between vaults without changing its id; accepts optional `vaultFolder` to target sub-vaults |
| `project_memory_summary` | Session-start entrypoint: themed notes, anchors, and explicit orientation (primaryEntry, suggestedNext, warnings) for fast project orientation |
| `recall` | Semantic search with optional project boost (+0.15) |
| `recent_memories` | Show the most recently updated memories for a scope and storage location |
| `remember` | Write note + embedding with project context from `cwd` and storage controlled by `scope`; `checkedForExisting` is a schema-only agent hint |
| `relate` | Create typed relationship (bidirectional by default) |
| `set_project_identity` | Save which git remote defines project identity |
| `set_project_memory_policy` | Set the default write scope and consolidation mode for a project |
| `sync` | Git sync when a remote exists, then always backfills missing local embeddings; `force=true` rebuilds all embeddings |
| `unrelate` | Remove relationship between two notes |
| `update` | Update content/title/tags, always re-embeds |
| `where_is_memory` | Show a memory's project association and actual storage location — lightweight alternative to `get` |

Relationship types: `related-to`, `explains`, `example-of`, `supersedes`.

## Prompts

| Prompt | Description |
| ------ | ----------- |
| `mnemonic-workflow-hint` | Optional, on-demand. Covers discover → inspect → modify → organize pattern, storage-label model, and `recall` → `get` → `update` preference. Not auto-injected. |

Main-vault operational config lives in `config.json`, including `reindexEmbedConcurrency`, per-project memory policies, and consolidation mode defaults.

## Key design note: sync owns embedding rebuilds

`sync` is now the single recovery path for local embeddings:

- it still performs git fetch/pull/push when a remote exists
- it also backfills missing local embeddings even when no remote exists or git is disabled
- `sync force=true` rebuilds all embeddings regardless of whether the current model already has them

This makes `sync` the tool that brings a vault to a fully operational state, instead of splitting that responsibility across `sync` and a separate `reindex` tool.

## Zod schemas

The structured-content module still contains result schemas and types for removed tools as historical implementation detail, but `src/index.ts` no longer registers `reindex`.

## storageLabel return type

`storageLabel(vault: Vault)` returns one of three values:

- `"main-vault"` for the global vault
- `"project-vault"` for the primary project vault (`.mnemonic/`)
- `` `sub-vault:${vaultFolderName}` `` for named sub-vaults (`.mnemonic-<name>/`)

## discover_tags behavior

`discover_tags` now has two modes:

- default `mode: "suggest"` returns bounded `recommendedTags` for a specific note
- explicit `mode: "browse"` returns broader inventory-style `tags`

The intended workflow is to pass note context when tag choice is ambiguous so the tool can suggest canonical tags without flooding the agent with unrelated ones.

### Tag discovery cognitive model: how LLMs use usage statistics for accurate selection

**Tags:** cognitive-model, discover_tags, pattern-matching, llm-behavior

## Pattern Matching Over Deep Understanding

`discover_tags` should evolve from a corpus-oriented inventory into a note-oriented suggestion tool.

The core cognitive model still holds: the LLM benefits from seeing canonical project vocabulary and a small amount of evidence. But the evidence should be filtered through the specific note being written rather than dumping the whole tag catalog.

## Updated Information Hierarchy

### 1. Note Relevance (Primary Signal)

The most useful tag is the one that matches the note being written, not the one that is merely common across the whole vault.

- A note about MCP prompt wording should prefer `mcp`, `prompt`, `workflow`, or `design` over unrelated but globally common tags
- Relevance should narrow the candidate set before any popularity-based ranking

### 2. Usage Count (Canonicality Signal)

Usage count remains valuable, but as a secondary signal:

- `bug` (12 uses) vs `bugs` (2 uses) still indicates canonical terminology
- High count helps break ties among relevant candidates
- High count alone should not surface unrelated tags

### 3. Example Titles or Short Reasons (Trust Signal)

The LLM only needs a little evidence to trust a suggestion:

- one short example title or a brief reason is usually enough
- this keeps responses compact while still grounding the suggestion in real project usage

### 4. Lifecycle Distribution (Quality Signal)

Temporary-only tags are still useful as a warning signal:

- permanent-heavy tags imply durable vocabulary
- temporary-only tags should be demoted unless the target note is also temporary

## Updated Cognitive Model

**Before the shift**:

1. LLM calls `discover_tags()`
2. Sees a broad tag inventory with usage counts and examples
3. Infers which tags are probably relevant
4. Risks distraction from many unrelated tags and large payloads

**After the shift**:

1. LLM calls `discover_tags()` with note context
2. Tool narrows candidates to tags relevant to that note
3. Tool boosts canonical tags by usage count
4. Tool returns a compact ranked list plus minimal evidence
5. LLM chooses from a smaller, more trustworthy set

## Why This Better Serves the Original Goal

The original goal was not to expose every existing tag. It was to help the LLM avoid inventing or overusing unrelated tags.

A note-oriented `discover_tags` serves that goal better because it:

- reduces irrelevant tags in context
- preserves canonical vocabulary signals
- keeps payload size manageable
- still gives enough evidence for confident pattern matching

The LLM's strength is still pattern recognition, not deep semantic reasoning. The improvement is that pattern matching now happens over a relevant candidate set instead of the entire tag corpus.

## Specificity-first ranking update

`discover_tags` suggestion mode now prefers specificity when direct lexical evidence exists in the note context.

- exact tag-name matches outweigh broad high-frequency tags
- token overlap and note-context overlap outrank raw popularity
- usage count remains a secondary canonicality signal rather than the dominant ranking factor
- when no strong specific candidate exists, ranking falls back toward broader canonical tags instead of returning a full inventory dump

## Generalized rule for other projects

The specificity heuristic should not overfit to this repository's tag distribution.

- a clearly specific exact match must still win even if the tag appears only once in a sparse project
- generic prompts should still fall back to broad canonical tags instead of niche one-off tags
- the branch into specificity-heavy ranking should only happen for exact matches that are genuinely specific, not weak lexical overlap from arbitrary project vocabulary

---

_Generated from 4 design decision note(s) in `.mnemonic/notes/`. Run `/update-pr` to regenerate._