### PR TITLE
Active session project cache: single in-memory vault cache per MCP session

### DIFF
--- a/.mnemonic/notes/active-session-project-cache-single-in-memory-vault-cache-pe-7463f124.md
+++ b/.mnemonic/notes/active-session-project-cache-single-in-memory-vault-cache-pe-7463f124.md
@@ -8,7 +8,7 @@ tags:
   - decision
 lifecycle: permanent
 createdAt: '2026-03-25T12:36:45.634Z'
-updatedAt: '2026-03-25T12:37:13.150Z'
+updatedAt: '2026-03-25T12:42:56.587Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
@@ -53,7 +53,24 @@ Timing hooks added to `recall`, `get`, and `project_memory_summary` via `perform
 
 29 unit tests in `tests/cache.unit.test.ts` covering: lifecycle, invalidation, note lookup, projection cache, failure handling, and instrumentation (all 6 event types verified without affecting returned data).
 
-## Trade-offs
+## Why full invalidation, not targeted per-note invalidation
+
+The cache stores lists (`noteList: Note[]`, `embeddings: EmbeddingRecord[]`), not just individual entries. Targeted invalidation would require surgically mutating those arrays on every write path:
+
+- `remember` → append to both arrays
+- `forget` → splice from both arrays
+- `update` → find-and-replace in both arrays
+- `relate`/`unrelate` → update two note objects in-place (relationship data lives in note frontmatter content)
+- `move_memory` → remove from one vault's cache, insert into another
+- `sync` → unknown remote changeset; no way to know what changed without re-reading storage
+
+That creates tight coupling between the cache module and storage mutation logic, and introduces a class of silent staleness bugs if any mutation path diverges. Full invalidation keeps correctness trivially obvious: write happens → cache is gone → next read rebuilds from storage.
+
+The session pattern doesn't need targeted invalidation either. The cache's value is in the read phase — several `recall`/`get`/`project_memory_summary` calls before any writes. After a write, the rebuild cost is cheap (one parallel `listNotes()` + `listEmbeddings()`).
+
+Projections are the one case where targeted invalidation would be clean (keyed by note ID, no list dependency), but the gain is marginal since projections are only populated explicitly by tools, not on every cache build.
+
+## Other trade-offs
 
 - No TTL, no LRU — session lifetime is bounded by the MCP process, so no eviction needed.
 - Slight redundancy: `project_memory_summary` calls `resolveProject` twice (once to get cache key, once inside `collectVisibleNotes`). Accepted for clean code.

--- a/.mnemonic/notes/active-session-project-cache-single-in-memory-vault-cache-pe-7463f124.md
+++ b/.mnemonic/notes/active-session-project-cache-single-in-memory-vault-cache-pe-7463f124.md
@@ -1,0 +1,55 @@
+---
+title: 'Active session project cache: single in-memory vault cache per MCP session'
+tags:
+  - architecture
+  - performance
+  - cache
+  - scaling
+  - decision
+lifecycle: permanent
+createdAt: '2026-03-25T12:36:45.634Z'
+updatedAt: '2026-03-25T12:36:45.634Z'
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+Phase 5 adds a lightweight in-memory session cache (`src/cache.ts`) that eliminates redundant `listNotes()` + `listEmbeddings()` I/O across tool calls within a single MCP session.
+
+## Design
+
+- **Module-level singleton** — `SessionProjectCache` keyed by project ID; no external library, plain TypeScript `Map` objects.
+- **Single active project** — only the current project is cached; switching projects silently replaces the cache.
+- **Per-vault cache** — each `VaultCache` holds `notesById`, `noteList`, and `embeddings`; built lazily on first access.
+- **Eager co-load** — notes and embeddings are loaded together via `Promise.all([listNotes(), listEmbeddings()])` regardless of which accessor triggers the build, so both are always available after one I/O pass.
+- **Projection cache** — `projectionsById` stored on `SessionProjectCache` for `NoteProjection` reuse across tools.
+- **Fail-soft** — all cache functions return `undefined` on error; callers fall back to direct storage access.
+- **Invalidation** — `invalidateActiveProjectCache()` (no-arg) is called by every write-path tool (`remember`, `update`, `forget`, `relate`, `unrelate`, `move_memory`, `consolidate`, `sync`) and on `ensureBranchSynced`.
+
+## Instrumentation
+
+Event log via `console.error`:
+
+- `[cache:miss]` — first access per project/vault
+- `[cache:build]` — successful build with `notes=N embeddings=N time=Xms`
+- `[cache:hit]` — warm access
+- `[cache:invalidate]` — on mutation or project switch
+- `[cache:fallback]` — on storage error
+
+Timing hooks added to `recall`, `get`, and `project_memory_summary` via `performance.now()`.
+
+## Integration points in src/index.ts
+
+- `collectVisibleNotes` accepts optional `sessionProjectId`; uses `getOrBuildVaultNoteList` with fallback
+- `project_memory_summary` pre-resolves project before `collectVisibleNotes` to supply the cache key
+- `recall` uses `getSessionCachedNote` for single-note lookup; `getOrBuildVaultEmbeddings` for embedding list
+- `get` checks `getSessionCachedNote` before calling `vaultManager.findNote`
+
+## Testing
+
+29 unit tests in `tests/cache.unit.test.ts` covering: lifecycle, invalidation, note lookup, projection cache, failure handling, and instrumentation (all 6 event types verified without affecting returned data).
+
+## Trade-offs
+
+- No TTL, no LRU — session lifetime is bounded by the MCP process, so no eviction needed.
+- Slight redundancy: `project_memory_summary` calls `resolveProject` twice (once to get cache key, once inside `collectVisibleNotes`). Accepted for clean code.
+- No cross-tool projection warming — projections must still be computed and stored explicitly per tool call.

--- a/.mnemonic/notes/active-session-project-cache-single-in-memory-vault-cache-pe-7463f124.md
+++ b/.mnemonic/notes/active-session-project-cache-single-in-memory-vault-cache-pe-7463f124.md
@@ -8,9 +8,12 @@ tags:
   - decision
 lifecycle: permanent
 createdAt: '2026-03-25T12:36:45.634Z'
-updatedAt: '2026-03-25T12:36:45.634Z'
+updatedAt: '2026-03-25T12:36:53.888Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: enrichment-layer-design-provenance-temporal-recall-projectio-7af26f06
+    type: related-to
 memoryVersion: 1
 ---
 Phase 5 adds a lightweight in-memory session cache (`src/cache.ts`) that eliminates redundant `listNotes()` + `listEmbeddings()` I/O across tool calls within a single MCP session.

--- a/.mnemonic/notes/active-session-project-cache-single-in-memory-vault-cache-pe-7463f124.md
+++ b/.mnemonic/notes/active-session-project-cache-single-in-memory-vault-cache-pe-7463f124.md
@@ -8,11 +8,13 @@ tags:
   - decision
 lifecycle: permanent
 createdAt: '2026-03-25T12:36:45.634Z'
-updatedAt: '2026-03-25T12:36:53.888Z'
+updatedAt: '2026-03-25T12:37:13.150Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
   - id: enrichment-layer-design-provenance-temporal-recall-projectio-7af26f06
+    type: related-to
+  - id: performance-principles-for-file-first-mcp-and-git-backed-wor-4e7d3bc8
     type: related-to
 memoryVersion: 1
 ---

--- a/.mnemonic/notes/enrichment-layer-design-provenance-temporal-recall-projectio-7af26f06.md
+++ b/.mnemonic/notes/enrichment-layer-design-provenance-temporal-recall-projectio-7af26f06.md
@@ -12,11 +12,13 @@ tags:
   - relationship-expansion
 lifecycle: permanent
 createdAt: '2026-03-24T10:54:54.335Z'
-updatedAt: '2026-03-24T10:54:54.335Z'
+updatedAt: '2026-03-25T12:36:53.888Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
   - id: mnemonic-key-design-decisions-3f2a6273
+    type: related-to
+  - id: active-session-project-cache-single-in-memory-vault-cache-pe-7463f124
     type: related-to
 memoryVersion: 1
 ---

--- a/.mnemonic/notes/performance-principles-for-file-first-mcp-and-git-backed-wor-4e7d3bc8.md
+++ b/.mnemonic/notes/performance-principles-for-file-first-mcp-and-git-backed-wor-4e7d3bc8.md
@@ -9,7 +9,7 @@ tags:
   - completed
 lifecycle: permanent
 createdAt: '2026-03-14T22:14:46.759Z'
-updatedAt: '2026-03-25T12:37:13.150Z'
+updatedAt: '2026-03-25T12:37:22.129Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
@@ -62,6 +62,13 @@ Low-hanging performance improvements (March 2024):
 - Avoid duplicate git-root lookup in searchOrder
 - Commit: `perf: avoid duplicate git-root lookup in searchOrder`
 - Validation: `npm test -- tests/vault.test.ts tests/project.test.ts tests/project-introspection.test.ts`
+
+### 6. Active session project cache (Phase 5)
+
+- Module-level singleton in `src/cache.ts` caches `listNotes()` + `listEmbeddings()` together per vault; `recall`, `get`, and `project_memory_summary` all read from the same warm cache within a session
+- Invalidated on every write-path tool; fail-soft returns `undefined` so callers fall back cleanly
+- Instrumented with `[cache:hit/miss/build/invalidate/fallback]` events and per-tool timing via `performance.now()`
+- Validation: `npm test -- tests/cache.unit.test.ts tests/project-memory-summary.integration.test.ts`
 
 ## Design Guardrails
 

--- a/.mnemonic/notes/performance-principles-for-file-first-mcp-and-git-backed-wor-4e7d3bc8.md
+++ b/.mnemonic/notes/performance-principles-for-file-first-mcp-and-git-backed-wor-4e7d3bc8.md
@@ -9,11 +9,13 @@ tags:
   - completed
 lifecycle: permanent
 createdAt: '2026-03-14T22:14:46.759Z'
-updatedAt: '2026-03-15T13:45:02.169Z'
+updatedAt: '2026-03-25T12:37:13.150Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
   - id: mnemonic-key-design-decisions-3f2a6273
+    type: related-to
+  - id: active-session-project-cache-single-in-memory-vault-cache-pe-7463f124
     type: related-to
 memoryVersion: 1
 ---

--- a/AGENT.md
+++ b/AGENT.md
@@ -230,6 +230,7 @@ Keep these high-level anchors in mind:
 - `src/storage.ts` owns markdown notes and embedding JSON persistence
 - `src/git.ts` makes git part of normal mutating behavior
 - `src/migration.ts` owns schema evolution and dry-run-first migration flow
+- `src/cache.ts` owns the active session project cache: one in-memory `SessionProjectCache` per project, keyed by project ID; invalidated on every write-path tool
 - `src/recall.ts` and `src/consolidate.ts` hold behavior that intentionally stays lightweight instead of introducing heavier runtime state
 
 ## Prompts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to `mnemonic` will be documented in this file.
 
 The format is loosely based on Keep a Changelog and uses semver-style version headings.
 
+## [0.17.0] - 2026-03-25
+
+### Added
+
+- Active session project cache (`src/cache.ts`): notes and embeddings are cached in memory after the first access within an MCP session, so repeated calls to `recall`, `get`, and `project_memory_summary` skip redundant storage reads.
+- The cache is invalidated automatically on every write-path tool (`remember`, `update`, `forget`, `relate`, `unrelate`, `move_memory`, `consolidate`, `sync`) and on branch switch.
+
 ## [0.16.0] - 2026-03-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,10 +23,9 @@ mnemonic is at the inception stage. The storage format (frontmatter schema, vaul
 
 - Hundreds to low thousands of notes: excellent fit.
 - Several thousand: often fine, depending on note size, machine speed, and embedding throughput.
+- Within a session, notes and embeddings are cached after first access — repeated `recall`, `get`, and `project_memory_summary` calls skip storage reads regardless of vault size.
 - Very large collections: expect pain points around reindex time, recall latency, and git churn.
 - Many concurrent writers or massive scale: consider a dedicated database and indexing layer instead.
-
-**Session performance:** Within a single MCP session, notes and embeddings are cached in memory after the first access. Repeated calls to `recall`, `get`, and `project_memory_summary` within the same session avoid redundant storage reads. The cache is invalidated automatically on any write (`remember`, `update`, `forget`, `relate`, `unrelate`, `move_memory`, `consolidate`, `sync`).
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ mnemonic is at the inception stage. The storage format (frontmatter schema, vaul
 - Very large collections: expect pain points around reindex time, recall latency, and git churn.
 - Many concurrent writers or massive scale: consider a dedicated database and indexing layer instead.
 
+**Session performance:** Within a single MCP session, notes and embeddings are cached in memory after the first access. Repeated calls to `recall`, `get`, and `project_memory_summary` within the same session avoid redundant storage reads. The cache is invalidated automatically on any write (`remember`, `update`, `forget`, `relate`, `unrelate`, `move_memory`, `consolidate`, `sync`).
+
 ## Prerequisites
 
 [Ollama](https://ollama.com) must be running locally with an embedding model pulled:

--- a/docs/index.html
+++ b/docs/index.html
@@ -2002,6 +2002,26 @@ VAULT_PATH = <span class="str">"/Users/you/mnemonic-vault"</span></pre>
       <div class="dogfood-card fade-up">
         <div class="dogfood-card-top">
           <div class="dogfood-meta">
+            <span class="dogfood-tag">architecture</span>
+            <span class="dogfood-tag">performance</span>
+            <span class="dogfood-tag">decision</span>
+          </div>
+          <div class="dogfood-id">active-session-project-cache-single-in-memory-vault-cache-pe-7463f124</div>
+        </div>
+        <h3 class="dogfood-title">Active session project cache</h3>
+        <div class="dogfood-body">
+          <p>A module-level singleton in <code>src/cache.ts</code> caches notes, embeddings, and projections per vault for the duration of the MCP session. Notes and embeddings are co-loaded in a single <code>Promise.all()</code> pass on first access, so both are always warm after one I/O round trip.</p>
+          <p>The cache is keyed by project ID and invalidated on every write-path tool. All cache functions are fail-soft: errors return <code>undefined</code> and callers fall back to direct storage. Instrumented with <code>[cache:hit/miss/build/invalidate/fallback]</code> events and per-tool timing.</p>
+        </div>
+        <div class="dogfood-footer">
+          <span class="dogfood-rel">relates to recall-heuristic, enrichment-layer-design</span>
+          <span class="dogfood-date">Mar 25, 2026</span>
+        </div>
+      </div>
+
+      <div class="dogfood-card fade-up">
+        <div class="dogfood-card-top">
+          <div class="dogfood-meta">
             <span class="dogfood-tag">markdown</span>
             <span class="dogfood-tag">linting</span>
             <span class="dogfood-tag">dogfooding</span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@danielmarbach/mnemonic-mcp",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.1",
         "gray-matter": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "A local MCP memory server backed by markdown + JSON files, synced via git",
   "type": "module",
   "repository": {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,207 @@
+import { performance } from "perf_hooks";
+import type { Note, EmbeddingRecord } from "./storage.js";
+import type { NoteProjection } from "./structured-content.js";
+import type { Vault } from "./vault.js";
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+interface VaultCache {
+  notesById: Map<string, Note>;
+  noteList: Note[];
+  embeddings: EmbeddingRecord[];
+}
+
+export interface SessionProjectCache {
+  projectId: string;
+  /** Per-vault caches keyed by vaultPath. Built lazily per vault on first access. */
+  vaultCaches: Map<string, VaultCache>;
+  /** Projection cache shared across all cached vaults for this project. */
+  projectionsById: Map<string, NoteProjection>;
+  /** ISO timestamp of when this cache entry was first created. */
+  lastBuiltAt: string;
+}
+
+interface SessionCaches {
+  activeProject?: SessionProjectCache;
+}
+
+// ── Module-level singleton ─────────────────────────────────────────────────────
+
+const sessionCaches: SessionCaches = {};
+
+// ── Internal helpers ───────────────────────────────────────────────────────────
+
+function debugLog(event: string, message: string): void {
+  console.error(`[${event}] ${message}`);
+}
+
+function ensureActiveProjectCache(projectId: string): SessionProjectCache {
+  const current = sessionCaches.activeProject;
+  if (current?.projectId === projectId) {
+    return current;
+  }
+  // Different project (or first use): create fresh cache
+  if (current) {
+    debugLog("cache:invalidate", `switching project from=${current.projectId} to=${projectId}`);
+  }
+  const fresh: SessionProjectCache = {
+    projectId,
+    vaultCaches: new Map(),
+    projectionsById: new Map(),
+    lastBuiltAt: new Date().toISOString(),
+  };
+  sessionCaches.activeProject = fresh;
+  return fresh;
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────────
+
+/**
+ * Discard the entire active project cache.
+ *
+ * Call this after any mutation that modifies notes, embeddings, or relationships
+ * so the next read rebuilds from storage. Safe to call when no cache exists (no-op).
+ */
+export function invalidateActiveProjectCache(): void {
+  if (sessionCaches.activeProject) {
+    debugLog("cache:invalidate", `project=${sessionCaches.activeProject.projectId}`);
+    sessionCaches.activeProject = undefined;
+  }
+}
+
+/**
+ * Return the active project cache for the given projectId without triggering a build.
+ * Returns undefined when no cache exists or the cached project is different.
+ */
+export function getActiveProjectCache(projectId: string): SessionProjectCache | undefined {
+  const cache = sessionCaches.activeProject;
+  if (cache?.projectId === projectId) return cache;
+  return undefined;
+}
+
+/**
+ * Get the full note list for a vault from the session cache, building it lazily if needed.
+ *
+ * When the vault cache is first built, notes AND embeddings are loaded together so
+ * both are available for subsequent calls at no extra I/O cost.
+ *
+ * Fail-soft: returns `undefined` on error. Callers must fall back to direct storage access.
+ */
+export async function getOrBuildVaultNoteList(
+  projectId: string,
+  vault: Vault
+): Promise<Note[] | undefined> {
+  const vaultPath = vault.storage.vaultPath;
+  const cache = ensureActiveProjectCache(projectId);
+
+  const existing = cache.vaultCaches.get(vaultPath);
+  if (existing) {
+    debugLog("cache:hit", `project=${projectId} vault=${vaultPath} notes=${existing.noteList.length}`);
+    return existing.noteList;
+  }
+
+  debugLog("cache:miss", `project=${projectId} vault=${vaultPath}`);
+  try {
+    const t0 = performance.now();
+    const [noteList, embeddings] = await Promise.all([
+      vault.storage.listNotes(),
+      vault.storage.listEmbeddings(),
+    ]);
+    const notesById = new Map<string, Note>(noteList.map((n) => [n.id, n]));
+    cache.vaultCaches.set(vaultPath, { notesById, noteList, embeddings });
+    const ms = (performance.now() - t0).toFixed(1);
+    debugLog(
+      "cache:build",
+      `project=${projectId} vault=${vaultPath} notes=${noteList.length} embeddings=${embeddings.length} time=${ms}ms`
+    );
+    return noteList;
+  } catch (err) {
+    debugLog("cache:fallback", `project=${projectId} vault=${vaultPath} error=${String(err)}`);
+    return undefined;
+  }
+}
+
+/**
+ * Get the embeddings list for a vault from the session cache, building it lazily if needed.
+ *
+ * When the vault cache is first built, notes AND embeddings are loaded together so
+ * both are available for subsequent calls at no extra I/O cost.
+ *
+ * Fail-soft: returns `undefined` on error. Callers must fall back to direct storage access.
+ */
+export async function getOrBuildVaultEmbeddings(
+  projectId: string,
+  vault: Vault
+): Promise<EmbeddingRecord[] | undefined> {
+  const vaultPath = vault.storage.vaultPath;
+  const cache = ensureActiveProjectCache(projectId);
+
+  const existing = cache.vaultCaches.get(vaultPath);
+  if (existing) {
+    debugLog("cache:hit", `project=${projectId} vault=${vaultPath} embeddings=${existing.embeddings.length}`);
+    return existing.embeddings;
+  }
+
+  debugLog("cache:miss", `project=${projectId} vault=${vaultPath}`);
+  try {
+    const t0 = performance.now();
+    const [noteList, embeddings] = await Promise.all([
+      vault.storage.listNotes(),
+      vault.storage.listEmbeddings(),
+    ]);
+    const notesById = new Map<string, Note>(noteList.map((n) => [n.id, n]));
+    cache.vaultCaches.set(vaultPath, { notesById, noteList, embeddings });
+    const ms = (performance.now() - t0).toFixed(1);
+    debugLog(
+      "cache:build",
+      `project=${projectId} vault=${vaultPath} notes=${noteList.length} embeddings=${embeddings.length} time=${ms}ms`
+    );
+    return embeddings;
+  } catch (err) {
+    debugLog("cache:fallback", `project=${projectId} vault=${vaultPath} error=${String(err)}`);
+    return undefined;
+  }
+}
+
+/**
+ * Look up a single note from an already-built vault cache.
+ * Returns `undefined` when the vault cache has not been built yet or the note is not found.
+ * Does NOT trigger a cache build — callers should use `getOrBuildVaultNoteList` or
+ * `getOrBuildVaultEmbeddings` to ensure the vault cache is warm first.
+ */
+export function getSessionCachedNote(
+  projectId: string,
+  vaultPath: string,
+  noteId: string
+): Note | undefined {
+  const cache = sessionCaches.activeProject;
+  if (!cache || cache.projectId !== projectId) return undefined;
+  return cache.vaultCaches.get(vaultPath)?.notesById.get(noteId);
+}
+
+/**
+ * Retrieve a cached projection for a note.
+ * Returns `undefined` when no cache or projection exists.
+ */
+export function getSessionCachedProjection(
+  projectId: string,
+  noteId: string
+): NoteProjection | undefined {
+  const cache = sessionCaches.activeProject;
+  if (!cache || cache.projectId !== projectId) return undefined;
+  return cache.projectionsById.get(noteId);
+}
+
+/**
+ * Store a projection in the session cache.
+ * No-op when no active cache exists for this project.
+ */
+export function setSessionCachedProjection(
+  projectId: string,
+  noteId: string,
+  projection: NoteProjection
+): void {
+  const cache = sessionCaches.activeProject;
+  if (!cache || cache.projectId !== projectId) return;
+  cache.projectionsById.set(noteId, projection);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,13 @@ import { embed, cosineSimilarity, embedModel } from "./embeddings.js";
 import { type CommitResult, type PushResult, type SyncResult } from "./git.js";
 import { buildTemporalHistoryEntry, computeConfidence, getNoteProvenance } from "./provenance.js";
 import { getOrBuildProjection } from "./projections.js";
+import {
+  invalidateActiveProjectCache,
+  getOrBuildVaultEmbeddings,
+  getOrBuildVaultNoteList,
+  getSessionCachedNote,
+} from "./cache.js";
+import { performance } from "perf_hooks";
 
 import {
   filterRelationships,
@@ -500,6 +507,9 @@ async function ensureBranchSynced(cwd?: string): Promise<boolean> {
 
   const mainBackfill = await backfillEmbeddingsAfterSync(vaultManager.main.storage, "main vault", [], true);
   console.error(`[branch] Main vault embedded ${mainBackfill.embedded} notes`);
+
+  // Vault contents changed — discard session cache so next access rebuilds from fresh state
+  invalidateActiveProjectCache();
 
   return true;
 }
@@ -1070,6 +1080,7 @@ async function collectVisibleNotes(
   scope: SearchScope = "all",
   tags?: string[],
   storedIn: StorageScope = "any",
+  sessionProjectId?: string,
 ): Promise<{ project: Awaited<ReturnType<typeof resolveProject>>; entries: NoteEntry[] }> {
   const project = await resolveProject(cwd);
   const vaults = await vaultManager.searchOrder(cwd);
@@ -1082,10 +1093,25 @@ async function collectVisibleNotes(
   const entries: NoteEntry[] = [];
 
   for (const vault of vaults) {
-    const vaultNotes = await vault.storage.listNotes(
-      filterProject !== undefined ? { project: filterProject } : undefined
-    );
-    for (const note of vaultNotes) {
+    let rawNotes: Note[];
+    if (sessionProjectId) {
+      const cached = await getOrBuildVaultNoteList(sessionProjectId, vault);
+      if (cached !== undefined) {
+        // Apply project filter on the full cached list
+        rawNotes = filterProject !== undefined
+          ? cached.filter((n) => filterProject === null ? !n.project : n.project === filterProject)
+          : cached;
+      } else {
+        rawNotes = await vault.storage.listNotes(
+          filterProject !== undefined ? { project: filterProject } : undefined
+        );
+      }
+    } else {
+      rawNotes = await vault.storage.listNotes(
+        filterProject !== undefined ? { project: filterProject } : undefined
+      );
+    }
+    for (const note of rawNotes) {
       if (seen.has(note.id)) {
         continue;
       }
@@ -1843,7 +1869,8 @@ server.registerTool(
       timestamp: now,
       persistence,
     };
-    
+
+    invalidateActiveProjectCache();
     return {
       content: [{ type: "text", text: textContent }],
       structuredContent,
@@ -2120,6 +2147,7 @@ server.registerTool(
     outputSchema: RecallResultSchema,
   },
   async ({ query, cwd, limit, minSimilarity, mode, verbose, tags, scope }) => {
+    const t0Recall = performance.now();
     await ensureBranchSynced(cwd);
 
     const project = await resolveProject(cwd);
@@ -2129,6 +2157,11 @@ server.registerTool(
 
     const noteCacheKey = (vault: Vault, id: string): string => `${vault.storage.vaultPath}::${id}`;
     const readCachedNote = async (vault: Vault, id: string): Promise<Note | null> => {
+      // Check session cache first (populated when getOrBuildVaultEmbeddings was called)
+      if (project) {
+        const sessionNote = getSessionCachedNote(project.id, vault.storage.vaultPath, id);
+        if (sessionNote !== undefined) return sessionNote;
+      }
       const key = noteCacheKey(vault, id);
       const cached = noteCache.get(key);
       if (cached) {
@@ -2150,7 +2183,9 @@ server.registerTool(
     const scored: Array<{ id: string; score: number; boosted: number; vault: Vault; isCurrentProject: boolean }> = [];
 
     for (const vault of vaults) {
-      const embeddings = await vault.storage.listEmbeddings();
+      const embeddings = project
+        ? (await getOrBuildVaultEmbeddings(project.id, vault)) ?? await vault.storage.listEmbeddings()
+        : await vault.storage.listEmbeddings();
 
       for (const rec of embeddings) {
         const rawScore = cosineSimilarity(queryVec, rec.embedding);
@@ -2298,7 +2333,7 @@ server.registerTool(
     }
 
     const textContent = `${header}\n\n${sections.join("\n\n---\n\n")}`;
-    
+
     const structuredContent: RecallResult = {
       action: "recalled",
       query,
@@ -2306,6 +2341,7 @@ server.registerTool(
       results: structuredResults,
     };
 
+    console.error(`[recall:timing] ${(performance.now() - t0Recall).toFixed(1)}ms`);
     return {
       content: [{ type: "text", text: textContent }],
       structuredContent,
@@ -2470,6 +2506,7 @@ server.registerTool(
       persistence,
     };
     
+    invalidateActiveProjectCache();
     return { content: [{ type: "text", text: `Updated memory '${id}'\n${formatPersistenceSummary(persistence)}` }], structuredContent };
   }
 );
@@ -2592,6 +2629,7 @@ server.registerTool(
     };
     
     const retrySummary = formatRetrySummary(retry);
+    invalidateActiveProjectCache();
     return {
       content: [{
         type: "text",
@@ -2635,6 +2673,7 @@ server.registerTool(
     outputSchema: GetResultSchema,
   },
   async ({ ids, cwd, includeRelationships }) => {
+    const t0Get = performance.now();
     await ensureBranchSynced(cwd);
 
     const project = await resolveProject(cwd);
@@ -2642,7 +2681,20 @@ server.registerTool(
     const notFound: string[] = [];
 
     for (const id of ids) {
-      const result = await vaultManager.findNote(id, cwd);
+      // Check session cache before hitting storage
+      let result: { note: Note; vault: Vault } | null = null;
+      if (project) {
+        for (const vault of vaultManager.allKnownVaults()) {
+          const cached = getSessionCachedNote(project.id, vault.storage.vaultPath, id);
+          if (cached !== undefined) {
+            result = { note: cached, vault };
+            break;
+          }
+        }
+      }
+      if (!result) {
+        result = await vaultManager.findNote(id, cwd);
+      }
       if (!result) {
         notFound.push(id);
         continue;
@@ -2698,6 +2750,7 @@ server.registerTool(
       notFound,
     };
 
+    console.error(`[get:timing] ${(performance.now() - t0Get).toFixed(1)}ms`);
     return { content: [{ type: "text", text: lines.join("\n").trim() }], structuredContent };
   }
 );
@@ -3353,9 +3406,12 @@ server.registerTool(
     outputSchema: ProjectSummaryResultSchema,
   },
   async ({ cwd, maxPerTheme, recentLimit, anchorLimit, includeRelatedGlobal, relatedGlobalLimit }) => {
+    const t0Summary = performance.now();
     await ensureBranchSynced(cwd);
 
-    const { project, entries } = await collectVisibleNotes(cwd, "all");
+    // Pre-resolve project so we can pass its id to collectVisibleNotes for session caching
+    const preProject = await resolveProject(cwd);
+    const { project, entries } = await collectVisibleNotes(cwd, "all", undefined, "any", preProject?.id);
     if (!project) {
       return { content: [{ type: "text", text: `Could not detect a project for: ${cwd}` }], isError: true };
     }
@@ -3724,6 +3780,7 @@ server.registerTool(
       relatedGlobal,
     };
 
+    console.error(`[summary:timing] ${(performance.now() - t0Summary).toFixed(1)}ms`);
     return { content: [{ type: "text", text: sections.join("\n") }], structuredContent };
   }
 );
@@ -3818,7 +3875,9 @@ server.registerTool(
       action: "synced",
       vaults: vaultResults,
     };
-    
+
+    // Vault contents may have changed via pull — discard session cache
+    invalidateActiveProjectCache();
     return { content: [{ type: "text", text: lines.join("\n") }], structuredContent };
   }
 );
@@ -3990,7 +4049,8 @@ server.registerTool(
     const associationText = metadataRewritten
       ? `Project association is now ${associationValue}.`
       : `Project association remains ${associationValue}.`;
-    
+
+    invalidateActiveProjectCache();
     return {
       content: [{
         type: "text",
@@ -4186,6 +4246,7 @@ server.registerTool(
     };
     
     const retrySummary = formatRetrySummary(retry);
+    invalidateActiveProjectCache();
     return {
       content: [{
         type: "text",
@@ -4371,6 +4432,7 @@ server.registerTool(
     };
     
     const retrySummary = formatRetrySummary(retry);
+    invalidateActiveProjectCache();
     return {
       content: [{
         type: "text",
@@ -4487,14 +4549,20 @@ server.registerTool(
       case "suggest-merges":
         return suggestMerges(projectNotes, threshold, defaultConsolidationMode, project, mode);
 
-      case "execute-merge":
+      case "execute-merge": {
         if (!mergePlan) {
           return { content: [{ type: "text", text: "execute-merge strategy requires a mergePlan with sourceIds and targetTitle." }], isError: true };
         }
-        return executeMerge(entries, mergePlan, defaultConsolidationMode, project, cwd, mode, policy, allowProtectedBranch);
+        const mergeResult = await executeMerge(entries, mergePlan, defaultConsolidationMode, project, cwd, mode, policy, allowProtectedBranch);
+        invalidateActiveProjectCache();
+        return mergeResult;
+      }
 
-      case "prune-superseded":
-        return pruneSuperseded(projectNotes, mode ?? defaultConsolidationMode, project, cwd, policy, allowProtectedBranch);
+      case "prune-superseded": {
+        const pruneResult = await pruneSuperseded(projectNotes, mode ?? defaultConsolidationMode, project, cwd, policy, allowProtectedBranch);
+        invalidateActiveProjectCache();
+        return pruneResult;
+      }
 
       case "dry-run":
         return dryRunAll(projectNotes, threshold, defaultConsolidationMode, project, mode);

--- a/tests/cache.unit.test.ts
+++ b/tests/cache.unit.test.ts
@@ -1,0 +1,391 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import type { Note, EmbeddingRecord } from "../src/storage.js";
+import type { NoteProjection } from "../src/structured-content.js";
+import type { Vault } from "../src/vault.js";
+
+import {
+  invalidateActiveProjectCache,
+  getActiveProjectCache,
+  getOrBuildVaultNoteList,
+  getOrBuildVaultEmbeddings,
+  getSessionCachedNote,
+  getSessionCachedProjection,
+  setSessionCachedProjection,
+} from "../src/cache.js";
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
+const NOW = "2026-01-01T00:00:00.000Z";
+
+function makeNote(id: string, overrides: Partial<Note> = {}): Note {
+  return {
+    id,
+    title: `Note ${id}`,
+    content: `Content for ${id}`,
+    tags: [],
+    lifecycle: "permanent",
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+function makeEmbedding(id: string): EmbeddingRecord {
+  return { id, model: "nomic-embed-text", embedding: [0.1, 0.2, 0.3], updatedAt: NOW };
+}
+
+function makeProjection(noteId: string): NoteProjection {
+  return {
+    noteId,
+    title: `Note ${noteId}`,
+    summary: "Summary",
+    headings: [],
+    tags: [],
+    lifecycle: "permanent",
+    updatedAt: NOW,
+    projectionText: `Title: Note ${noteId}`,
+    generatedAt: NOW,
+  };
+}
+
+function makeVault(vaultPath: string, notes: Note[], embeddings: EmbeddingRecord[]): Vault {
+  return {
+    storage: {
+      vaultPath,
+      listNotes: vi.fn().mockResolvedValue(notes),
+      listEmbeddings: vi.fn().mockResolvedValue(embeddings),
+      readNote: vi.fn(),
+      writeNote: vi.fn(),
+      deleteNote: vi.fn(),
+      readEmbedding: vi.fn(),
+      writeEmbedding: vi.fn(),
+      readProjection: vi.fn(),
+      writeProjection: vi.fn(),
+      notesDir: `${vaultPath}/notes`,
+      embeddingsDir: `${vaultPath}/embeddings`,
+      projectionsDir: `${vaultPath}/projections`,
+      init: vi.fn(),
+    } as unknown as Vault["storage"],
+    git: {} as Vault["git"],
+    isProject: false,
+    notesRelDir: ".mnemonic/notes",
+  } as unknown as Vault;
+}
+
+// ── Reset between tests ───────────────────────────────────────────────────────
+
+beforeEach(() => {
+  // Clear any active cache left over from previous tests
+  invalidateActiveProjectCache();
+});
+
+// ── A. Cache lifecycle ─────────────────────────────────────────────────────────
+
+describe("cache lifecycle", () => {
+  it("has no cache before first access", () => {
+    expect(getActiveProjectCache("test-project")).toBeUndefined();
+  });
+
+  it("builds vault note list on first access (cache miss)", async () => {
+    const notes = [makeNote("note-1"), makeNote("note-2")];
+    const vault = makeVault("/vault/project", notes, []);
+
+    const result = await getOrBuildVaultNoteList("test-project", vault);
+
+    expect(result).toEqual(notes);
+    expect(vault.storage.listNotes).toHaveBeenCalledOnce();
+  });
+
+  it("reuses cached note list on subsequent access (cache hit)", async () => {
+    const notes = [makeNote("note-1")];
+    const vault = makeVault("/vault/project", notes, []);
+
+    await getOrBuildVaultNoteList("test-project", vault);
+    const second = await getOrBuildVaultNoteList("test-project", vault);
+
+    expect(second).toEqual(notes);
+    // listNotes should only be called once — second call hits cache
+    expect(vault.storage.listNotes).toHaveBeenCalledOnce();
+  });
+
+  it("builds vault embeddings on first access (cache miss)", async () => {
+    const embeddings = [makeEmbedding("note-1"), makeEmbedding("note-2")];
+    const vault = makeVault("/vault/project", [], embeddings);
+
+    const result = await getOrBuildVaultEmbeddings("test-project", vault);
+
+    expect(result).toEqual(embeddings);
+    expect(vault.storage.listEmbeddings).toHaveBeenCalledOnce();
+  });
+
+  it("reuses cached embeddings on subsequent access (cache hit)", async () => {
+    const embeddings = [makeEmbedding("note-1")];
+    const vault = makeVault("/vault/project", [], embeddings);
+
+    await getOrBuildVaultEmbeddings("test-project", vault);
+    const second = await getOrBuildVaultEmbeddings("test-project", vault);
+
+    expect(second).toEqual(embeddings);
+    expect(vault.storage.listEmbeddings).toHaveBeenCalledOnce();
+  });
+
+  it("shares vault data between note list and embeddings calls", async () => {
+    const notes = [makeNote("note-1")];
+    const embeddings = [makeEmbedding("note-1")];
+    const vault = makeVault("/vault/project", notes, embeddings);
+
+    // First call via notes — builds the vault cache (loads both notes AND embeddings)
+    await getOrBuildVaultNoteList("test-project", vault);
+    // Second call via embeddings — should hit the same vault cache
+    const cachedEmbeddings = await getOrBuildVaultEmbeddings("test-project", vault);
+
+    expect(cachedEmbeddings).toEqual(embeddings);
+    // Only one call to each because both were loaded in a single build
+    expect(vault.storage.listNotes).toHaveBeenCalledOnce();
+    expect(vault.storage.listEmbeddings).toHaveBeenCalledOnce();
+  });
+
+  it("reports cache presence after first build", async () => {
+    const vault = makeVault("/vault/project", [], []);
+
+    await getOrBuildVaultNoteList("test-project", vault);
+
+    expect(getActiveProjectCache("test-project")).toBeDefined();
+  });
+
+  it("returns undefined from getActiveProjectCache for a different project", async () => {
+    const vault = makeVault("/vault/project", [], []);
+
+    await getOrBuildVaultNoteList("project-A", vault);
+
+    expect(getActiveProjectCache("project-B")).toBeUndefined();
+  });
+});
+
+// ── B. Invalidation ────────────────────────────────────────────────────────────
+
+describe("invalidation", () => {
+  it("clears cache on invalidation", async () => {
+    const vault = makeVault("/vault/project", [makeNote("note-1")], []);
+    await getOrBuildVaultNoteList("test-project", vault);
+
+    expect(getActiveProjectCache("test-project")).toBeDefined();
+
+    invalidateActiveProjectCache();
+
+    expect(getActiveProjectCache("test-project")).toBeUndefined();
+  });
+
+  it("is safe to call when no cache exists (no-op)", () => {
+    expect(() => invalidateActiveProjectCache()).not.toThrow();
+  });
+
+  it("forces a rebuild on next access after invalidation", async () => {
+    const vault = makeVault("/vault/project", [makeNote("note-1")], []);
+
+    await getOrBuildVaultNoteList("test-project", vault);
+    invalidateActiveProjectCache();
+    await getOrBuildVaultNoteList("test-project", vault);
+
+    // Called twice: once before invalidation, once after rebuild
+    expect(vault.storage.listNotes).toHaveBeenCalledTimes(2);
+  });
+
+  it("creates a fresh cache when project switches", async () => {
+    const vaultA = makeVault("/vault/A", [makeNote("note-a")], []);
+    const vaultB = makeVault("/vault/B", [makeNote("note-b")], []);
+
+    await getOrBuildVaultNoteList("project-A", vaultA);
+    // Accessing project-B should silently discard project-A cache and start fresh
+    await getOrBuildVaultNoteList("project-B", vaultB);
+
+    expect(getActiveProjectCache("project-A")).toBeUndefined();
+    expect(getActiveProjectCache("project-B")).toBeDefined();
+  });
+});
+
+// ── C. Individual note lookup ──────────────────────────────────────────────────
+
+describe("getSessionCachedNote", () => {
+  it("returns note after vault cache is built", async () => {
+    const note = makeNote("note-1");
+    const vault = makeVault("/vault/project", [note], []);
+
+    await getOrBuildVaultNoteList("test-project", vault);
+
+    const found = getSessionCachedNote("test-project", "/vault/project", "note-1");
+    expect(found).toEqual(note);
+  });
+
+  it("returns undefined for an id not in the vault", async () => {
+    const vault = makeVault("/vault/project", [makeNote("note-1")], []);
+    await getOrBuildVaultNoteList("test-project", vault);
+
+    expect(getSessionCachedNote("test-project", "/vault/project", "missing")).toBeUndefined();
+  });
+
+  it("returns undefined when no cache exists", () => {
+    expect(getSessionCachedNote("test-project", "/vault/project", "note-1")).toBeUndefined();
+  });
+
+  it("returns undefined for a different project", async () => {
+    const note = makeNote("note-1");
+    const vault = makeVault("/vault/project", [note], []);
+    await getOrBuildVaultNoteList("project-A", vault);
+
+    expect(getSessionCachedNote("project-B", "/vault/project", "note-1")).toBeUndefined();
+  });
+});
+
+// ── D. Projection cache ────────────────────────────────────────────────────────
+
+describe("projection cache", () => {
+  it("stores and retrieves a projection", async () => {
+    const vault = makeVault("/vault/project", [], []);
+    // Ensure cache exists for the project
+    await getOrBuildVaultNoteList("test-project", vault);
+
+    const projection = makeProjection("note-1");
+    setSessionCachedProjection("test-project", "note-1", projection);
+
+    expect(getSessionCachedProjection("test-project", "note-1")).toEqual(projection);
+  });
+
+  it("returns undefined for unknown projection", async () => {
+    const vault = makeVault("/vault/project", [], []);
+    await getOrBuildVaultNoteList("test-project", vault);
+
+    expect(getSessionCachedProjection("test-project", "missing")).toBeUndefined();
+  });
+
+  it("projection is cleared on invalidation", async () => {
+    const vault = makeVault("/vault/project", [], []);
+    await getOrBuildVaultNoteList("test-project", vault);
+
+    setSessionCachedProjection("test-project", "note-1", makeProjection("note-1"));
+    invalidateActiveProjectCache();
+
+    expect(getSessionCachedProjection("test-project", "note-1")).toBeUndefined();
+  });
+
+  it("setSessionCachedProjection is a no-op when no cache exists", () => {
+    expect(() => setSessionCachedProjection("test-project", "note-1", makeProjection("note-1"))).not.toThrow();
+  });
+});
+
+// ── E. Failure handling ────────────────────────────────────────────────────────
+
+describe("failure handling", () => {
+  it("returns undefined when storage.listNotes throws", async () => {
+    const vault = makeVault("/vault/project", [], []);
+    vi.mocked(vault.storage.listNotes).mockRejectedValueOnce(new Error("disk error"));
+
+    const result = await getOrBuildVaultNoteList("test-project", vault);
+
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when storage.listEmbeddings throws", async () => {
+    const vault = makeVault("/vault/project", [], []);
+    vi.mocked(vault.storage.listEmbeddings).mockRejectedValueOnce(new Error("io error"));
+
+    const result = await getOrBuildVaultEmbeddings("test-project", vault);
+
+    expect(result).toBeUndefined();
+  });
+
+  it("does not corrupt cache state after a failed build", async () => {
+    const notes = [makeNote("note-1")];
+    const vault = makeVault("/vault/project", notes, []);
+    vi.mocked(vault.storage.listNotes).mockRejectedValueOnce(new Error("first call fails"));
+
+    // First call fails
+    const failed = await getOrBuildVaultNoteList("test-project", vault);
+    expect(failed).toBeUndefined();
+
+    // Second call should succeed (storage back to healthy)
+    const ok = await getOrBuildVaultNoteList("test-project", vault);
+    expect(ok).toEqual(notes);
+  });
+});
+
+// ── F. Measurement coverage ────────────────────────────────────────────────────
+
+describe("measurement / instrumentation", () => {
+  it("emits cache:miss log on first build", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const vault = makeVault("/vault/project", [], []);
+
+    await getOrBuildVaultNoteList("test-project", vault);
+
+    const logs = spy.mock.calls.map((args) => args[0] as string);
+    expect(logs.some((l) => l.includes("[cache:miss]"))).toBe(true);
+    spy.mockRestore();
+  });
+
+  it("emits cache:build log with timing on first build", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const vault = makeVault("/vault/project", [], []);
+
+    await getOrBuildVaultNoteList("test-project", vault);
+
+    const logs = spy.mock.calls.map((args) => args[0] as string);
+    expect(logs.some((l) => l.includes("[cache:build]") && l.includes("time="))).toBe(true);
+    spy.mockRestore();
+  });
+
+  it("emits cache:hit log on warm access", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const vault = makeVault("/vault/project", [], []);
+
+    await getOrBuildVaultNoteList("test-project", vault);
+    spy.mockClear();
+    await getOrBuildVaultNoteList("test-project", vault);
+
+    const logs = spy.mock.calls.map((args) => args[0] as string);
+    expect(logs.some((l) => l.includes("[cache:hit]"))).toBe(true);
+    spy.mockRestore();
+  });
+
+  it("emits cache:invalidate log on invalidation", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const vault = makeVault("/vault/project", [], []);
+
+    await getOrBuildVaultNoteList("test-project", vault);
+    spy.mockClear();
+    invalidateActiveProjectCache();
+
+    const logs = spy.mock.calls.map((args) => args[0] as string);
+    expect(logs.some((l) => l.includes("[cache:invalidate]"))).toBe(true);
+    spy.mockRestore();
+  });
+
+  it("emits cache:fallback log on storage error", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const vault = makeVault("/vault/project", [], []);
+    vi.mocked(vault.storage.listNotes).mockRejectedValueOnce(new Error("io error"));
+
+    await getOrBuildVaultNoteList("test-project", vault);
+
+    const logs = spy.mock.calls.map((args) => args[0] as string);
+    expect(logs.some((l) => l.includes("[cache:fallback]"))).toBe(true);
+    spy.mockRestore();
+  });
+
+  it("instrumentation does not affect returned data", async () => {
+    const notes = [makeNote("note-1"), makeNote("note-2")];
+    const embeddings = [makeEmbedding("note-1")];
+    const vault = makeVault("/vault/project", notes, embeddings);
+
+    // Suppress debug output — should not change results
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const noteList = await getOrBuildVaultNoteList("test-project", vault);
+    const embList = await getOrBuildVaultEmbeddings("test-project", vault);
+
+    expect(noteList).toEqual(notes);
+    expect(embList).toEqual(embeddings);
+
+    vi.restoreAllMocks();
+  });
+});

--- a/tests/provenance.unit.test.ts
+++ b/tests/provenance.unit.test.ts
@@ -37,16 +37,17 @@ describe("computeConfidence", () => {
 
 describe("getNoteProvenance", () => {
   it("returns provenance when git has a commit for the file", async () => {
+    const recentTimestamp = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
     mockGit.getLastCommit.mockResolvedValueOnce({
       hash: "abc123",
       message: "feat: add test note",
-      timestamp: "2026-03-20T10:00:00Z",
+      timestamp: recentTimestamp,
     });
 
     const result = await getNoteProvenance(mockGit, "notes/test.md");
 
     expect(result).toEqual({
-      lastUpdatedAt: "2026-03-20T10:00:00Z",
+      lastUpdatedAt: recentTimestamp,
       lastCommitHash: "abc123",
       lastCommitMessage: "feat: add test note",
       recentlyChanged: true,

--- a/tests/tool-descriptions.integration.test.ts
+++ b/tests/tool-descriptions.integration.test.ts
@@ -188,6 +188,8 @@ describe("tool-descriptions", () => {
   }, 15000);
 
   it("keeps broad canonical tags near the top when the prompt is generic", async () => {
+    // Timeout doubled: this test spawns 5 processes (4×remember + discover_tags), more than any
+    // other test in this file. On slow CI the 15 s budget is too tight.
     const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mcp-vault-"));
     tempDirs.push(vaultDir);
     const embeddingServer = await startFakeEmbeddingServer();
@@ -255,7 +257,7 @@ describe("tool-descriptions", () => {
     } finally {
       await embeddingServer.close();
     }
-  }, 15000);
+  }, 30000);
 
   it("prefers an exact specific tag even when it only exists once", async () => {
     const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mcp-vault-"));


### PR DESCRIPTION
## Summary

This PR captures the following design decisions:

- **Active session project cache: single in-memory vault cache per MCP session**
- **Enrichment layer design: provenance, temporal recall, projections, and relationship expansion**
- **Performance principles and completed optimizations**

## Design Decisions

### Active session project cache: single in-memory vault cache per MCP session

**Tags:** architecture, performance, cache, scaling, decision

Phase 5 adds a lightweight in-memory session cache (`src/cache.ts`) that eliminates redundant `listNotes()` + `listEmbeddings()` I/O across tool calls within a single MCP session.

## Design

- **Module-level singleton** — `SessionProjectCache` keyed by project ID; no external library, plain TypeScript `Map` objects.
- **Single active project** — only the current project is cached; switching projects silently replaces the cache.
- **Per-vault cache** — each `VaultCache` holds `notesById`, `noteList`, and `embeddings`; built lazily on first access.
- **Eager co-load** — notes and embeddings are loaded together via `Promise.all([listNotes(), listEmbeddings()])` regardless of which accessor triggers the build, so both are always available after one I/O pass.
- **Projection cache** — `projectionsById` stored on `SessionProjectCache` for `NoteProjection` reuse across tools.
- **Fail-soft** — all cache functions return `undefined` on error; callers fall back to direct storage access.
- **Invalidation** — `invalidateActiveProjectCache()` (no-arg) is called by every write-path tool (`remember`, `update`, `forget`, `relate`, `unrelate`, `move_memory`, `consolidate`, `sync`) and on `ensureBranchSynced`.

## Instrumentation

Event log via `console.error`:

- `[cache:miss]` — first access per project/vault
- `[cache:build]` — successful build with `notes=N embeddings=N time=Xms`
- `[cache:hit]` — warm access
- `[cache:invalidate]` — on mutation or project switch
- `[cache:fallback]` — on storage error

Timing hooks added to `recall`, `get`, and `project_memory_summary` via `performance.now()`.

## Integration points in src/index.ts

- `collectVisibleNotes` accepts optional `sessionProjectId`; uses `getOrBuildVaultNoteList` with fallback
- `project_memory_summary` pre-resolves project before `collectVisibleNotes` to supply the cache key
- `recall` uses `getSessionCachedNote` for single-note lookup; `getOrBuildVaultEmbeddings` for embedding list
- `get` checks `getSessionCachedNote` before calling `vaultManager.findNote`

## Testing

29 unit tests in `tests/cache.unit.test.ts` covering: lifecycle, invalidation, note lookup, projection cache, failure handling, and instrumentation (all 6 event types verified without affecting returned data).

## Why full invalidation, not targeted per-note invalidation

The cache stores lists (`noteList: Note[]`, `embeddings: EmbeddingRecord[]`), not just individual entries. Targeted invalidation would require surgically mutating those arrays on every write path:

- `remember` → append to both arrays
- `forget` → splice from both arrays
- `update` → find-and-replace in both arrays
- `relate`/`unrelate` → update two note objects in-place (relationship data lives in note frontmatter content)
- `move_memory` → remove from one vault's cache, insert into another
- `sync` → unknown remote changeset; no way to know what changed without re-reading storage

That creates tight coupling between the cache module and storage mutation logic, and introduces a class of silent staleness bugs if any mutation path diverges. Full invalidation keeps correctness trivially obvious: write happens → cache is gone → next read rebuilds from storage.

The session pattern doesn't need targeted invalidation either. The cache's value is in the read phase — several `recall`/`get`/`project_memory_summary` calls before any writes. After a write, the rebuild cost is cheap (one parallel `listNotes()` + `listEmbeddings()`).

Projections are the one case where targeted invalidation would be clean (keyed by note ID, no list dependency), but the gain is marginal since projections are only populated explicitly by tools, not on every cache build.

## Other trade-offs

- No TTL, no LRU — session lifetime is bounded by the MCP process, so no eviction needed.
- Slight redundancy: `project_memory_summary` calls `resolveProject` twice (once to get cache key, once inside `collectVisibleNotes`). Accepted for clean code.
- No cross-tool projection warming — projections must still be computed and stored explicitly per tool call.

### Enrichment layer design: provenance, temporal recall, projections, and relationship expansion

**Tags:** architecture, design, decision, provenance, temporal, embeddings, relationship-expansion

Four post-processing enrichment layers added on top of semantic recall. Each is additive: core recall ranking is unaffected, failures fail-soft.

## Phase 1 — Provenance + Confidence

Every `recall` and `project_memory_summary` result includes git-backed metadata:

```typescript
type Provenance = {
  lastUpdatedAt: string;
  lastCommitHash: string;
  lastCommitMessage: string;
  recentlyChanged: boolean;  // daysSinceUpdate < 5
};
type Confidence = "high" | "medium" | "low";
```

Confidence heuristic:
```
if (lifecycle === "permanent" && centrality >= 5 && daysSinceUpdate < 30) → "high"
else if (daysSinceUpdate < 90) → "medium"
else → "low"
```

Git calls are read-only, scoped to top-N results only, and robust to missing repo/detached HEAD/empty history.

## Phase 2 — Temporal recall

`recall` gains opt-in `mode: "temporal"` for on-demand history exploration.

**Pipeline:** normal semantic recall first (including project bias) → then fetch git history for top N matched notes only.

History shape per note:
```ts
{ commitHash, timestamp, message, summary? }
```

Summary is compact diff-stat style: `+42/-10 lines`, `3 files changed`, `minor edit`, `substantial update`, `metadata-only change`. Never raw diffs.

`verbose: true` (only with `mode: "temporal"`) adds richer stats-based context. Even verbose avoids full diffs.

Bounded: top 3–5 notes, 3–5 commits each. No repo-wide scans. Default recall latency unchanged when temporal mode is not used.

**Non-goals:** no repo-wide timelines, no cross-note history stitching, no replacement of semantic recall with git traversal.

## Phase 3 — Projection layer

Projections are compact, deterministic derived representations used as embedding input instead of raw title+content.

**Schema** (stored in `vaultPath/projections/` as JSON, gitignored):
- `projectionText`: max 1200 chars — Title / Lifecycle / Tags / Summary / Headings
- `summary`: first non-heading paragraph → first bullet list → first 200 chars
- `headings`: h1–h3, deduplicated, max 8
- `updatedAt`: staleness anchor (matches note.updatedAt)

**Staleness:** `isProjectionStale = projection.updatedAt !== note.updatedAt`. No hashing needed.

**Lazy build:** `getOrBuildProjection` builds on demand, saves best-effort (never throws). Fallback: if build fails, embed uses raw title+content.

**Storage:** `Storage` gains `projectionsDir`, `projectionPath(id)`, `writeProjection()`, `readProjection()`. `ensureGitignore` adds both `embeddings/` and `projections/`.

## Phase 4 — Relationship expansion

Bounded 1-hop relationship previews attached to `recall`, `project_memory_summary`, and `get` results.

**Scoring:**
```
relationshipScore = sameProjectBoost + anchorBoost + recencyBoost + confidenceBoost
```

**Hard limits:** max 3 shown per note, absolute cap 5, `truncated: true` when more exist.

**Integration:**
- `project_memory_summary`: `primaryEntry` and `suggestedNext` always get previews if relations exist
- `recall`: top 1–3 results get previews; semantic ranking unchanged, expansion happens after selection
- `get`: `includeRelationships?: boolean` flag

**Selection rules:** 1-hop only (no recursion), same-project first, explicit `relatedTo` edges only (no semantic inference), anchor notes prioritized.

**Non-goals:** no recursive traversal, no semantic edge inference, no redesign of recall ranking, no graph visualizations.

### Performance principles and completed optimizations

**Tags:** performance, io, git, design, principles, completed

## Durable Performance Principles

Core principles:

- Favor low-risk optimizations that preserve behavior and safety over broad rewrites
- Optimize hot paths by reusing already-available data in-memory before adding new I/O
- Keep git subprocess usage minimal, especially on successful mutation paths
- Prefer bounded parallel file reads for independent files while preserving output stability and ordering contracts
- Keep retry/recovery metadata construction constant-time from existing context

## Completed Optimizations

Low-hanging performance improvements (March 2024):

### 1. Recall per-request note cache

- Added caching to avoid duplicate note reads during recall operations
- Commit: `perf: cache recall note reads per request`
- Validation: `npm test -- tests/recall.test.ts`

### 2. Consolidate analysis embedding reuse  

- Reuse loaded embeddings during consolidate analysis instead of re-reading per comparison
- Commit: `perf: reuse embeddings in consolidate analysis`
- Validation: `npm test -- tests/consolidate.test.ts`

### 3. Storage.listNotes parallel file reads

- Parallelized file reads with preserved order
- Commit: `perf: parallelize Storage.listNotes reads`
- Validation: `npm test -- tests/storage.test.ts tests/recall.test.ts tests/project-introspection.test.ts`

### 4. Storage.listEmbeddings parallel file reads

- Parallelized embeddings file reads
- Commit: `perf: parallelize Storage.listEmbeddings reads`
- Validation: `npm test -- tests/embeddings.test.ts tests/recall.test.ts tests/consolidate.test.ts`

### 5. VaultManager.searchOrder duplicate resolution

- Avoid duplicate git-root lookup in searchOrder
- Commit: `perf: avoid duplicate git-root lookup in searchOrder`
- Validation: `npm test -- tests/vault.test.ts tests/project.test.ts tests/project-introspection.test.ts`

### 6. Active session project cache (Phase 5)

- Module-level singleton in `src/cache.ts` caches `listNotes()` + `listEmbeddings()` together per vault; `recall`, `get`, and `project_memory_summary` all read from the same warm cache within a session
- Invalidated on every write-path tool; fail-soft returns `undefined` so callers fall back cleanly
- Instrumented with `[cache:hit/miss/build/invalidate/fallback]` events and per-tool timing via `performance.now()`
- Validation: `npm test -- tests/cache.unit.test.ts tests/project-memory-summary.integration.test.ts`

## Design Guardrails

- Avoid full-vault scans in mutation hot paths
- Avoid adding extra git calls on successful commit/push flows
- Keep correctness and recoverability explicit in structured outputs

## Future Performance Work

When adding new features, apply these principles:

1. Measure before optimizing
2. Prefer in-memory reuse over new I/O
3. Keep hot paths lean
4. Maintain test coverage for performance-critical paths

---

_Generated from 3 design decision note(s) in `.mnemonic/notes/`. Run `/update-pr` to regenerate._