### PR TITLE
Parallel consolidate operations can leave staged local-only notes without actionable retry signal

### DIFF
--- a/.mnemonic/notes/git-resilience-retry-contract-concurrency-design-and-languag-351fab47.md
+++ b/.mnemonic/notes/git-resilience-retry-contract-concurrency-design-and-languag-351fab47.md
@@ -11,7 +11,7 @@ tags:
   - decision
 lifecycle: permanent
 createdAt: '2026-03-24T10:53:27.605Z'
-updatedAt: '2026-03-24T10:53:27.605Z'
+updatedAt: '2026-03-26T21:00:32.043Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
@@ -19,6 +19,8 @@ relatedTo:
     type: explains
   - id: parallel-consolidate-operations-can-leave-staged-local-only--e8c33780
     type: example-of
+  - id: manual-exact-git-recovery-contract-for-partial-mnemonic-pers-ffae4896
+    type: explains
 memoryVersion: 1
 ---
 ## Why retry is necessary

--- a/.mnemonic/notes/manual-exact-git-recovery-contract-for-partial-mnemonic-pers-ffae4896.md
+++ b/.mnemonic/notes/manual-exact-git-recovery-contract-for-partial-mnemonic-pers-ffae4896.md
@@ -1,0 +1,54 @@
+---
+title: Manual exact git recovery contract for partial mnemonic persistence failures
+tags:
+  - git
+  - retry
+  - persistence
+  - design
+  - mcp-tools
+lifecycle: permanent
+createdAt: '2026-03-26T20:59:03.983Z'
+updatedAt: '2026-03-26T20:59:03.983Z'
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+When a mutating mnemonic operation has already written note or embedding state but git add or commit fails, mnemonic should return an explicit manual recovery contract.
+
+Decision:
+
+- Manual git recovery is allowed only when `mutationApplied=true`.
+- Recovery must use only the exact tool-provided commit data.
+- Agents must not infer recovery details from git history, note title, summary text, or repo state.
+- Plain-text output must render the exact authorized recovery data, not just a generic safe-retry hint.
+
+Recommended contract changes:
+
+- Add a first-class recovery object with a `kind` such as `manual-exact-git-recovery`, `rerun-tool-call`, or `no-manual-recovery`.
+- For the allowed manual path, include exact `attemptedCommit.subject`, `attemptedCommit.body`, `attemptedCommit.files`, `vault`, `cwd`, `operation`, and `error`.
+- Add explicit instruction flags or equivalent semantics stating:
+  - source of truth is `attemptedCommit`
+  - use exact subject/body/files
+  - do not infer from history
+  - do not infer from title or summary
+- Rename `attemptedCommit.message` to `attemptedCommit.subject` to make git semantics unambiguous.
+
+Plain-text UX requirement:
+
+- Replace vague text like `Retry: safe | vault=... | files=...` with imperative recovery guidance.
+- The text output should explicitly say whether manual recovery is allowed.
+- If allowed, it should print the exact commit subject, full body, exact files, and the git failure.
+- The text must clearly state that only those exact values are authorized.
+
+Why this is needed:
+
+- Structured retry metadata already exists, but weaker or sloppy models still improvise because the text output is under-specified.
+- The tool should be the only source of truth for recovery after partial persistence failures.
+- This prevents agents from reverse-engineering commit style from history or inventing their own commit messages.
+
+Acceptance criteria:
+
+- Tool output alone is sufficient for deterministic recovery.
+- A model can recover correctly without inspecting git history.
+- The allowed recovery action and forbidden inference sources are explicit.
+- Exact subject/body/files are visible in both structured and plain-text output.

--- a/.mnemonic/notes/manual-exact-git-recovery-contract-for-partial-mnemonic-pers-ffae4896.md
+++ b/.mnemonic/notes/manual-exact-git-recovery-contract-for-partial-mnemonic-pers-ffae4896.md
@@ -8,7 +8,7 @@ tags:
   - mcp-tools
 lifecycle: permanent
 createdAt: '2026-03-26T20:59:03.983Z'
-updatedAt: '2026-03-26T21:01:55.152Z'
+updatedAt: '2026-03-26T21:04:09.139Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
@@ -20,24 +20,43 @@ relatedTo:
     type: related-to
 memoryVersion: 1
 ---
-When a mutating mnemonic operation has already written note or embedding state but git add or commit fails, mnemonic should return an explicit manual recovery contract.
+When a mutating mnemonic operation has already written note or embedding state but git add or commit fails, mnemonic should return an explicit recovery contract.
 
-Decision:
+Refined decision:
 
-- Manual git recovery is allowed only when `mutationApplied=true`.
+- Recovery must encode both the authorized action and the precedence between recovery paths.
+- If the tool has a deterministic built-in reconciliation path, that path should be preferred over manual git recovery.
+- Same-vault recovery and retry operations must be serialized; agents and callers must not replay same-vault mutations in parallel.
+
+Recovery precedence:
+
+1. `rerun-tool-call-serial`
+   - Preferred when the tool can reconcile pending persisted mutations safely and deterministically.
+   - Must be replayed serially for the affected vault.
+2. `manual-exact-git-recovery`
+   - Fallback when `mutationApplied=true` and no higher-level deterministic reconciliation path exists.
+   - Recovery must use only the exact tool-provided commit data.
+3. `no-manual-recovery`
+   - Used when neither tool replay nor manual git is safe.
+
+Manual recovery rules:
+
+- Manual git recovery is allowed only when explicitly authorized by the tool.
 - Recovery must use only the exact tool-provided commit data.
 - Agents must not infer recovery details from git history, note title, summary text, or repo state.
 - Plain-text output must render the exact authorized recovery data, not just a generic safe-retry hint.
 
 Recommended contract changes:
 
-- Add a first-class recovery object with a `kind` such as `manual-exact-git-recovery`, `rerun-tool-call`, or `no-manual-recovery`.
+- Add a first-class recovery object with a `kind` such as `rerun-tool-call-serial`, `manual-exact-git-recovery`, or `no-manual-recovery`.
 - For the allowed manual path, include exact `attemptedCommit.subject`, `attemptedCommit.body`, `attemptedCommit.files`, `vault`, `cwd`, `operation`, and `error`.
 - Add explicit instruction flags or equivalent semantics stating:
   - source of truth is `attemptedCommit`
   - use exact subject/body/files
   - do not infer from history
   - do not infer from title or summary
+  - do not replay same-vault mutations in parallel
+  - prefer tool reconciliation over manual git when available
 - Rename `attemptedCommit.message` to `attemptedCommit.subject` to make git semantics unambiguous.
 
 Plain-text UX requirement:
@@ -46,16 +65,20 @@ Plain-text UX requirement:
 - The text output should explicitly say whether manual recovery is allowed.
 - If allowed, it should print the exact commit subject, full body, exact files, and the git failure.
 - The text must clearly state that only those exact values are authorized.
+- If a tool replay path is preferred, the text should say to rerun the same tool call serially and explicitly forbid parallel same-vault retries.
 
-Why this is needed:
+Why this refinement is needed:
 
 - Structured retry metadata already exists, but weaker or sloppy models still improvise because the text output is under-specified.
 - The tool should be the only source of truth for recovery after partial persistence failures.
-- This prevents agents from reverse-engineering commit style from history or inventing their own commit messages.
+- The latest failure showed that even a correct retry path can be misused if same-vault retries are dispatched in parallel.
+- This prevents agents from reverse-engineering commit style from history or recreating lock contention during recovery.
 
 Acceptance criteria:
 
 - Tool output alone is sufficient for deterministic recovery.
 - A model can recover correctly without inspecting git history.
+- Recovery precedence is explicit.
+- Same-vault retries are explicitly serialized.
 - The allowed recovery action and forbidden inference sources are explicit.
-- Exact subject/body/files are visible in both structured and plain-text output.
+- Exact subject/body/files are visible in both structured and plain-text output when manual recovery is allowed.

--- a/.mnemonic/notes/manual-exact-git-recovery-contract-for-partial-mnemonic-pers-ffae4896.md
+++ b/.mnemonic/notes/manual-exact-git-recovery-contract-for-partial-mnemonic-pers-ffae4896.md
@@ -8,9 +8,12 @@ tags:
   - mcp-tools
 lifecycle: permanent
 createdAt: '2026-03-26T20:59:03.983Z'
-updatedAt: '2026-03-26T20:59:03.983Z'
+updatedAt: '2026-03-26T21:00:32.043Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: git-resilience-retry-contract-concurrency-design-and-languag-351fab47
+    type: explains
 memoryVersion: 1
 ---
 When a mutating mnemonic operation has already written note or embedding state but git add or commit fails, mnemonic should return an explicit manual recovery contract.

--- a/.mnemonic/notes/manual-exact-git-recovery-contract-for-partial-mnemonic-pers-ffae4896.md
+++ b/.mnemonic/notes/manual-exact-git-recovery-contract-for-partial-mnemonic-pers-ffae4896.md
@@ -8,7 +8,7 @@ tags:
   - mcp-tools
 lifecycle: permanent
 createdAt: '2026-03-26T20:59:03.983Z'
-updatedAt: '2026-03-26T21:04:09.139Z'
+updatedAt: '2026-03-26T21:46:50.436Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
@@ -22,63 +22,57 @@ memoryVersion: 1
 ---
 When a mutating mnemonic operation has already written note or embedding state but git add or commit fails, mnemonic should return an explicit recovery contract.
 
-Refined decision:
+Status: implemented.
 
-- Recovery must encode both the authorized action and the precedence between recovery paths.
-- If the tool has a deterministic built-in reconciliation path, that path should be preferred over manual git recovery.
-- Same-vault recovery and retry operations must be serialized; agents and callers must not replay same-vault mutations in parallel.
+Implemented outcome:
 
-Recovery precedence:
+- `MutationRetryContract` now includes a first-class `recovery` object with `kind`, `allowed`, and `reason`.
+- The contract now includes explicit `instructions` metadata covering source of truth, exact-value usage, no-inference rules, same-vault serialization, and preference for tool reconciliation.
+- Retry metadata now uses `attemptedCommit.subject` instead of `attemptedCommit.message`.
+- Plain-text retry output is now imperative and recovery-specific instead of generic `Retry: safe` text.
+
+Implemented recovery precedence:
 
 1. `rerun-tool-call-serial`
    - Preferred when the tool can reconcile pending persisted mutations safely and deterministically.
-   - Must be replayed serially for the affected vault.
+   - Implemented for `relate` and `unrelate` reconciliation paths.
 2. `manual-exact-git-recovery`
    - Fallback when `mutationApplied=true` and no higher-level deterministic reconciliation path exists.
-   - Recovery must use only the exact tool-provided commit data.
 3. `no-manual-recovery`
-   - Used when neither tool replay nor manual git is safe.
+   - Reserved for cases where neither tool replay nor manual git is safe.
 
 Manual recovery rules:
 
 - Manual git recovery is allowed only when explicitly authorized by the tool.
 - Recovery must use only the exact tool-provided commit data.
 - Agents must not infer recovery details from git history, note title, summary text, or repo state.
-- Plain-text output must render the exact authorized recovery data, not just a generic safe-retry hint.
+- Plain-text output renders the exact authorized recovery data instead of a generic safe-retry hint.
 
-Recommended contract changes:
+Preview-mode API decision:
 
-- Add a first-class recovery object with a `kind` such as `rerun-tool-call-serial`, `manual-exact-git-recovery`, or `no-manual-recovery`.
-- For the allowed manual path, include exact `attemptedCommit.subject`, `attemptedCommit.body`, `attemptedCommit.files`, `vault`, `cwd`, `operation`, and `error`.
-- Add explicit instruction flags or equivalent semantics stating:
-  - source of truth is `attemptedCommit`
-  - use exact subject/body/files
-  - do not infer from history
-  - do not infer from title or summary
-  - do not replay same-vault mutations in parallel
-  - prefer tool reconciliation over manual git when available
-- Rename `attemptedCommit.message` to `attemptedCommit.subject` to make git semantics unambiguous.
+- The preview contract now exposes only `attemptedCommit.subject`.
+- The temporary compatibility alias back to `attemptedCommit.message` was intentionally removed because the project is still in preview and the cleaner contract is preferable now.
 
-Plain-text UX requirement:
+Plain-text UX now does the following:
 
-- Replace vague text like `Retry: safe | vault=... | files=...` with imperative recovery guidance.
-- The text output should explicitly say whether manual recovery is allowed.
-- If allowed, it should print the exact commit subject, full body, exact files, and the git failure.
-- The text must clearly state that only those exact values are authorized.
-- If a tool replay path is preferred, the text should say to rerun the same tool call serially and explicitly forbid parallel same-vault retries.
+- For `manual-exact-git-recovery`, prints the exact commit subject, full body when present, exact files, and the git failure, together with an explicit no-inference warning.
+- For `rerun-tool-call-serial`, instructs callers to rerun the same tool call serially and explicitly forbids replaying same-vault mutations in parallel.
 
-Why this refinement is needed:
+Files changed for the implementation:
 
-- Structured retry metadata already exists, but weaker or sloppy models still improvise because the text output is under-specified.
-- The tool should be the only source of truth for recovery after partial persistence failures.
-- The latest failure showed that even a correct retry path can be misused if same-vault retries are dispatched in parallel.
-- This prevents agents from reverse-engineering commit style from history or recreating lock contention during recovery.
+- `src/index.ts`
+- `src/structured-content.ts`
+- `tests/memory-lifecycle.integration.test.ts`
+- `CHANGELOG.md`
 
-Acceptance criteria:
+Verification evidence from implementation:
 
-- Tool output alone is sufficient for deterministic recovery.
-- A model can recover correctly without inspecting git history.
-- Recovery precedence is explicit.
-- Same-vault retries are explicitly serialized.
-- The allowed recovery action and forbidden inference sources are explicit.
-- Exact subject/body/files are visible in both structured and plain-text output when manual recovery is allowed.
+- Focused retry-contract tests passed.
+- Typecheck passed.
+- Sequential full-suite runs still showed intermittent unrelated MCP integration flakiness (`Missing tool response` / truncated JSON style failures), but the affected integration files passed when rerun in isolation. The implemented retry-contract change itself verified cleanly in focused coverage.
+
+Why this matters:
+
+- The tool is now much closer to being the sole source of truth for recovery after partial persistence failures.
+- Tool-specific reconciliation paths now outrank manual git when available.
+- The output now explicitly teaches weaker models what to do and what not to do.

--- a/.mnemonic/notes/manual-exact-git-recovery-contract-for-partial-mnemonic-pers-ffae4896.md
+++ b/.mnemonic/notes/manual-exact-git-recovery-contract-for-partial-mnemonic-pers-ffae4896.md
@@ -8,12 +8,16 @@ tags:
   - mcp-tools
 lifecycle: permanent
 createdAt: '2026-03-26T20:59:03.983Z'
-updatedAt: '2026-03-26T21:00:32.043Z'
+updatedAt: '2026-03-26T21:01:55.152Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
   - id: git-resilience-retry-contract-concurrency-design-and-languag-351fab47
     type: explains
+  - id: parallel-consolidate-operations-can-leave-staged-local-only--e8c33780
+    type: explains
+  - id: mnemonic-git-commit-protocol-standardization-f2ee3d5e
+    type: related-to
 memoryVersion: 1
 ---
 When a mutating mnemonic operation has already written note or embedding state but git add or commit fails, mnemonic should return an explicit manual recovery contract.

--- a/.mnemonic/notes/mnemonic-git-commit-protocol-standardization-f2ee3d5e.md
+++ b/.mnemonic/notes/mnemonic-git-commit-protocol-standardization-f2ee3d5e.md
@@ -10,11 +10,13 @@ tags:
   - llm
 lifecycle: permanent
 createdAt: '2026-03-07T23:34:04.303Z'
-updatedAt: '2026-03-14T19:57:05.434Z'
+updatedAt: '2026-03-26T21:00:32.043Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
   - id: mnemonic-key-design-decisions-3f2a6273
+    type: related-to
+  - id: manual-exact-git-recovery-contract-for-partial-mnemonic-pers-ffae4896
     type: related-to
 memoryVersion: 1
 ---

--- a/.mnemonic/notes/parallel-consolidate-operations-can-leave-staged-local-only--e8c33780.md
+++ b/.mnemonic/notes/parallel-consolidate-operations-can-leave-staged-local-only--e8c33780.md
@@ -12,12 +12,14 @@ tags:
   - lessons
 lifecycle: permanent
 createdAt: '2026-03-14T23:38:26.947Z'
-updatedAt: '2026-03-14T23:40:47.420Z'
+updatedAt: '2026-03-26T21:00:32.043Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
   - id: persistence-status-reporting-design-and-implementation-8a50b95a
     type: related-to
+  - id: manual-exact-git-recovery-contract-for-partial-mnemonic-pers-ffae4896
+    type: explains
 memoryVersion: 1
 ---
 Observed a gap in the git retry/persistence contract during conservative note consolidation on branch `cleanup`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 
 ### Changed
 
-- Retry/recovery contract for mutating git-backed tools is now explicit and imperative instead of vague `Retry: safe` text. Partial-persistence failures now return structured recovery metadata with a first-class recovery kind, exact `attemptedCommit.subject`/`body`/`files` for manual recovery, and explicit no-inference instructions.
-- Recovery precedence is now encoded in the tool result: generic deterministic partial-persistence failures default to manual exact git recovery, while `relate` and `unrelate` prefer serial tool-call replay through their built-in reconciliation path.
+- Mutating tool retry results now return explicit recovery guidance instead of vague `Retry: safe` text, including recovery kind and no-inference instructions for partial-persistence failures.
+- Recovery precedence is now encoded in retry metadata: deterministic tool reconciliation is preferred where available, and same-vault retries must be replayed serially.
 - Retry metadata now uses `attemptedCommit.subject` instead of `attemptedCommit.message`.
 
 ## [0.17.0] - 2026-03-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `mnemonic` will be documented in this file.
 
 The format is loosely based on Keep a Changelog and uses semver-style version headings.
 
+## [0.18.0] - Unreleased
+
+### Changed
+
+- Retry/recovery contract for mutating git-backed tools is now explicit and imperative instead of vague `Retry: safe` text. Partial-persistence failures now return structured recovery metadata with a first-class recovery kind, exact `attemptedCommit.subject`/`body`/`files` for manual recovery, and explicit no-inference instructions.
+- Recovery precedence is now encoded in the tool result: generic deterministic partial-persistence failures default to manual exact git recovery, while `relate` and `unrelate` prefer serial tool-call replay through their built-in reconciliation path.
+- Retry metadata now uses `attemptedCommit.subject` instead of `attemptedCommit.message`.
+
 ## [0.17.0] - 2026-03-25
 
 ### Added

--- a/src/index.ts
+++ b/src/index.ts
@@ -958,14 +958,30 @@ function buildMutationRetryContract(args: {
   cwd?: string;
   vault: Vault;
   mutationApplied: boolean;
+  preferredRecovery?: "manual-exact-git-recovery" | "rerun-tool-call-serial" | "no-manual-recovery";
 }): MutationRetryContract | undefined {
   if (args.commit.status !== "failed") {
     return undefined;
   }
 
+  const recoveryKind = args.preferredRecovery ?? (args.mutationApplied
+    ? "manual-exact-git-recovery"
+    : "no-manual-recovery");
+
+  const recoveryReason = recoveryKind === "rerun-tool-call-serial"
+    ? "Tool-level reconciliation exists for this mutation; rerun the same tool call serially for the affected vault."
+    : recoveryKind === "manual-exact-git-recovery"
+      ? "Mutation is already persisted on disk; manual git recovery is allowed only with the exact attemptedCommit values."
+      : "Mutation was not applied deterministically; manual git recovery is not authorized.";
+
   return {
+    recovery: {
+      kind: recoveryKind,
+      allowed: recoveryKind !== "no-manual-recovery",
+      reason: recoveryReason,
+    },
     attemptedCommit: {
-      message: args.commitMessage,
+      subject: args.commitMessage,
       body: args.commitBody,
       files: args.files,
       cwd: args.cwd,
@@ -978,6 +994,17 @@ function buildMutationRetryContract(args: {
     rationale: args.mutationApplied
       ? "Mutation is already persisted on disk; commit can be retried deterministically."
       : "Mutation was not applied; retry may require re-running the operation.",
+    instructions: {
+      sourceOfTruth: recoveryKind === "manual-exact-git-recovery" ? "attemptedCommit" : "tool-response",
+      useExactSubject: recoveryKind === "manual-exact-git-recovery",
+      useExactBody: recoveryKind === "manual-exact-git-recovery",
+      useExactFiles: recoveryKind === "manual-exact-git-recovery",
+      forbidInferenceFromHistory: true,
+      forbidInferenceFromTitleOrSummary: true,
+      forbidParallelSameVaultRetries: true,
+      preferToolReconciliation: recoveryKind === "rerun-tool-call-serial",
+      rerunSameToolCallSerially: recoveryKind === "rerun-tool-call-serial",
+    },
   };
 }
 
@@ -986,13 +1013,54 @@ function formatRetrySummary(retry?: MutationRetryContract): string | undefined {
     return undefined;
   }
 
-  const safety = retry.retrySafe ? "safe" : "requires review";
   const opLabel = retry.attemptedCommit.operation === "add" ? "add" : "commit";
   const error = retry.attemptedCommit.error;
-  return [
-    `Retry: ${safety} | vault=${retry.attemptedCommit.vault} | files=${retry.attemptedCommit.files.length}`,
-    `Git ${opLabel} error: ${error}`,
-  ].join("\n");
+  const lines: string[] = [];
+
+  switch (retry.recovery.kind) {
+    case "rerun-tool-call-serial":
+      lines.push("Recovery: rerun same tool call serially");
+      lines.push(retry.recovery.reason);
+      lines.push("Rerun the same mnemonic tool call one time for the affected vault.");
+      lines.push("Do not replay same-vault mutations in parallel.");
+      lines.push("Manual git recovery is not authorized for this failure.");
+      lines.push("Git failure:");
+      lines.push(`${opLabel}: ${error}`);
+      break;
+    case "manual-exact-git-recovery":
+      lines.push("Recovery: manual exact git recovery allowed");
+      lines.push(retry.recovery.reason);
+      lines.push("Use only the exact values below. Do not infer from git history, note title, summary, or repo state.");
+      lines.push("");
+      lines.push("Commit subject:");
+      lines.push(retry.attemptedCommit.subject);
+      if (retry.attemptedCommit.body) {
+        lines.push("");
+        lines.push("Commit body:");
+        lines.push(retry.attemptedCommit.body);
+      }
+      lines.push("");
+      lines.push("Files:");
+      for (const file of retry.attemptedCommit.files) {
+        lines.push(`- ${file}`);
+      }
+      lines.push("");
+      lines.push("Git failure:");
+      lines.push(`${opLabel}: ${error}`);
+      break;
+    case "no-manual-recovery":
+      lines.push("Recovery: no manual recovery authorized");
+      lines.push(retry.recovery.reason);
+      lines.push("Git failure:");
+      lines.push(`${opLabel}: ${error}`);
+      break;
+    default: {
+      const _exhaustive: never = retry.recovery.kind;
+      throw new Error(`Unknown recovery kind: ${_exhaustive}`);
+    }
+  }
+
+  return lines.join("\n");
 }
 
 function formatPersistenceSummary(persistence: PersistenceStatus): string {
@@ -1007,7 +1075,9 @@ function formatPersistenceSummary(persistence: PersistenceStatus): string {
     lines[0] += ` | embedding reason=${persistence.embedding.reason}`;
   }
 
-  if (persistence.git.commit === "failed" && persistence.git.commitError) {
+  const retrySummary = formatRetrySummary(persistence.retry);
+
+  if (!retrySummary && persistence.git.commit === "failed" && persistence.git.commitError) {
     const opLabel = persistence.git.commitOperation === "add" ? "add" : "commit";
     lines.push(`Git ${opLabel} error: ${persistence.git.commitError}`);
   }
@@ -1016,7 +1086,6 @@ function formatPersistenceSummary(persistence: PersistenceStatus): string {
     lines.push(`Git push error: ${persistence.git.pushError}`);
   }
 
-  const retrySummary = formatRetrySummary(persistence.retry);
   if (retrySummary) {
     lines.push(retrySummary);
   }
@@ -4173,6 +4242,7 @@ server.registerTool(
             cwd,
             vault,
             mutationApplied: true,
+            preferredRecovery: "rerun-tool-call-serial",
           });
           
           const structuredContent: RelateResult = {
@@ -4226,6 +4296,7 @@ server.registerTool(
           cwd,
           vault,
           mutationApplied: true,
+          preferredRecovery: "rerun-tool-call-serial",
         });
       }
       if (commitStatus.status === "committed") {
@@ -4362,6 +4433,7 @@ server.registerTool(
             cwd,
             vault,
             mutationApplied: true,
+            preferredRecovery: "rerun-tool-call-serial",
           });
           
           const structuredContent: RelateResult = {
@@ -4409,6 +4481,7 @@ server.registerTool(
           cwd,
           vault,
           mutationApplied: true,
+          preferredRecovery: "rerun-tool-call-serial",
         });
       }
       if (commitStatus.status === "committed") {

--- a/src/structured-content.ts
+++ b/src/structured-content.ts
@@ -31,8 +31,13 @@ export interface PersistenceStatus {
 }
 
 export interface MutationRetryContract {
+  recovery: {
+    kind: "manual-exact-git-recovery" | "rerun-tool-call-serial" | "no-manual-recovery";
+    allowed: boolean;
+    reason: string;
+  };
   attemptedCommit: {
-    message: string;
+    subject: string;
     body?: string;
     files: string[];
     cwd?: string;
@@ -44,6 +49,17 @@ export interface MutationRetryContract {
   mutationApplied: boolean;
   retrySafe: boolean;
   rationale: string;
+  instructions: {
+    sourceOfTruth: "attemptedCommit" | "tool-response";
+    useExactSubject: boolean;
+    useExactBody: boolean;
+    useExactFiles: boolean;
+    forbidInferenceFromHistory: boolean;
+    forbidInferenceFromTitleOrSummary: boolean;
+    forbidParallelSameVaultRetries: boolean;
+    preferToolReconciliation: boolean;
+    rerunSameToolCallSerially: boolean;
+  };
 }
 
 export interface StructuredResponse {
@@ -456,8 +472,13 @@ export const PersistenceStatusSchema = z.object({
     pushError: z.string().optional(),
   }),
   retry: z.object({
+    recovery: z.object({
+      kind: z.enum(["manual-exact-git-recovery", "rerun-tool-call-serial", "no-manual-recovery"]),
+      allowed: z.boolean(),
+      reason: z.string(),
+    }),
     attemptedCommit: z.object({
-      message: z.string(),
+      subject: z.string(),
       body: z.string().optional(),
       files: z.array(z.string()),
       cwd: z.string().optional(),
@@ -468,6 +489,17 @@ export const PersistenceStatusSchema = z.object({
     mutationApplied: z.boolean(),
     retrySafe: z.boolean(),
     rationale: z.string(),
+    instructions: z.object({
+      sourceOfTruth: z.enum(["attemptedCommit", "tool-response"]),
+      useExactSubject: z.boolean(),
+      useExactBody: z.boolean(),
+      useExactFiles: z.boolean(),
+      forbidInferenceFromHistory: z.boolean(),
+      forbidInferenceFromTitleOrSummary: z.boolean(),
+      forbidParallelSameVaultRetries: z.boolean(),
+      preferToolReconciliation: z.boolean(),
+      rerunSameToolCallSerially: z.boolean(),
+    }),
   }).optional(),
   durability: z.enum(["local-only", "committed", "pushed"]),
 });

--- a/tests/memory-lifecycle.integration.test.ts
+++ b/tests/memory-lifecycle.integration.test.ts
@@ -124,14 +124,21 @@ describe("memory-lifecycle", () => {
       expect(git?.["commitOperation"]).toBe("add");
       expect(git?.["push"]).toBe("skipped");
       expect(String(git?.["commitError"] ?? "")).toContain("index.lock");
-      expect(response.text).toContain("Git add error:");
-      expect(response.text).toContain("Retry: safe");
+      expect(response.text).toContain("Recovery: manual exact git recovery allowed");
+      expect(response.text).toContain("Use only the exact values below.");
+      expect(response.text).toContain("Commit subject:");
+      expect(response.text).toContain("remember: Retry contract remember test");
+      expect(response.text).toContain("Git failure:");
+      expect(response.text).not.toContain("Retry: safe");
 
       const retry = persistence?.["retry"] as Record<string, unknown>;
       expect(retry?.["mutationApplied"]).toBe(true);
       expect(retry?.["retrySafe"]).toBe(true);
+      const recovery = retry?.["recovery"] as Record<string, unknown>;
+      expect(recovery?.["kind"]).toBe("manual-exact-git-recovery");
+      expect(recovery?.["allowed"]).toBe(true);
       const attemptedCommit = retry?.["attemptedCommit"] as Record<string, unknown>;
-      expect(attemptedCommit?.["message"]).toBe("remember: Retry contract remember test");
+      expect(attemptedCommit?.["subject"]).toBe("remember: Retry contract remember test");
       expect(attemptedCommit?.["vault"]).toBe("main-vault");
       expect(attemptedCommit?.["operation"]).toBe("add");
       expect((attemptedCommit?.["files"] as string[])).toHaveLength(1);
@@ -156,12 +163,11 @@ describe("memory-lifecycle", () => {
     }, { disableGit: false });
 
     expect(response.text).toContain("defaultScope=global");
-    expect(response.text).toContain("Git add error:");
-    expect(response.text).toContain("Retry: safe");
+    expect(response.text).toContain("Recovery: manual exact git recovery allowed");
     const retry = response.structuredContent?.["retry"] as Record<string, unknown>;
     expect(retry?.["mutationApplied"]).toBe(true);
     const attempted = retry?.["attemptedCommit"] as Record<string, unknown>;
-    expect(attempted?.["message"]).toContain("policy:");
+    expect(attempted?.["subject"]).toContain("policy:");
     expect(attempted?.["vault"]).toBe("main-vault");
     expect(String(attempted?.["error"] ?? "")).toContain("index.lock");
   }, 15000);
@@ -201,14 +207,18 @@ describe("memory-lifecycle", () => {
       }, { ollamaUrl: embeddingServer.url, disableGit: false });
 
       expect(response.text).toContain(`Linked \`${firstId}\` ↔ \`${secondId}\` (related-to)`);
-      expect(response.text).toContain("Git add error:");
-      expect(response.text).toContain("Retry: safe");
+      expect(response.text).toContain("Recovery: rerun same tool call serially");
+      expect(response.text).toContain("Do not replay same-vault mutations in parallel.");
+      expect(response.text).not.toContain("Recovery: manual exact git recovery allowed");
 
       const retry = response.structuredContent?.["retry"] as Record<string, unknown>;
       expect(retry?.["mutationApplied"]).toBe(true);
       expect(retry?.["retrySafe"]).toBe(true);
+      const recovery = retry?.["recovery"] as Record<string, unknown>;
+      expect(recovery?.["kind"]).toBe("rerun-tool-call-serial");
+      expect(recovery?.["allowed"]).toBe(true);
       const attempted = retry?.["attemptedCommit"] as Record<string, unknown>;
-      expect(attempted?.["message"]).toContain("relate:");
+      expect(attempted?.["subject"]).toContain("relate:");
       expect(attempted?.["vault"]).toBe("main-vault");
       expect(String(attempted?.["error"] ?? "")).toContain("index.lock");
     } finally {


### PR DESCRIPTION
## Summary

This PR fixes bugs and adds enhancements:

- **Parallel consolidate operations can leave staged local-only notes without actionable retry signal**
- **mnemonic git commit protocol standardization**
- **Git resilience: retry contract, concurrency design, and language-independent state detection**
- **Manual exact git recovery contract for partial mnemonic persistence failures**

## Design Decisions

### Parallel consolidate operations can leave staged local-only notes without actionable retry signal

**Tags:** git, retry, consolidate, persistence, concurrency, bug, lessons

Observed a gap in the git retry/persistence contract during conservative note consolidation on branch `cleanup`.

What happened:

- Four `consolidate.execute-merge` operations were launched in parallel against the same project vault.
- Two completed with auto-commit success.
- Two wrote the canonical note and embedding but returned `git local-only`, leaving new note files staged and uncommitted in the repo.
- The repo state was cleanly recoverable, but the tool result did not make the failure actionable enough for the agent to automatically retry or re-run the operation.

Durable lesson:

- Mutating git-backed operations against the same vault should not be run in parallel unless the tool internally serializes persistence.
- When persistence is partial, the tool should surface commit failure as a first-class structured result with explicit retry guidance.
- Retry should be idempotent and safe when the note content already exists but commit/push did not finish.

Why this matters:

- Content durability and git durability can diverge.
- Agents need enough structured failure detail to distinguish note-write success from commit failure and choose the correct recovery path.
- Silent or weakly-signaled `git local-only` outcomes can leave staged changes behind and create confusion.

Recommended product behavior:

- Return explicit commit failure metadata and retry-safe instructions for partial persistence outcomes.
- Prefer internal serialization for concurrent mutating operations targeting the same vault, or document that callers must serialize them.
- Make redo safe when canonical note creation already happened but git persistence is incomplete.

Recovery used in this session:

- Inspected `git status`
- Verified only two consolidated note files were staged
- Manually committed them with `consolidate(supersedes): finalize canonical rollout memories`
- Working tree returned to clean state

### mnemonic git commit protocol standardization

**Tags:** git, protocol, standards, mcp-tools, documentation, enhancement, llm

Enhanced git commit protocol with comprehensive LLM-provided summary support across multiple tools.

**Extended LLM Summary Support:**

Beyond `remember`, the following tools now accept optional `summary` parameters:

1. **`update` tool** - `summary` parameter:
   - LLM explains what changed and why
   - Example: "Clarify JWT migration timeline after security review"
   - Fallback: "Updated title, content, tags" listing actual changes

2. **`consolidate` tool** - `mergePlan.summary` parameter:
   - LLM explains merge rationale
   - Example: "Merge release workflow notes into single comprehensive guide"
   - Fallback: "Consolidated N notes into new note"

**Benefits of LLM-provided summaries:**

- LLM has full context when composing operations
- Better quality than auto-generated descriptions
- Follows conventional commit best practices
- No extra AI calls in code (simpler, faster)
- Commit messages tell the story; metadata provides structure

**Implementation pattern:**

```typescript
// Tool accepts optional summary parameter
summary: z.string().optional()

// Use LLM-provided or fallback
const commitSummary = summary ?? generateFallbackSummary()

// Include in commit body
formatCommitBody({ summary: commitSummary, ... })
```

**Updated documentation:**

- AGENT.md: Extended tool conventions table with all summary sources
- AGENT.md: Added comprehensive LLM summary guidance section
- README.md: System prompt guidance for `remember` tool

**Tools with LLM summary support:**

- `remember` - `summary` parameter (primary use case)
- `update` - `summary` parameter
- `consolidate` - `mergePlan.summary` parameter

All 26 tests passing. Build successful. Architecture is extensible - easy to add to additional tools if needed.

### Git resilience: retry contract, concurrency design, and language-independent state detection

**Tags:** git, resilience, retry, concurrency, design, decision

## Why retry is necessary

Multiple agent sessions (Claude desktop, VSCode plugin, CLI) can concurrently access the same vault with no mutex coordination. This amplifies index.lock probability:

- 10% base lock × 3 concurrent agents ≈ 27% failure rate without retry
- With 3-attempt exponential backoff: ≈ 3% effective failure rate
- Rapid-fire operations (recall → discover_tags → remember → relate) can hit the lock within <100ms

## Retry contract

`git.add()` and `git.commit()` can both fail with index.lock:

- **Add retry**: `addWithRetry()` wraps `git.add()` with 3 retries and exponential backoff (50ms → 100ms → 200ms) for transient lock errors
- **Commit failure**: if add succeeds but commit fails, returns `operation: "commit"`
- **Add exhaustion**: if all add retries fail, returns `operation: "add"`

Retry metadata exposed to callers: `attemptedCommit` payload (`message`, `body`, `files`, `cwd`, `vault`, `error`, `operation`), `mutationApplied`, `retrySafe`, and rationale.

### Scope covered

`remember`, `update`, `move_memory`, `forget`, `relate`, `unrelate`, `set_project_identity`, `set_project_memory_policy`, `consolidate` mutating paths (`execute-merge`, `prune-superseded`).

### Known limitation

Parallel mutating operations against the same vault can still leave partial persistence states (note + embedding written but git only local). **Same-vault mutating operations should be serialized by callers.**

## Language-independent state detection

Never rely on git error message keywords — they are localized and change under different `LANG`/`LC_ALL` settings.

Safe alternatives:

- **`git status --porcelain`** status codes (UU, AA, DD) — not localized, safe to parse; `simple-git`'s `status().conflicted` uses this
- **Git internal state files** — filesystem paths, entirely language-independent:
  - `.git/rebase-merge/` — interactive or `--merge` rebase in progress
  - `.git/rebase-apply/` — `--apply` strategy rebase in progress
  - `.git/MERGE_HEAD` — plain merge conflict

Applied in `GitOps.isConflictInProgress()` in `src/git.ts`: replaced keyword-based fallback with `fs.access` checks on the three paths above.

### Manual exact git recovery contract for partial mnemonic persistence failures

**Tags:** git, retry, persistence, design, mcp-tools

When a mutating mnemonic operation has already written note or embedding state but git add or commit fails, mnemonic should return an explicit recovery contract.

Status: implemented.

Implemented outcome:

- `MutationRetryContract` now includes a first-class `recovery` object with `kind`, `allowed`, and `reason`.
- The contract now includes explicit `instructions` metadata covering source of truth, exact-value usage, no-inference rules, same-vault serialization, and preference for tool reconciliation.
- Retry metadata now uses `attemptedCommit.subject` instead of `attemptedCommit.message`.
- Plain-text retry output is now imperative and recovery-specific instead of generic `Retry: safe` text.

Implemented recovery precedence:

1. `rerun-tool-call-serial`
   - Preferred when the tool can reconcile pending persisted mutations safely and deterministically.
   - Implemented for `relate` and `unrelate` reconciliation paths.
2. `manual-exact-git-recovery`
   - Fallback when `mutationApplied=true` and no higher-level deterministic reconciliation path exists.
3. `no-manual-recovery`
   - Reserved for cases where neither tool replay nor manual git is safe.

Manual recovery rules:

- Manual git recovery is allowed only when explicitly authorized by the tool.
- Recovery must use only the exact tool-provided commit data.
- Agents must not infer recovery details from git history, note title, summary text, or repo state.
- Plain-text output renders the exact authorized recovery data instead of a generic safe-retry hint.

Preview-mode API decision:

- The preview contract now exposes only `attemptedCommit.subject`.
- The temporary compatibility alias back to `attemptedCommit.message` was intentionally removed because the project is still in preview and the cleaner contract is preferable now.

Plain-text UX now does the following:

- For `manual-exact-git-recovery`, prints the exact commit subject, full body when present, exact files, and the git failure, together with an explicit no-inference warning.
- For `rerun-tool-call-serial`, instructs callers to rerun the same tool call serially and explicitly forbids replaying same-vault mutations in parallel.

Files changed for the implementation:

- `src/index.ts`
- `src/structured-content.ts`
- `tests/memory-lifecycle.integration.test.ts`
- `CHANGELOG.md`

Verification evidence from implementation:

- Focused retry-contract tests passed.
- Typecheck passed.
- Sequential full-suite runs still showed intermittent unrelated MCP integration flakiness (`Missing tool response` / truncated JSON style failures), but the affected integration files passed when rerun in isolation. The implemented retry-contract change itself verified cleanly in focused coverage.

Why this matters:

- The tool is now much closer to being the sole source of truth for recovery after partial persistence failures.
- Tool-specific reconciliation paths now outrank manual git when available.
- The output now explicitly teaches weaker models what to do and what not to do.

---

_Generated from 4 design decision note(s) in `.mnemonic/notes/`. Run `/update-pr` to regenerate._