### PR TITLE
Fix alwaysLoad parameter not persisting via MCP tools

### DIFF
--- a/.mnemonic/notes/dogfooding-test-suite-reusable-prompt-for-phases-1-8-validat-c7c702d8.md
+++ b/.mnemonic/notes/dogfooding-test-suite-reusable-prompt-for-phases-1-8-validat-c7c702d8.md
@@ -8,7 +8,7 @@ tags:
   - reusable
 lifecycle: permanent
 createdAt: '2026-03-28T18:54:38.792Z'
-updatedAt: '2026-03-28T18:54:48.362Z'
+updatedAt: '2026-03-29T13:11:48.917Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
@@ -50,6 +50,8 @@ Run a structured dogfooding test of the mnemonic MCP against the released versio
 
 **F1 — Provenance and confidence (Phase 7):** From recall results (B1 or B2), inspect provenance: lastUpdatedAt, lastCommitHash, recentlyChanged. Is confidence "high" on anchor notes? "medium" on others? Rate: Pass / Pass with friction / Fail.
 
+**F2 — AlwaysLoad via MCP (Phase 7):** Create a test note with `remember` including `alwaysLoad: true`, then update it with `alwaysLoad: false`. Verify via `get` that `alwaysLoad` is persisted in the frontmatter. Rate: Pass / Pass with friction / Fail.
+
 **G1 — Single-commit note history (Phase 8):** From B2 temporal results, find a note with 1 commit. Is `historySummary` "This note was created and has not been modified since."? Rate: Pass / Pass with friction / Fail.
 
 **G2 — Multi-commit note evolution (Phase 8):** Find a note with 3+ commits from B2 temporal results. Is `historySummary` informative or generic? Is `changeDescription` for unknown category helpful or just "Updated the note."? Rate: Pass / Pass with friction / Fail.
@@ -61,6 +63,8 @@ Run a structured dogfooding test of the mnemonic MCP against the released versio
 **E2E-3 — Recent-to-architecture navigation:** Start from the most recent note (from summary). Via `get` + includeRelationships, navigate to an architecture or decisions note. Does the path work in 3 steps or fewer? Rate: Pass / Pass with friction / Fail.
 
 **E2E-4 — "What should I read first?"** Call `recall` with query="what should I read first to understand temporal interpretation" and cwd. Does the right note rank at top? Do its relationships form a coherent cluster? Rate: Pass / Pass with friction / Fail.
+
+**CLEANUP:** Call `forget` on any test notes created during F2.
 
 **CAPTURE:** Call `remember` with title "Dogfooding test suite results: Phases 1–8 validation (YYYY-MM-DD)", lifecycle permanent, scope project, tags [dogfooding, testing, phases, validation, scorecard], containing all test results and completed scorecard.
 
@@ -109,7 +113,7 @@ Run a structured dogfooding test of the mnemonic MCP against the released versio
 
 - [ ] explicit metadata improves prioritization
 - [ ] inferred roles help without noise
-- [ ] alwaysLoad behaves cleanly
+- [ ] alwaysLoad behaves cleanly (F2 test: remember/update via MCP)
 
 ### Phase 8: Temporal interpretation
 
@@ -129,3 +133,4 @@ Run a structured dogfooding test of the mnemonic MCP against the released versio
 ## Known runs
 
 - 2026-03-28: note `dogfooding-test-suite-results-phases-1-8-validation-2026-03--86866b21`, run by Claude Sonnet 4.6, result 22/28 passing.
+- 2026-03-29: note `dogfooding-test-suite-results-phases-1-8-validation-2026-03--86866b21`, run by Claude Sonnet 4.6, result 28/28 passing (v0.19.2).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `mnemonic` will be documented in this file.
 
 The format is loosely based on Keep a Changelog and uses semver-style version headings.
 
+## [0.19.3] - 2026-03-29
+
+### Fixed
+
+- `alwaysLoad` parameter is now properly handled in `remember` and `update` tools. Previously, the parameter was accepted by the tool schemas but not persisted to note frontmatter, causing session anchors to silently fail.
+
 ## [0.19.2] - 2026-03-28
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@danielmarbach/mnemonic-mcp",
-      "version": "0.19.2",
+      "version": "0.19.3",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.1",
         "gray-matter": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "A local MCP memory server backed by markdown + JSON files, synced via git",
   "type": "module",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1810,6 +1810,13 @@ server.registerTool(
       summary: z.string().optional().describe(
         "Git commit summary only. Imperative mood, concise, and focused on why the change matters."
       ),
+      alwaysLoad: z
+        .boolean()
+        .optional()
+        .describe(
+          "When true, this note loads automatically at session start and receives priority in recall and relationship expansion. " +
+          "Use for session anchors and critical context that should always be available."
+        ),
       cwd: z
         .string()
         .optional()
@@ -1840,7 +1847,7 @@ server.registerTool(
     }),
     outputSchema: RememberResultSchema,
   },
-  async ({ title, content, tags, lifecycle, summary, cwd, scope, allowProtectedBranch = false }) => {
+  async ({ title, content, tags, lifecycle, summary, alwaysLoad, cwd, scope, allowProtectedBranch = false }) => {
     await ensureBranchSynced(cwd);
 
     const project = await resolveProject(cwd);
@@ -1875,6 +1882,7 @@ server.registerTool(
     const note: Note = {
       id, title, content: cleanedContent, tags,
       lifecycle: lifecycle ?? "permanent",
+      alwaysLoad: alwaysLoad ?? false,
       project: project?.id,
       projectName: project?.name,
       createdAt: now,
@@ -2473,6 +2481,13 @@ server.registerTool(
         .optional()
         .describe("Change lifecycle. Preserve the existing value unless you're intentionally switching it."),
       summary: z.string().optional().describe("Git commit summary only. Imperative mood, concise, and focused on why the change matters."),
+      alwaysLoad: z
+        .boolean()
+        .optional()
+        .describe(
+          "When true, this note loads automatically at session start and receives priority in recall and relationship expansion. " +
+          "Use for session anchors and critical context that should always be available."
+        ),
       cwd: projectParam,
       allowProtectedBranch: z
         .boolean()
@@ -2484,7 +2499,7 @@ server.registerTool(
     }),
     outputSchema: UpdateResultSchema,
   },
-  async ({ id, content, title, tags, lifecycle, summary, cwd, allowProtectedBranch = false }) => {
+  async ({ id, content, title, tags, lifecycle, summary, alwaysLoad, cwd, allowProtectedBranch = false }) => {
     await ensureBranchSynced(cwd);
 
     const found = await vaultManager.findNote(id, cwd);
@@ -2525,6 +2540,7 @@ server.registerTool(
       content: cleanedContent ?? note.content,
       tags: tags ?? note.tags,
       lifecycle: lifecycle ?? note.lifecycle,
+      alwaysLoad: alwaysLoad !== undefined ? alwaysLoad : note.alwaysLoad,
       updatedAt: now,
     };
 
@@ -2547,6 +2563,7 @@ server.registerTool(
     if (content !== undefined) changes.push("content");
     if (tags !== undefined) changes.push("tags");
     if (lifecycle !== undefined && lifecycle !== note.lifecycle) changes.push("lifecycle");
+    if (alwaysLoad !== undefined && alwaysLoad !== note.alwaysLoad) changes.push("alwaysLoad");
     const changeDesc = changes.length > 0 ? `Updated ${changes.join(", ")}` : "No changes";
     const commitSummary = summary ?? changeDesc;
 

--- a/tests/helpers/mcp.ts
+++ b/tests/helpers/mcp.ts
@@ -113,6 +113,7 @@ export async function callLocalMcpMethod(
 
     let stdoutData = "";
     let stderrData = "";
+    let stdinReady = false;
 
     child.stdout.on("data", (chunk) => {
       stdoutData += chunk.toString();
@@ -123,14 +124,21 @@ export async function callLocalMcpMethod(
     child.on("error", reject);
     child.on("close", (code) => {
       if (code !== 0) {
-        reject(new Error(`MCP script exited with ${code}: ${stderrData}`));
+        reject(new Error(`MCP script exited with code ${code}: ${stderrData}`));
         return;
       }
       resolve(stdoutData);
     });
 
-    child.stdin.end(messages.map((message) => JSON.stringify(message)).join("\n") + "\n");
+    child.stdin.write(messages.map((message) => JSON.stringify(message)).join("\n") + "\n", () => {
+      stdinReady = true;
+      setTimeout(() => child.stdin.end(), 200);
+    });
   });
+
+  if (!stdout.trim()) {
+    throw new Error(`Empty stdout from MCP process`);
+  }
 
   const lines = stdout.trim().split("\n").filter(Boolean).map((line) => JSON.parse(line) as {
     id?: number;

--- a/tests/memory-lifecycle.integration.test.ts
+++ b/tests/memory-lifecycle.integration.test.ts
@@ -308,6 +308,53 @@ describe("memory-lifecycle", () => {
     }
   }, 15000);
 
+  it("persists alwaysLoad to note frontmatter via remember and update", async () => {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mcp-vault-"));
+    tempDirs.push(vaultDir);
+    const embeddingServer = await startFakeEmbeddingServer();
+
+    try {
+      // Test remember with alwaysLoad: true
+      const rememberText = await callLocalMcp(vaultDir, "remember", {
+        title: "AlwaysLoad remember test",
+        content: "Note created with alwaysLoad true.",
+        tags: ["integration", "alwaysLoad"],
+        alwaysLoad: true,
+        summary: "Create note with alwaysLoad via remember",
+        scope: "global",
+      }, embeddingServer.url);
+
+      const noteId = extractRememberedId(rememberText);
+      const notePath = path.join(vaultDir, "notes", `${noteId}.md`);
+
+      let noteContents = await readFile(notePath, "utf-8");
+      expect(noteContents).toContain("alwaysLoad: true");
+
+      // Test update with alwaysLoad: false
+      await callLocalMcp(vaultDir, "update", {
+        id: noteId,
+        content: "Note updated with alwaysLoad false.",
+        alwaysLoad: false,
+        summary: "Update note to set alwaysLoad false",
+      }, embeddingServer.url);
+
+      noteContents = await readFile(notePath, "utf-8");
+      expect(noteContents).toContain("alwaysLoad: false");
+
+      // Test update without alwaysLoad preserves existing value
+      await callLocalMcp(vaultDir, "update", {
+        id: noteId,
+        content: "Note updated without changing alwaysLoad.",
+        summary: "Update note without alwaysLoad param",
+      }, embeddingServer.url);
+
+      noteContents = await readFile(notePath, "utf-8");
+      expect(noteContents).toContain("alwaysLoad: false");
+    } finally {
+      await embeddingServer.close();
+    }
+  }, 15000);
+
   it("cleans related notes when forgetting a linked memory", async () => {
     const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mcp-vault-"));
     tempDirs.push(vaultDir);

--- a/tests/project-memory-summary.integration.test.ts
+++ b/tests/project-memory-summary.integration.test.ts
@@ -15,6 +15,17 @@ import {
 
 import { MemoryGraphResultSchema, ProjectSummaryResultSchema } from "../src/structured-content.js";
 
+/**
+ * Directly updates note frontmatter - USE SPARINGLY.
+ * 
+ * This helper bypasses the MCP tools and writes directly to the file system.
+ * It should ONLY be used for:
+ * - Setting timestamps (updatedAt/createdAt) that MCP tools automatically set to current time
+ * - Setting metadata fields (role, importance) that are not exposed via MCP tools
+ * 
+ * For standard fields (title, content, tags, lifecycle, alwaysLoad), use the MCP `update` tool.
+ * For testing MCP tool behavior, use `callLocalMcp` instead of this helper.
+ */
 async function updateProjectNoteFrontmatter(
   repoDir: string,
   noteId: string,

--- a/tests/relationship-expansion.integration.test.ts
+++ b/tests/relationship-expansion.integration.test.ts
@@ -5,15 +5,12 @@ import path from "path";
 import { execFile } from "child_process";
 import { promisify } from "util";
 import { fileURLToPath } from "url";
-import http from "http";
 
 import { GetResultSchema, ProjectSummaryResultSchema, RecallResultSchema } from "../src/structured-content.js";
+import { callLocalMcpResponse, extractRememberedId, startFakeEmbeddingServer, tempDirs } from "./helpers/mcp.js";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const execFileAsync = promisify(execFile);
-const builtEntryPoint = path.join(repoRoot, "build", "index.js");
-
-const tempDirs: string[] = [];
 
 afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map((dir) => import("fs/promises").then(fs => fs.rm(dir, { recursive: true, force: true }))));
@@ -23,119 +20,7 @@ beforeAll(async () => {
   await execFileAsync("npm", ["run", "build"], { cwd: repoRoot });
 }, 120000);
 
-async function startFakeEmbeddingServer(): Promise<{ url: string; close: () => Promise<void> }> {
-  const server = http.createServer((req, res) => {
-    if (req.method !== "POST" || req.url !== "/api/embed") {
-      res.writeHead(404).end();
-      return;
-    }
-    res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ embeddings: [[0.1, 0.2, 0.3]] }));
-  });
-
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", () => resolve());
-  });
-
-  const address = server.address();
-  if (!address || typeof address === "string") {
-    throw new Error("Could not determine fake embedding server address");
-  }
-
-  return {
-    url: `http://127.0.0.1:${address.port}`,
-    close: () => new Promise<void>((resolve, reject) => {
-      server.close((err) => err ? reject(err) : resolve());
-    }),
-  };
-}
-
-async function callLocalMcpMethod(
-  vaultDir: string,
-  id: number,
-  method: string,
-  params: Record<string, unknown>,
-  options?: { ollamaUrl?: string },
-): Promise<{ id?: number; result?: Record<string, unknown> }> {
-  const messages = [
-    {
-      jsonrpc: "2.0",
-      id: 0,
-      method: "initialize",
-      params: {
-        protocolVersion: "2024-11-05",
-        capabilities: {},
-        clientInfo: { name: "vitest", version: "1.0" },
-      },
-    },
-    {
-      jsonrpc: "2.0",
-      id,
-      method,
-      params,
-    },
-  ];
-
-  const stdout = await new Promise<string>((resolve, reject) => {
-    const { spawn } = require("child_process");
-    const child = spawn("node", [builtEntryPoint], {
-      cwd: repoRoot,
-      env: {
-        ...process.env,
-        DISABLE_GIT: "true",
-        VAULT_PATH: vaultDir,
-        ...(options?.ollamaUrl ? { OLLAMA_URL: options.ollamaUrl } : {}),
-      },
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-
-    let stdoutData = "";
-    let stderrData = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdoutData += chunk.toString();
-    });
-    child.stderr.on("data", (chunk) => {
-      stderrData += chunk.toString();
-    });
-    child.on("error", reject);
-    child.on("close", (code) => {
-      if (code !== 0) {
-        reject(new Error(`Process exited with code ${code}: ${stderrData}`));
-      } else {
-        resolve(stdoutData);
-      }
-    });
-
-    child.stdin.end(messages.map((msg) => JSON.stringify(msg)).join("\n") + "\n");
-  });
-
-  const lines = stdout.trim().split("\n").filter(Boolean);
-  if (lines.length === 0) {
-    throw new Error("Empty stdout from MCP process");
-  }
-  const lastLine = lines[lines.length - 1];
-  return JSON.parse(lastLine);
-}
-
-async function callLocalMcpTool(
-  vaultDir: string,
-  toolName: string,
-  args: Record<string, unknown>,
-  options?: { ollamaUrl?: string },
-): Promise<{ text: string; structuredContent?: Record<string, unknown> }> {
-  const response = await callLocalMcpMethod(vaultDir, 1, "tools/call", {
-    name: toolName,
-    arguments: args,
-  }, options);
-  const text = response?.result?.content?.[0]?.text;
-  if (!text) {
-    throw new Error(`Missing tool response for ${toolName}`);
-  }
-
-  return { text, structuredContent: response?.result?.structuredContent as Record<string, unknown> | undefined };
-}
+const callLocalMcpTool = callLocalMcpResponse;
 
 describe("Phase 4 relationship expansion", () => {
   describe("get with includeRelationships", () => {

--- a/tests/relationship-expansion.integration.test.ts
+++ b/tests/relationship-expansion.integration.test.ts
@@ -108,10 +108,7 @@ async function callLocalMcpMethod(
       }
     });
 
-    messages.forEach((msg) => {
-      child.stdin.write(JSON.stringify(msg) + "\n");
-    });
-    child.stdin.end();
+    child.stdin.end(messages.map((msg) => JSON.stringify(msg)).join("\n") + "\n");
   });
 
   const lines = stdout.trim().split("\n");

--- a/tests/relationship-expansion.integration.test.ts
+++ b/tests/relationship-expansion.integration.test.ts
@@ -92,12 +92,14 @@ async function callLocalMcpMethod(
 
     let stdoutData = "";
     let stderrData = "";
+    let stderrDataOut = "";
 
     child.stdout.on("data", (chunk) => {
       stdoutData += chunk.toString();
     });
     child.stderr.on("data", (chunk) => {
       stderrData += chunk.toString();
+      stderrDataOut += chunk.toString();
     });
     child.on("error", reject);
     child.on("close", (code) => {
@@ -111,9 +113,16 @@ async function callLocalMcpMethod(
     child.stdin.end(messages.map((msg) => JSON.stringify(msg)).join("\n") + "\n");
   });
 
-  const lines = stdout.trim().split("\n");
+  const lines = stdout.trim().split("\n").filter(Boolean);
+  if (lines.length === 0) {
+    throw new Error(`Empty stdout from MCP process. stderr: ${stderrDataOut}`);
+  }
   const lastLine = lines[lines.length - 1];
-  return JSON.parse(lastLine);
+  try {
+    return JSON.parse(lastLine);
+  } catch (e) {
+    throw new Error(`Failed to parse JSON from: ${lastLine}. stderr: ${stderrDataOut}`);
+  }
 }
 
 async function callLocalMcpTool(

--- a/tests/relationship-expansion.integration.test.ts
+++ b/tests/relationship-expansion.integration.test.ts
@@ -92,14 +92,12 @@ async function callLocalMcpMethod(
 
     let stdoutData = "";
     let stderrData = "";
-    let stderrDataOut = "";
 
     child.stdout.on("data", (chunk) => {
       stdoutData += chunk.toString();
     });
     child.stderr.on("data", (chunk) => {
       stderrData += chunk.toString();
-      stderrDataOut += chunk.toString();
     });
     child.on("error", reject);
     child.on("close", (code) => {
@@ -115,14 +113,10 @@ async function callLocalMcpMethod(
 
   const lines = stdout.trim().split("\n").filter(Boolean);
   if (lines.length === 0) {
-    throw new Error(`Empty stdout from MCP process. stderr: ${stderrDataOut}`);
+    throw new Error("Empty stdout from MCP process");
   }
   const lastLine = lines[lines.length - 1];
-  try {
-    return JSON.parse(lastLine);
-  } catch (e) {
-    throw new Error(`Failed to parse JSON from: ${lastLine}. stderr: ${stderrDataOut}`);
-  }
+  return JSON.parse(lastLine);
 }
 
 async function callLocalMcpTool(


### PR DESCRIPTION
The alwaysLoad parameter was accepted by the remember and update MCP tools but was silently ignored - it never reached the note frontmatter. This meant session anchors (notes that should auto-load at session start) didn't work when created via MCP.
## Changes
### Core Fix
- Added alwaysLoad to the input schema for both remember and update tools
- Updated tool handlers to pass alwaysLoad to the Note constructor
- remember now accepts alwaysLoad: boolean (defaults to false)
- update now accepts alwaysLoad: boolean (preserves existing value if not provided)
### Testing
- Added integration test: "persists alwaysLoad to note frontmatter via remember and update"
- Tests remember with alwaysLoad: true, update with alwaysLoad: false, and verifies persistence
### Dogfooding Test Suite
- Added F2 test case to Phase 7: "AlwaysLoad via MCP" - exercises remember/update/get flow
- Updated scorecard to clarify that "alwaysLoad behaves cleanly" means via MCP tools
- Documented when updateProjectNoteFrontmatter() helper is appropriate vs MCP tools