### PR TITLE
Git mutation coordination: per-repo mutex plus retry fallback

### DIFF
--- a/.mnemonic/notes/git-mutation-coordination-per-repo-mutex-plus-retry-fallback-56264a36.md
+++ b/.mnemonic/notes/git-mutation-coordination-per-repo-mutex-plus-retry-fallback-56264a36.md
@@ -8,10 +8,13 @@ tags:
   - resilience
 lifecycle: permanent
 createdAt: '2026-04-05T12:46:05.045Z'
-updatedAt: '2026-04-05T12:46:05.045Z'
+updatedAt: '2026-04-05T12:54:17.658Z'
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: git-resilience-retry-contract-concurrency-design-and-languag-351fab47
+    type: explains
 memoryVersion: 1
 ---
 Approved design: serialize all mutating git operations inside mnemonic with an in-process per-repo async mutex, while keeping bounded retry handling for transient git lock failures.

--- a/.mnemonic/notes/git-mutation-coordination-per-repo-mutex-plus-retry-fallback-56264a36.md
+++ b/.mnemonic/notes/git-mutation-coordination-per-repo-mutex-plus-retry-fallback-56264a36.md
@@ -1,0 +1,45 @@
+---
+title: 'Git mutation coordination: per-repo mutex plus retry fallback'
+tags:
+  - git
+  - concurrency
+  - design
+  - retry
+  - resilience
+lifecycle: permanent
+createdAt: '2026-04-05T12:46:05.045Z'
+updatedAt: '2026-04-05T12:46:05.045Z'
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+Approved design: serialize all mutating git operations inside mnemonic with an in-process per-repo async mutex, while keeping bounded retry handling for transient git lock failures.
+
+Why:
+
+- Existing `git.add()` retry hardening reduced transient `.git/index.lock` failures but did not solve same-vault races created by concurrent mnemonic operations.
+- Project experience showed same-vault mutating operations should be serialized, while retries remain useful for cross-process contention or any missed edge.
+
+Design:
+
+- Add a small lock registry keyed by canonical `gitRoot`.
+- Wrap `GitOps.commitWithStatus()`, `GitOps.pushWithStatus()`, and `GitOps.sync()` in a shared mutation lock.
+- Keep read-only git methods unlocked.
+- Keep existing retry behavior and broaden it only for lock-shaped failures in mutating phases, with short bounded backoff.
+- Use the mutex as the primary same-process coordination mechanism and retry as the fallback for external contention.
+
+Desired behavior:
+
+- Same-repo mutations serialize.
+- Different repos can still mutate concurrently.
+- Lock release happens in `finally`.
+- Failure reporting should continue to use the existing structured retry/recovery contract.
+
+Testing intent:
+
+- Add focused tests proving same-repo mutation serialization.
+- Add release-on-error coverage.
+- Preserve or extend existing transient lock retry coverage.
+
+This design was explicitly approved for implementation.

--- a/.mnemonic/notes/git-resilience-retry-contract-concurrency-design-and-languag-351fab47.md
+++ b/.mnemonic/notes/git-resilience-retry-contract-concurrency-design-and-languag-351fab47.md
@@ -11,7 +11,7 @@ tags:
   - decision
 lifecycle: permanent
 createdAt: '2026-03-24T10:53:27.605Z'
-updatedAt: '2026-03-26T21:00:32.043Z'
+updatedAt: '2026-04-05T12:54:17.658Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
@@ -20,6 +20,8 @@ relatedTo:
   - id: parallel-consolidate-operations-can-leave-staged-local-only--e8c33780
     type: example-of
   - id: manual-exact-git-recovery-contract-for-partial-mnemonic-pers-ffae4896
+    type: explains
+  - id: git-mutation-coordination-per-repo-mutex-plus-retry-fallback-56264a36
     type: explains
 memoryVersion: 1
 ---

--- a/AGENT.md
+++ b/AGENT.md
@@ -36,6 +36,8 @@ Before calling `remember`:
 4. Pass `cwd` for anything about the current repo, even if you intend to store it in the main vault with `scope: "global"`.
 5. Omit `cwd` only for truly cross-project or personal memories; missing `cwd` makes the note global and unassociated.
 6. After `remember`, `update`, `move_memory`, or consolidation writes, inspect the returned structured persistence status before doing extra verification calls. It tells you the note path, embedding path, embedding outcome, and git commit/push outcome, including when push is intentionally skipped by config.
+7. Memory work is not complete after `remember`, `update`, or `consolidate` alone. If the note extends, implements, or was informed by an existing note surfaced via `recall`, `list`, `recent_memories`, or `get`, explicitly decide whether to `relate` or `consolidate` before finishing.
+8. Default stance: if a note continues a prior design, bug, decision, or implementation arc, create a relationship unless there is a concrete reason not to. Treat skipped relationships as something you should be able to justify, not as optional cleanup.
 
 ### Choosing note lifecycle
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 ### Fixed
 
 - Working-state continuity guidance no longer tells agents to preserve temporary checkpoints by default when consolidating completed work.
+- Same-repo git mutations inside mnemonic are now serialized, reducing transient `.git/index.lock` failures during concurrent mutating operations while keeping bounded retry fallback for external contention.
 
 ## [0.20.0] - 2026-04-04
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -2,6 +2,8 @@ import { access } from "fs/promises";
 import path from "path";
 import { simpleGit, SimpleGit } from "simple-git";
 
+const mutationLocks = new Map<string, Promise<void>>();
+
 export class GitOperationError extends Error {
   constructor(operation: "add" | "commit" | "push", cause: unknown) {
     const detail = cause instanceof Error ? cause.message : String(cause);
@@ -69,7 +71,7 @@ export class GitOps {
   private enabled: boolean;
 
   constructor(gitRoot: string, notesRelDir: string = "notes") {
-    this.gitRoot = gitRoot;
+    this.gitRoot = path.resolve(gitRoot);
     this.notesRelDir = notesRelDir;
     this.enabled = process.env["DISABLE_GIT"] !== "true";
   }
@@ -116,36 +118,33 @@ export class GitOps {
   async commitWithStatus(message: string, files: string[], body?: string): Promise<CommitResult> {
     if (!this.enabled) return { status: "skipped", reason: "git-disabled" };
 
-    // Scope every add+commit to only the paths mnemonic manages.
-    // Never commit files outside the vault — e.g. src/ or test/ changes
-    // that happen to be staged in the same repo.
-    const scopedFiles = files.length > 0 ? files : [`${this.notesRelDir}/`];
+    return this.withMutationLock(async () => {
+      // Scope every add+commit to only the paths mnemonic manages.
+      // Never commit files outside the vault — e.g. src/ or test/ changes
+      // that happen to be staged in the same repo.
+      const scopedFiles = files.length > 0 ? files : [`${this.notesRelDir}/`];
 
-    // Retry git.add() with exponential backoff for transient index.lock errors.
-    // git.add() can fail with "Unable to create '.git/index.lock': File exists"
-    // when concurrent git operations race for the index. This is recoverable
-    // by retrying after a short delay.
-    const addResult = await this.addWithRetry(scopedFiles);
-    if (addResult.status === "failed") {
-      return addResult;
-    }
+      const addResult = await this.addWithRetry(scopedFiles);
+      if (addResult.status === "failed") {
+        return addResult;
+      }
 
-    try {
-      const status = await this.git.status();
-      if (status.staged.length === 0) return { status: "skipped", reason: "no-changes" };
+      try {
+        const status = await this.git.status();
+        if (status.staged.length === 0) return { status: "skipped", reason: "no-changes" };
 
-      // Build commit message with optional body
-      const fullMessage = body ? `${message}\n\n${body}` : message;
-      await this.git.commit(fullMessage, scopedFiles);
+        const fullMessage = body ? `${message}\n\n${body}` : message;
+        await this.retryLockErrors("commit", () => this.git.commit(fullMessage, scopedFiles));
 
-      const displayMessage = body ? `${message} [...]` : message;
-      console.error(`[git] Committed: ${displayMessage}`);
-      return { status: "committed" };
-    } catch (err) {
-      const errMessage = err instanceof Error ? err.message : String(err);
-      console.error(`[git] Commit failed: ${errMessage}`);
-      return { status: "failed", reason: "error", operation: "commit", error: errMessage };
-    }
+        const displayMessage = body ? `${message} [...]` : message;
+        console.error(`[git] Committed: ${displayMessage}`);
+        return { status: "committed" };
+      } catch (err) {
+        const errMessage = err instanceof Error ? err.message : String(err);
+        console.error(`[git] Commit failed: ${errMessage}`);
+        return { status: "failed", reason: "error", operation: "commit", error: errMessage };
+      }
+    });
   }
 
   /**
@@ -153,31 +152,14 @@ export class GitOps {
    * Returns a CommitResult-like object for add failures.
    */
   private async addWithRetry(files: string[]): Promise<CommitResult> {
-    const maxRetries = 3;
-    const baseDelayMs = 50;
-
-    for (let attempt = 0; attempt < maxRetries; attempt++) {
-      try {
-        await this.git.add(files);
-        return { status: "committed" };
-      } catch (err) {
-        const errMessage = err instanceof Error ? err.message : String(err);
-        const isLockError = errMessage.includes("index.lock") || errMessage.includes("File exists");
-
-        if (isLockError && attempt < maxRetries - 1) {
-          const delayMs = baseDelayMs * Math.pow(2, attempt);
-          console.error(`[git] add() lock contention, retrying in ${delayMs}ms (attempt ${attempt + 1}/${maxRetries})`);
-          await new Promise((resolve) => setTimeout(resolve, delayMs));
-          continue;
-        }
-
-        console.error(`[git] add() failed: ${errMessage}`);
-        return { status: "failed", reason: "error", operation: "add", error: errMessage };
-      }
+    try {
+      await this.retryLockErrors("add", () => this.git.add(files));
+      return { status: "committed" };
+    } catch (err) {
+      const errMessage = err instanceof Error ? err.message : String(err);
+      console.error(`[git] add() failed: ${errMessage}`);
+      return { status: "failed", reason: "error", operation: "add", error: errMessage };
     }
-
-    // Should be unreachable, but TypeScript needs a return
-    return { status: "failed", reason: "error", operation: "add", error: "max retries exceeded" };
   }
 
   /**
@@ -212,71 +194,66 @@ export class GitOps {
 
     if (!this.enabled) return empty;
 
-    const remotes = await this.git.getRemotes();
-    if (remotes.length === 0) return empty;
+    return this.withMutationLock(async () => {
+      const remotes = await this.git.getRemotes();
+      if (remotes.length === 0) return empty;
 
-    const withRemote: Pick<SyncResult, "hasRemote" | "pulledNoteIds" | "deletedNoteIds" | "pushedCommits"> = {
-      hasRemote: true,
-      pulledNoteIds: [],
-      deletedNoteIds: [],
-      pushedCommits: 0,
-    };
-
-    // Phase 1: fetch
-    try {
-      await this.git.fetch();
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      console.error(`[git] Sync fetch failed: ${message}`);
-      return { ...withRemote, gitError: { phase: "fetch", message, isConflict: false } };
-    }
-
-    const unpushed = await this.countUnpushedCommits();
-    const localHead = await this.currentHead();
-
-    // Phase 2: pull (rebase)
-    try {
-      await this.git.pull(["--rebase"]);
-      console.error("[git] Pulled (rebase)");
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      console.error(`[git] Sync pull failed: ${message}`);
-      // Use language-independent checks: conflicted files from git status (porcelain codes,
-      // not localized) and git internal state files (.git/rebase-merge, .git/rebase-apply,
-      // .git/MERGE_HEAD) rather than error message keywords.
-      const conflictFiles = await this.getConflictFiles();
-      const isConflict = conflictFiles.length > 0 || await this.isConflictInProgress();
-      return {
-        ...withRemote,
-        gitError: {
-          phase: "pull",
-          message,
-          isConflict,
-          conflictFiles: conflictFiles.length > 0 ? conflictFiles : undefined,
-        },
-      };
-    }
-
-    const { pulledNoteIds, deletedNoteIds } = await this.diffNotesSince(localHead);
-
-    // Phase 3: push
-    try {
-      await this.git.push();
-      console.error(`[git] Pushed ${unpushed} local commit(s)`);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      console.error(`[git] Sync push failed: ${message}`);
-      // Pull succeeded — return partial success with the pulled notes and the push error
-      return {
+      const withRemote: Pick<SyncResult, "hasRemote" | "pulledNoteIds" | "deletedNoteIds" | "pushedCommits"> = {
         hasRemote: true,
-        pulledNoteIds,
-        deletedNoteIds,
+        pulledNoteIds: [],
+        deletedNoteIds: [],
         pushedCommits: 0,
-        gitError: { phase: "push", message, isConflict: false },
       };
-    }
 
-    return { hasRemote: true, pulledNoteIds, deletedNoteIds, pushedCommits: unpushed };
+      try {
+        await this.retryLockErrors("fetch", () => this.git.fetch());
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[git] Sync fetch failed: ${message}`);
+        return { ...withRemote, gitError: { phase: "fetch", message, isConflict: false } };
+      }
+
+      const unpushed = await this.countUnpushedCommits();
+      const localHead = await this.currentHead();
+
+      try {
+        await this.retryLockErrors("pull", () => this.git.pull(["--rebase"]));
+        console.error("[git] Pulled (rebase)");
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[git] Sync pull failed: ${message}`);
+        const conflictFiles = await this.getConflictFiles();
+        const isConflict = conflictFiles.length > 0 || await this.isConflictInProgress();
+        return {
+          ...withRemote,
+          gitError: {
+            phase: "pull",
+            message,
+            isConflict,
+            conflictFiles: conflictFiles.length > 0 ? conflictFiles : undefined,
+          },
+        };
+      }
+
+      const { pulledNoteIds, deletedNoteIds } = await this.diffNotesSince(localHead);
+
+      try {
+        await this.retryLockErrors("push", () => this.git.push());
+        console.error(`[git] Pushed ${unpushed} local commit(s)`);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[git] Sync push failed: ${message}`);
+        return {
+          hasRemote: true,
+          pulledNoteIds,
+          deletedNoteIds,
+          pushedCommits: 0,
+          gitError: { phase: "push", message, isConflict: false },
+        };
+      }
+
+      return { hasRemote: true, pulledNoteIds, deletedNoteIds, pushedCommits: unpushed };
+    });
   }
 
   private async getConflictFiles(): Promise<string[]> {
@@ -317,17 +294,67 @@ export class GitOps {
 
   async pushWithStatus(): Promise<PushResult> {
     if (!this.enabled) return { status: "skipped", reason: "git-disabled" };
+    return this.withMutationLock(async () => {
+      try {
+        const remotes = await this.git.getRemotes();
+        if (remotes.length === 0) return { status: "skipped", reason: "no-remote" };
+        await this.retryLockErrors("push", () => this.git.push());
+        console.error("[git] Pushed");
+        return { status: "pushed" };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[git] Push failed: ${message}`);
+        return { status: "failed", error: message };
+      }
+    });
+  }
+
+  private async withMutationLock<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = mutationLocks.get(this.gitRoot) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    mutationLocks.set(this.gitRoot, current);
+
+    await previous;
+
     try {
-      const remotes = await this.git.getRemotes();
-      if (remotes.length === 0) return { status: "skipped", reason: "no-remote" };
-      await this.git.push();
-      console.error("[git] Pushed");
-      return { status: "pushed" };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      console.error(`[git] Push failed: ${message}`);
-      return { status: "failed", error: message };
+      return await operation();
+    } finally {
+      release();
+      if (mutationLocks.get(this.gitRoot) === current) {
+        mutationLocks.delete(this.gitRoot);
+      }
     }
+  }
+
+  private async retryLockErrors<T>(operationName: string, operation: () => Promise<T>): Promise<T> {
+    const maxRetries = 3;
+    const baseDelayMs = 50;
+
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      try {
+        return await operation();
+      } catch (err) {
+        const errMessage = err instanceof Error ? err.message : String(err);
+        if (this.isLockError(errMessage) && attempt < maxRetries - 1) {
+          const delayMs = baseDelayMs * Math.pow(2, attempt);
+          console.error(`[git] ${operationName}() lock contention, retrying in ${delayMs}ms (attempt ${attempt + 1}/${maxRetries})`);
+          await new Promise((resolve) => setTimeout(resolve, delayMs));
+          continue;
+        }
+
+        throw err;
+      }
+    }
+
+    throw new Error(`[git] ${operationName}() lock retries exhausted`);
+  }
+
+  private isLockError(errMessage: string): boolean {
+    return errMessage.includes("index.lock") || errMessage.includes("File exists");
   }
 
   /**

--- a/tests/git.unit.test.ts
+++ b/tests/git.unit.test.ts
@@ -1,5 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 const add = vi.fn();
 const status = vi.fn();
 const commit = vi.fn();
@@ -166,6 +176,77 @@ describe("GitOps", () => {
     expect(result.status).toBe("failed");
     expect(result.operation).toBe("commit");
     expect(result.error).toContain("signing failed");
+  });
+
+  it("serializes concurrent same-repo commit mutations", async () => {
+    const { GitOps } = await import("../src/git.js");
+    const firstCommitGate = deferred<void>();
+    const firstAddStarted = deferred<void>();
+    let activeAdds = 0;
+    let maxConcurrentAdds = 0;
+    let addCallCount = 0;
+
+    add.mockImplementation(async () => {
+      addCallCount += 1;
+      activeAdds += 1;
+      maxConcurrentAdds = Math.max(maxConcurrentAdds, activeAdds);
+
+      if (addCallCount === 1) {
+        firstAddStarted.resolve();
+      }
+
+      await Promise.resolve();
+      activeAdds -= 1;
+    });
+
+    status.mockResolvedValue({ staged: ["notes/test.md"] });
+    commit.mockImplementation(async () => {
+      if (addCallCount === 1) {
+        await firstCommitGate.promise;
+      }
+    });
+
+    const gitA = new GitOps("/tmp/repo");
+    const gitB = new GitOps("/tmp/repo");
+    await gitA.init();
+    await gitB.init();
+
+    const first = gitA.commitWithStatus("remember: first", ["notes/first.md"]);
+    await firstAddStarted.promise;
+    const second = gitB.commitWithStatus("remember: second", ["notes/second.md"]);
+    await Promise.resolve();
+
+    expect(addCallCount).toBe(1);
+    expect(maxConcurrentAdds).toBe(1);
+
+    firstCommitGate.resolve();
+
+    await expect(first).resolves.toMatchObject({ status: "committed" });
+    await expect(second).resolves.toMatchObject({ status: "committed" });
+    expect(addCallCount).toBe(2);
+    expect(maxConcurrentAdds).toBe(1);
+  });
+
+  it("releases the same-repo mutation lock after a commit failure", async () => {
+    const { GitOps } = await import("../src/git.js");
+    const gitA = new GitOps("/tmp/repo");
+    const gitB = new GitOps("/tmp/repo");
+    await gitA.init();
+    await gitB.init();
+
+    add.mockResolvedValue(undefined);
+    status.mockResolvedValue({ staged: ["notes/test.md"] });
+    commit.mockRejectedValueOnce(new Error("signing failed"));
+    commit.mockResolvedValueOnce(undefined);
+
+    await expect(gitA.commitWithStatus("remember: first", ["notes/first.md"])).resolves.toMatchObject({
+      status: "failed",
+      operation: "commit",
+    });
+
+    await expect(gitB.commitWithStatus("remember: second", ["notes/second.md"])).resolves.toMatchObject({
+      status: "committed",
+    });
   });
 
   describe("sync", () => {


### PR DESCRIPTION
## Summary

This PR captures the following design decisions:

- **Git mutation coordination: per-repo mutex plus retry fallback**
- **Git resilience: retry contract, concurrency design, and language-independent state detection**

## Design Decisions

### Git mutation coordination: per-repo mutex plus retry fallback

**Tags:** git, concurrency, design, retry, resilience

Approved design: serialize all mutating git operations inside mnemonic with an in-process per-repo async mutex, while keeping bounded retry handling for transient git lock failures.

Why:

- Existing `git.add()` retry hardening reduced transient `.git/index.lock` failures but did not solve same-vault races created by concurrent mnemonic operations.
- Project experience showed same-vault mutating operations should be serialized, while retries remain useful for cross-process contention or any missed edge.

Design:

- Add a small lock registry keyed by canonical `gitRoot`.
- Wrap `GitOps.commitWithStatus()`, `GitOps.pushWithStatus()`, and `GitOps.sync()` in a shared mutation lock.
- Keep read-only git methods unlocked.
- Keep existing retry behavior and broaden it only for lock-shaped failures in mutating phases, with short bounded backoff.
- Use the mutex as the primary same-process coordination mechanism and retry as the fallback for external contention.

Desired behavior:

- Same-repo mutations serialize.
- Different repos can still mutate concurrently.
- Lock release happens in `finally`.
- Failure reporting should continue to use the existing structured retry/recovery contract.

Testing intent:

- Add focused tests proving same-repo mutation serialization.
- Add release-on-error coverage.
- Preserve or extend existing transient lock retry coverage.

This design was explicitly approved for implementation.

### Git resilience: retry contract, concurrency design, and language-independent state detection

**Tags:** git, resilience, retry, concurrency, design, decision

## Why retry is necessary

Multiple agent sessions (Claude desktop, VSCode plugin, CLI) can concurrently access the same vault with no mutex coordination. This amplifies index.lock probability:

- 10% base lock × 3 concurrent agents ≈ 27% failure rate without retry
- With 3-attempt exponential backoff: ≈ 3% effective failure rate
- Rapid-fire operations (recall → discover_tags → remember → relate) can hit the lock within <100ms

## Retry contract

`git.add()` and `git.commit()` can both fail with index.lock:

- **Add retry**: `addWithRetry()` wraps `git.add()` with 3 retries and exponential backoff (50ms → 100ms → 200ms) for transient lock errors
- **Commit failure**: if add succeeds but commit fails, returns `operation: "commit"`
- **Add exhaustion**: if all add retries fail, returns `operation: "add"`

Retry metadata exposed to callers: `attemptedCommit` payload (`message`, `body`, `files`, `cwd`, `vault`, `error`, `operation`), `mutationApplied`, `retrySafe`, and rationale.

### Scope covered

`remember`, `update`, `move_memory`, `forget`, `relate`, `unrelate`, `set_project_identity`, `set_project_memory_policy`, `consolidate` mutating paths (`execute-merge`, `prune-superseded`).

### Known limitation

Parallel mutating operations against the same vault can still leave partial persistence states (note + embedding written but git only local). **Same-vault mutating operations should be serialized by callers.**

## Language-independent state detection

Never rely on git error message keywords — they are localized and change under different `LANG`/`LC_ALL` settings.

Safe alternatives:

- **`git status --porcelain`** status codes (UU, AA, DD) — not localized, safe to parse; `simple-git`'s `status().conflicted` uses this
- **Git internal state files** — filesystem paths, entirely language-independent:
  - `.git/rebase-merge/` — interactive or `--merge` rebase in progress
  - `.git/rebase-apply/` — `--apply` strategy rebase in progress
  - `.git/MERGE_HEAD` — plain merge conflict

Applied in `GitOps.isConflictInProgress()` in `src/git.ts`: replaced keyword-based fallback with `fs.access` checks on the three paths above.

---

_Generated from 2 design decision note(s) in `.mnemonic/notes/`. Run `/update-pr` to regenerate._