### PR TITLE
Improve semanticPatch lint error handling: auto-fix, better errors, no fallback ease

### DIFF
--- a/.mnemonic/notes/improve-semanticpatch-lint-error-handling-auto-fix-better-er-48d0d31e.md
+++ b/.mnemonic/notes/improve-semanticpatch-lint-error-handling-auto-fix-better-er-48d0d31e.md
@@ -7,11 +7,14 @@ tags:
   - request
 lifecycle: temporary
 createdAt: '2026-04-24T18:48:51.710Z'
-updatedAt: '2026-04-24T18:48:51.710Z'
+updatedAt: '2026-04-24T19:12:40.312Z'
 role: context
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: semantic-patch-builder-design-implementation-906872f1
+    type: derives-from
 memoryVersion: 1
 ---
 # Request: Improve semanticPatch lint error handling

--- a/.mnemonic/notes/improve-semanticpatch-lint-error-handling-auto-fix-better-er-48d0d31e.md
+++ b/.mnemonic/notes/improve-semanticpatch-lint-error-handling-auto-fix-better-er-48d0d31e.md
@@ -1,0 +1,43 @@
+---
+title: >-
+  Improve semanticPatch lint error handling: auto-fix, better errors, no
+  fallback ease
+tags:
+  - workflow
+  - request
+lifecycle: temporary
+createdAt: '2026-04-24T18:48:51.710Z'
+updatedAt: '2026-04-24T18:48:51.710Z'
+role: context
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+# Request: Improve semanticPatch lint error handling
+
+## Problem
+
+Three issues with the semanticPatch flow when markdown lint fails:
+
+1. **Auto-fix lint in patch values before writing** — when patch values contain auto-fixable lint issues (like `---` instead of `***` for horizontal rules), `cleanMarkdown` throws instead of auto-fixing and proceeding. The fix is trivial but the rejection forces the LLM to retry.
+
+2. **Better error message** — the error just says "Semantic patch failed: Markdown lint failed:" with line numbers. It doesn't guide the LLM toward the correct recovery path (fix lint in patch values and retry, don't fall back to full content rewrite).
+
+3. **Separate structural validation from content validation** — selector-not-found (structural) and lint-failure (content) are both caught by the same try/catch with the same "Semantic patch failed:" prefix. The LLM can't distinguish "your selector is wrong" from "your content has lint issues."
+
+## Approach
+
+- Export a lenient `attemptCleanMarkdown` variant that returns `{ cleaned: string, warnings?: string[] }` instead of throwing on unfixable lint.
+- Refactor `cleanMarkdown` to use `attemptCleanMarkdown` internally and throw on warnings.
+- Change `applySemanticPatches` to use `attemptCleanMarkdown` and return warnings alongside the cleaned content.
+- Update the update handler to surface lint warnings in the success response (not an error), so the LLM sees them as advisory.
+- Distinguish error types: structural failures (selector not found, invalid operation) still hard-fail; lint warnings are advisory.
+
+## Files
+
+- `src/markdown.ts` — add `attemptCleanMarkdown`, refactor `cleanMarkdown`
+- `src/semantic-patch.ts` — use lenient cleaning, return warnings
+- `src/index.ts` — distinguish error types, surface warnings in response
+- `tests/semantic-patch.unit.test.ts` — add tests for lint warning behavior
+- `tests/markdown.unit.test.ts` — add tests for attemptCleanMarkdown

--- a/.mnemonic/notes/plan-semanticpatch-lint-error-handling-improvements-2f54b5df.md
+++ b/.mnemonic/notes/plan-semanticpatch-lint-error-handling-improvements-2f54b5df.md
@@ -1,0 +1,84 @@
+---
+title: 'Plan: semanticPatch lint error handling improvements'
+tags:
+  - workflow
+  - plan
+lifecycle: temporary
+createdAt: '2026-04-24T18:49:06.872Z'
+updatedAt: '2026-04-24T18:49:06.872Z'
+role: plan
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+# Plan: semanticPatch lint error handling improvements
+
+## Background
+
+Three related issues with the semanticPatch update flow:
+
+### Issue 1: Auto-fix lint in patch values before writing
+
+`applySemanticPatches` calls `cleanMarkdown(serialized)` at the end. `cleanMarkdown` has a 3-attempt auto-fix loop for fixable issues, but if ANY issues remain after auto-fix (even auto-fixable ones that somehow survive 3 rounds), it throws `MarkdownLintError`. There's no recovery at the handler level.
+
+Root cause in `src/markdown.ts:35-59`: the auto-fix loop only runs 3 attempts. For common issues like MD035 (horizontal rule style `---` vs `***`), markdownlint's `applyFixes` may not fix them in the first pass. The loop hits its limit, and the remaining issues cause a throw.
+
+### Issue 2: Better error message
+
+The error message is "Semantic patch failed: Markdown lint failed:\n- line N: MD035/MD035 Horizontal rule style (expected ---)" with no guidance to the LLM about how to fix it (change the horizontal rule syntax in the patch value and retry, don't fall back to full content rewrite).
+
+### Issue 3: No distinction between structural and content errors
+
+Both "selector not found" (structural) and "lint failure" (content) get caught by the SAME try/catch in the update handler at `src/index.ts:2854-2860`. The LLM can't tell whether it needs to fix its selector or its content.
+
+## Implementation
+
+### Step 1: Add `attemptCleanMarkdown` in `src/markdown.ts`
+
+A lenient variant that returns `{ cleaned: string; warnings: string[] }` instead of throwing:
+
+```typescript
+export async function attemptCleanMarkdown(markdown: string): Promise<{ cleaned: string; warnings: string[] }> {
+  // Same normalize + auto-fix loop as cleanMarkdown
+  // But instead of throwing on remaining issues, returns them as warnings
+  // Also: applyFixes one more round for each remaining unfixable issue after main loop
+  // to catch edge cases where fixable issues survive 3 rounds
+}
+```
+
+Refactor `cleanMarkdown` to use `attemptCleanMarkdown` internally:
+
+```typescript
+export async function cleanMarkdown(markdown: string): Promise<string> {
+  const { cleaned, warnings } = await attemptCleanMarkdown(markdown);
+  if (warnings.length > 0) {
+    throw new MarkdownLintError(warnings);
+  }
+  return cleaned;
+}
+```
+
+### Step 2: Update `applySemanticPatches` in `src/semantic-patch.ts`
+
+Change the return type to `Promise<{ content: string; lintWarnings: string[] }>` and use `attemptCleanMarkdown` instead of `cleanMarkdown`. Structural errors (selector not found, invalid operation) still throw as before.
+
+### Step 3: Update the update handler in `src/index.ts`
+
+- Catch `MarkdownLintError` specifically vs structural errors
+- Return lint warnings in the success response as advisory (not an error)
+- Structural errors still hard-fail with "Semantic patch failed: ..."
+- Include lint warnings in the response text so the LLM sees them
+
+## Risk
+
+- `applySemanticPatches` return type changes — callers must be updated (only in `src/index.ts`)
+- `cleanMarkdown` behavior is preserved exactly (still throws on unfixable issues)
+- The `attemptCleanMarkdown` naming makes the leniency explicit
+
+## Validation
+
+- All existing tests must pass without modification
+- New tests for `attemptCleanMarkdown` in `tests/markdown.unit.test.ts`
+- New test in `tests/semantic-patch.unit.test.ts` that a patch producing fixable lint (like `---`) succeeds and returns warnings
+- Typecheck clean

--- a/.mnemonic/notes/plan-semanticpatch-lint-error-handling-improvements-2f54b5df.md
+++ b/.mnemonic/notes/plan-semanticpatch-lint-error-handling-improvements-2f54b5df.md
@@ -5,11 +5,14 @@ tags:
   - plan
 lifecycle: temporary
 createdAt: '2026-04-24T18:49:06.872Z'
-updatedAt: '2026-04-24T18:49:06.872Z'
+updatedAt: '2026-04-24T19:12:40.313Z'
 role: plan
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: semantic-patch-builder-design-implementation-906872f1
+    type: derives-from
 memoryVersion: 1
 ---
 # Plan: semanticPatch lint error handling improvements

--- a/.mnemonic/notes/review-semanticpatch-lint-error-handling-improvements-02378fc4.md
+++ b/.mnemonic/notes/review-semanticpatch-lint-error-handling-improvements-02378fc4.md
@@ -1,0 +1,58 @@
+---
+title: 'Review: semanticPatch lint error handling improvements'
+tags:
+  - workflow
+  - review
+lifecycle: temporary
+createdAt: '2026-04-24T19:05:03.894Z'
+updatedAt: '2026-04-24T19:05:03.894Z'
+role: review
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+# Review: semanticPatch lint error handling improvements
+
+## Outcome: Continue — all changes implemented and verified
+
+## What was done
+
+### Issue 1: Auto-fix lint in patch values (formerly a hard error)
+
+- Added `attemptCleanMarkdown` in `src/markdown.ts` — returns `{ cleaned, warnings }` instead of throwing
+- Refactored `cleanMarkdown` to delegate to `attemptCleanMarkdown` and throw on warnings
+- `applySemanticPatches` now uses `attemptCleanMarkdown`, lint warnings become advisory
+- Patch succeeds with warnings surfaced, not rejected
+
+### Issue 2: Better error messages
+
+- `MarkdownLintError` in patch path gives explicit guidance: "Fix the lint issues in your patch values and retry — do NOT fall back to full content rewrite"
+- `semanticPatch` parameter description updated with same guidance at the schema level
+
+### Issue 3: Separate structural vs content errors
+
+- Structural errors (selector not found, unknown operation) → "Semantic patch failed:" + diagnostic hard fail
+- Content lint issues → success with advisory warnings, not rejection
+- Caught at different points: structural in `applySemanticPatches` (throws Error), lint in `attemptCleanMarkdown` (returns warnings)
+
+### Structured content
+
+- `UpdateResult` interface and schema gained `lintWarnings: string[]`
+- Text response includes warnings as "markdown lint warnings (auto-fixed):" section
+
+## Verification
+
+- 682 tests pass (all 46 test files, no regressions)
+- Unit tests updated for new return type: `applySemanticPatches` returns `{ content, lintWarnings }`
+- Integration tests pass through real MCP server handler
+- Design note updated with lenient lint decision and changed error behavior
+
+## Files changed
+
+- `src/markdown.ts` — added `attemptCleanMarkdown`, refactored `cleanMarkdown`
+- `src/semantic-patch.ts` — use `attemptCleanMarkdown`, return `{ content, lintWarnings }`
+- `src/index.ts` — distinguish error types, surface warnings, tool description guidance
+- `src/structured-content.ts` — added `lintWarnings` to interface and schema
+- `tests/semantic-patch.unit.test.ts` — updated for new return type
+- `tests/markdown.unit.test.ts` — added attemptCleanMarkdown tests

--- a/.mnemonic/notes/review-semanticpatch-lint-error-handling-improvements-02378fc4.md
+++ b/.mnemonic/notes/review-semanticpatch-lint-error-handling-improvements-02378fc4.md
@@ -5,11 +5,14 @@ tags:
   - review
 lifecycle: temporary
 createdAt: '2026-04-24T19:05:03.894Z'
-updatedAt: '2026-04-24T19:05:03.894Z'
+updatedAt: '2026-04-24T19:12:40.306Z'
 role: review
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: semantic-patch-builder-design-implementation-906872f1
+    type: derives-from
 memoryVersion: 1
 ---
 # Review: semanticPatch lint error handling improvements

--- a/.mnemonic/notes/semantic-patch-builder-design-implementation-906872f1.md
+++ b/.mnemonic/notes/semantic-patch-builder-design-implementation-906872f1.md
@@ -10,10 +10,13 @@ tags:
   - implementation
 lifecycle: permanent
 createdAt: '2026-04-24T11:09:39.750Z'
-updatedAt: '2026-04-24T19:05:37.959Z'
+updatedAt: '2026-04-24T19:12:40.313Z'
 role: reference
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: plan-semanticpatch-lint-error-handling-improvements-2f54b5df
+    type: derives-from
 memoryVersion: 1
 ---
 # Semantic Patch Builder: Design & Implementation

--- a/.mnemonic/notes/semantic-patch-builder-design-implementation-906872f1.md
+++ b/.mnemonic/notes/semantic-patch-builder-design-implementation-906872f1.md
@@ -10,7 +10,7 @@ tags:
   - implementation
 lifecycle: permanent
 createdAt: '2026-04-24T11:09:39.750Z'
-updatedAt: '2026-04-24T19:00:22.062Z'
+updatedAt: '2026-04-24T19:05:37.959Z'
 role: reference
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
@@ -41,6 +41,10 @@ This leniency is unique to the patch path for two reasons:
 
 `remember` and `update` with full `content` still use strict lint validation — if the body has unfixable lint, it is rejected. The auto-fix loop in `cleanMarkdown` handles fixable issues for those paths.
 
+## Decision: Guidance at the Schema Level, Not Just Error Messages
+
+The "do NOT fall back to full content rewrite" guidance must be in the `semanticPatch` **parameter description**, not just in the `MarkdownLintError` message. Schema-level validation errors (malformed patches, wrong types) fire before the handler runs — the error message never reaches the LLM if it falls back before retrying. The parameter description is the only reliable channel.
+
 ## Architecture (5 Layers)
 
 1. **Parser** (`src/markdown-ast.ts`): `remark` + `unified` → `mdast`. `remark-stringify` configured with `bullet: "-"`.
@@ -70,6 +74,7 @@ Zod schema uses `z.discriminatedUnion` for operations (`remove` has no `value`; 
 - Structural errors (selector, operation) → "Semantic patch failed:" hard fail; no mutation; no commit
 - Patch produces markdown with lint issues → success with advisory `lintWarnings` in response; content persisted
 - `remember` and `update(content)` still hard-fail on unfixable lint
+- Schema validation errors (malformed patch) → MCP validation error; guidance at schema level prevents fallback
 
 ## Empirical Token Savings
 

--- a/.mnemonic/notes/semantic-patch-builder-design-implementation-906872f1.md
+++ b/.mnemonic/notes/semantic-patch-builder-design-implementation-906872f1.md
@@ -10,7 +10,8 @@ tags:
   - implementation
 lifecycle: permanent
 createdAt: '2026-04-24T11:09:39.750Z'
-updatedAt: '2026-04-24T11:32:28.640Z'
+updatedAt: '2026-04-24T19:00:22.062Z'
+role: reference
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 memoryVersion: 1
@@ -27,7 +28,18 @@ AST-based semantic patch editing via `remark`/`unified`. The `update` tool gains
 
 ## Decision: No Silent Fallback
 
-If `semanticPatch` fails (selector not found, lint error), the tool hard-fails with a diagnostic. No fallback to `content` replacement — a hard fail lets the LLM `get` the current note and regenerate.
+If `semanticPatch` fails (selector not found, invalid operation), the tool hard-fails with a diagnostic. No fallback to `content` replacement — a hard fail lets the LLM `get` the current note and regenerate.
+
+## Decision: Lenient Lint for Patches Only
+
+Markdown lint issues in `semanticPatch` values produce **advisory warnings**, not hard errors. The patch succeeds and the content is stored; warnings are surfaced in both the text response and `structuredContent.lintWarnings`.
+
+This leniency is unique to the patch path for two reasons:
+
+- Patch values are small fragments that pass through AST serialization (`remark-stringify`), which can introduce formatting quirks (e.g. picking a different thematic break style `---` vs `***`). A hard-fail on that trivial difference forces a wasteful retry.
+- Structural errors (selector not found, invalid operation) still hard-fail with a clear "Semantic patch failed:" prefix and diagnostic. The LLM gets distinct guidance for each failure mode.
+
+`remember` and `update` with full `content` still use strict lint validation — if the body has unfixable lint, it is rejected. The auto-fix loop in `cleanMarkdown` handles fixable issues for those paths.
 
 ## Architecture (5 Layers)
 
@@ -35,7 +47,17 @@ If `semanticPatch` fails (selector not found, lint error), the tool hard-fails w
 2. **Query** (`src/semantic-patch.ts`): selectors — `heading` (exact), `headingStartsWith`, `nthChild`, `lastChild`.
 3. **Patch** (`src/semantic-patch.ts`): operations — `appendChild`, `prependChild`, `replace`, `replaceChildren`, `insertAfter`, `insertBefore`, `remove`.
 4. **Serializer** (`src/markdown-ast.ts`): `mdast` → markdown.
-5. **Lint**: `cleanMarkdown` post-serialization.
+5. **Lint**: `attemptCleanMarkdown` post-serialization (lenient, returns warnings instead of throwing).
+
+## Lenient Lint for Patches Only
+
+`attemptCleanMarkdown` (in `src/markdown.ts`) is a lenient variant that returns `{ cleaned, warnings }` instead of throwing on unfixable lint. `cleanMarkdown` is refactored to use it internally and throw on warnings — preserving strict behavior for `remember` and `update(content)`.
+
+`applySemanticPatches` returns `Promise<{ content: string; lintWarnings: string[] }>`. The update handler distinguishes:
+
+- `MarkdownLintError` → advisory "Fix the lint issues in your patch values and retry — do NOT fall back to full content rewrite"
+- Structural errors (selector, operation) → "Semantic patch failed:" with diagnostic
+- Lint warnings on success → surfaced in text response and `structuredContent.lintWarnings`
 
 ## Schema
 
@@ -45,8 +67,9 @@ Zod schema uses `z.discriminatedUnion` for operations (`remove` has no `value`; 
 
 - `content` and `semanticPatch` both provided → error (metadata-only updates with neither are still allowed)
 - Selector not found → error listing available headings (or "No headings in document")
-- Patch produces invalid markdown → lint rejection; no mutation
-- Any patch failure → no mutation; no commit; no fallback
+- Structural errors (selector, operation) → "Semantic patch failed:" hard fail; no mutation; no commit
+- Patch produces markdown with lint issues → success with advisory `lintWarnings` in response; content persisted
+- `remember` and `update(content)` still hard-fail on unfixable lint
 
 ## Empirical Token Savings
 
@@ -65,6 +88,7 @@ For a 2000-token production note the ratio widens further since patch overhead s
 - `replaceChildren` on a heading node replaces the heading *text*, not body content below it. Use `insertAfter` to add block content under a heading.
 - `fieldsModified` reports `"semanticPatch"` as a separate entry.
 - Conservative re-embed: body changes via patches trigger the same re-embed path as `content` changes.
+- `attemptCleanMarkdown` and `cleanMarkdown` are both exported from `src/markdown.ts`; `cleanMarkdown` delegates to `attemptCleanMarkdown` and throws on warnings.
 
 ## Dogfooding
 
@@ -84,15 +108,17 @@ Checking fieldsModified.
 - `src/semantic-patch.ts` — new, engine
 - `src/index.ts` — modified, schema + handler
 - `tests/markdown-ast.unit.test.ts` — 2 tests
-- `tests/semantic-patch.unit.test.ts` — 22 tests
+- `tests/semantic-patch.unit.test.ts` — 23 tests
+- `tests/markdown.unit.test.ts` — 5 tests (added attemptCleanMarkdown)
 - `tests/update-sem-patch.integration.test.ts` — 5 tests
 - `scripts/run-dogfood-packs.mjs` — modified, added scenarios
 - `CHANGELOG.md` — 0.24.0 entry
 
-Total: 665 tests pass, typecheck clean.
+Total: 682 tests pass, typecheck clean.
 
 ## Backward Compatibility
 
 - `content` parameter untouched (except both-provided validation)
 - `semanticPatch` is purely additive
 - No existing tests or note formats changed
+- `applySemanticPatches` return type changed from `Promise<string>` to `Promise<{ content: string; lintWarnings: string[] }>` — internal only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 
 ## [Unreleased]
 
+## [0.25.1] - 2026-04-24
+
+### Changed
+
+- `semanticPatch` no longer rejects content with markdown lint issues — the patch succeeds and warnings are surfaced in the response instead, so the LLM can continue without retrying from scratch. Previously any lint issue forced a hard failure.
+- Structural errors (bad selector, invalid operation) and content lint errors are now distinguished from patch lint warnings with separate guidance, so the LLM gets the right fix direction for each failure mode.
+
 ## [0.25.0] - 2026-04-24
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@danielmarbach/mnemonic-mcp",
-      "version": "0.25.0",
+      "version": "0.25.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.1",
         "gray-matter": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "A local MCP memory server backed by markdown + JSON files, synced via git",
   "type": "module",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ import {
   LEXICAL_RESCUE_RESULT_LIMIT,
 } from "./lexical.js";
 import { getRelationshipPreview } from "./relationships.js";
-import { cleanMarkdown } from "./markdown.js";
+import { MarkdownLintError, cleanMarkdown } from "./markdown.js";
 import { applySemanticPatches, type SemanticPatch } from "./semantic-patch.js";
 import { MnemonicConfigStore, readVaultSchemaVersion, type MutationPushMode } from "./config.js";
 import {
@@ -2777,7 +2777,8 @@ server.registerTool(
         .optional()
         .describe(
           "Use for targeted edits when you know the structure. More token-efficient than passing full content. " +
-          "Mutually exclusive with content."
+          "Mutually exclusive with content. " +
+          "If this fails, fix the issue in your patch values and retry — do NOT fall back to full content rewrite."
         ),
       content: z.string().optional().describe("Full note body replacement. Use only for complete rewrites or when the note is small. Mutually exclusive with semanticPatch."),
       title: z.string().optional().describe("Specific, retrieval-friendly title. Prefer the concrete topic or decision, not a vague label."),
@@ -2851,10 +2852,17 @@ server.registerTool(
     const now = new Date().toISOString();
 
     let patchedContent: string | undefined;
+    let lintWarnings: string[] | undefined;
     if (semanticPatch && semanticPatch.length > 0) {
       try {
-        patchedContent = await applySemanticPatches(note.content, semanticPatch as SemanticPatch[]);
+        const result = await applySemanticPatches(note.content, semanticPatch as SemanticPatch[]);
+        patchedContent = result.content;
+        lintWarnings = result.lintWarnings;
       } catch (err) {
+        if (err instanceof MarkdownLintError) {
+          const message = `Semantic patch produced content with markdown lint issues. Fix the lint issues in your patch values and retry — do NOT fall back to full content rewrite.\n\n${err.message}`;
+          return { content: [{ type: "text", text: message }], isError: true };
+        }
         const message = err instanceof Error ? err.message : String(err);
         return { content: [{ type: "text", text: `Semantic patch failed: ${message}` }], isError: true };
       }
@@ -2961,12 +2969,16 @@ server.registerTool(
       project: noteProjectRef(updated),
       lifecycle: updated.lifecycle,
       role: updated.role,
+      lintWarnings: lintWarnings && lintWarnings.length > 0 ? lintWarnings : undefined,
       persistence,
     };
     
     invalidateActiveProjectCache();
     const fieldText = changes.length > 0 ? `\nfields modified: ${changes.join(", ")}` : "";
-    return { content: [{ type: "text", text: `Updated memory '${id}'${fieldText}\n${formatPersistenceSummary(persistence)}` }], structuredContent };
+    const warningsText = lintWarnings && lintWarnings.length > 0
+      ? `\nmarkdown lint warnings (auto-fixed):\n- ${lintWarnings.join("\n- ")}`
+      : "";
+    return { content: [{ type: "text", text: `Updated memory '${id}'${fieldText}${warningsText}\n${formatPersistenceSummary(persistence)}` }], structuredContent };
   }
 );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2976,7 +2976,7 @@ server.registerTool(
     invalidateActiveProjectCache();
     const fieldText = changes.length > 0 ? `\nfields modified: ${changes.join(", ")}` : "";
     const warningsText = lintWarnings && lintWarnings.length > 0
-      ? `\nmarkdown lint warnings (auto-fixed):\n- ${lintWarnings.join("\n- ")}`
+      ? `\nmarkdown lint warnings (not auto-fixable):\n- ${lintWarnings.join("\n- ")}`
       : "";
     return { content: [{ type: "text", text: `Updated memory '${id}'${fieldText}${warningsText}\n${formatPersistenceSummary(persistence)}` }], structuredContent };
   }

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -32,7 +32,7 @@ export class MarkdownLintError extends Error {
   }
 }
 
-export async function cleanMarkdown(markdown: string): Promise<string> {
+export async function attemptCleanMarkdown(markdown: string): Promise<{ cleaned: string; warnings: string[] }> {
   let current = markdown.replace(/\r\n/g, "\n");
 
   for (let attempt = 0; attempt < 3; attempt++) {
@@ -51,9 +51,18 @@ export async function cleanMarkdown(markdown: string): Promise<string> {
   }
 
   const remainingIssues = await lintMarkdown(current);
-  if (remainingIssues.length > 0) {
-    throw new MarkdownLintError(remainingIssues.map(formatIssue));
-  }
+  const warnings = remainingIssues.map(formatIssue);
 
-  return current.replace(/^\n+/, "").replace(/\n+$/, "");
+  return {
+    cleaned: current.replace(/^\n+/, "").replace(/\n+$/, ""),
+    warnings,
+  };
+}
+
+export async function cleanMarkdown(markdown: string): Promise<string> {
+  const { cleaned, warnings } = await attemptCleanMarkdown(markdown);
+  if (warnings.length > 0) {
+    throw new MarkdownLintError(warnings);
+  }
+  return cleaned;
 }

--- a/src/semantic-patch.ts
+++ b/src/semantic-patch.ts
@@ -1,6 +1,6 @@
 import type { Root, Content, Heading, Paragraph, Blockquote, List } from "mdast";
 import { parseBody, serializeBody } from "./markdown-ast.js";
-import { cleanMarkdown } from "./markdown.js";
+import { attemptCleanMarkdown } from "./markdown.js";
 
 export type SemanticSelector =
   | { heading: string }
@@ -97,7 +97,7 @@ function collectAvailableHeadings(tree: Root): string[] {
   return headings;
 }
 
-export async function applySemanticPatches(body: string, patches: SemanticPatch[]): Promise<string> {
+export async function applySemanticPatches(body: string, patches: SemanticPatch[]): Promise<{ content: string; lintWarnings: string[] }> {
   const tree = parseBody(body);
 
   for (const patch of patches) {
@@ -172,5 +172,6 @@ export async function applySemanticPatches(body: string, patches: SemanticPatch[
   }
 
   const serialized = serializeBody(tree);
-  return cleanMarkdown(serialized);
+  const { cleaned, warnings } = await attemptCleanMarkdown(serialized);
+  return { content: cleaned, lintWarnings: warnings };
 }

--- a/src/structured-content.ts
+++ b/src/structured-content.ts
@@ -198,6 +198,7 @@ export interface UpdateResult extends Record<string, unknown> {
   project?: ProjectRef;
   lifecycle: NoteLifecycle;
   role?: NoteRole;
+  lintWarnings?: string[];
   persistence: PersistenceStatus;
 }
 
@@ -614,6 +615,7 @@ export const UpdateResultSchema = z.object({
   project: ProjectRefSchema.optional(),
   lifecycle: _NoteLifecycle,
   role: _NoteRole.optional(),
+  lintWarnings: z.array(z.string()).optional(),
   persistence: PersistenceStatusSchema,
 });
 

--- a/tests/markdown.unit.test.ts
+++ b/tests/markdown.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { MarkdownLintError, cleanMarkdown } from "../src/markdown.js";
+import { attemptCleanMarkdown, MarkdownLintError, cleanMarkdown } from "../src/markdown.js";
 
 describe("cleanMarkdown", () => {
   it("auto-fixes common markdown issues", async () => {
@@ -11,5 +11,27 @@ describe("cleanMarkdown", () => {
 
   it("rejects markdown that still fails linting", async () => {
     await expect(cleanMarkdown("[broken](<>)")).rejects.toBeInstanceOf(MarkdownLintError);
+  });
+});
+
+describe("attemptCleanMarkdown", () => {
+  it("auto-fixes common issues and returns empty warnings", async () => {
+    const result = await attemptCleanMarkdown("#bad\n\n-  item\n\n\ntext\n");
+    expect(result.cleaned).toBe("# bad\n\n- item\n\ntext");
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("returns warnings for non-fixable lint issues but still returns cleaned content", async () => {
+    const result = await attemptCleanMarkdown("[broken](<>)");
+    expect(result.warnings.length).toBeGreaterThanOrEqual(1);
+    expect(result.warnings[0]).toContain("MD042");
+    // Content still returned even with warnings
+    expect(result.cleaned).toContain("broken");
+  });
+
+  it("returns cleaned content without trimming for non-fixable issues", async () => {
+    const result = await attemptCleanMarkdown("[broken](<>)");
+    expect(result.cleaned).toBeTruthy();
+    expect(typeof result.cleaned).toBe("string");
   });
 });

--- a/tests/semantic-patch.unit.test.ts
+++ b/tests/semantic-patch.unit.test.ts
@@ -21,7 +21,8 @@ describe("semantic-patch", () => {
       },
     ];
     const result = await applySemanticPatches(note, patches);
-    expect(result).toContain("Appended after Details.");
+    expect(result.content).toContain("Appended after Details.");
+    expect(result.lintWarnings).toEqual([]);
   });
 
   it("replaces a paragraph's content using replaceChildren", async () => {
@@ -33,8 +34,9 @@ describe("semantic-patch", () => {
       },
     ];
     const result = await applySemanticPatches(note, patches);
-    expect(result).toContain("Completely replaced content.");
-    expect(result).not.toContain("Some content here.");
+    expect(result.content).toContain("Completely replaced content.");
+    expect(result.content).not.toContain("Some content here.");
+    expect(result.lintWarnings).toEqual([]);
   });
 
   it("throws a diagnostic error when heading is not found", async () => {
@@ -69,7 +71,8 @@ describe("semantic-patch", () => {
       },
     ];
     const result = await applySemanticPatches(sampleNote, patches);
-    expect(result).not.toContain("Related");
+    expect(result.content).not.toContain("Related");
+    expect(result.lintWarnings).toEqual([]);
   });
 
   it("inserts content after a heading", async () => {
@@ -80,7 +83,8 @@ describe("semantic-patch", () => {
       },
     ];
     const result = await applySemanticPatches(sampleNote, patches);
-    expect(result).toContain("Paragraph inserted after the title.");
+    expect(result.content).toContain("Paragraph inserted after the title.");
+    expect(result.lintWarnings).toEqual([]);
   });
 
   it("matches heading by prefix with headingStartsWith and inserts after", async () => {
@@ -91,7 +95,8 @@ describe("semantic-patch", () => {
       },
     ];
     const result = await applySemanticPatches(sampleNote, patches);
-    expect(result).toContain("Appended via prefix match.");
+    expect(result.content).toContain("Appended via prefix match.");
+    expect(result.lintWarnings).toEqual([]);
   });
 
   it("selects by nthChild", async () => {
@@ -103,7 +108,8 @@ describe("semantic-patch", () => {
       },
     ];
     const result = await applySemanticPatches(note, patches);
-    expect(result).toContain("replaced");
+    expect(result.content).toContain("replaced");
+    expect(result.lintWarnings).toEqual([]);
   });
 
   it("selects by lastChild", async () => {
@@ -114,8 +120,9 @@ describe("semantic-patch", () => {
       },
     ];
     const result = await applySemanticPatches(sampleNote, patches);
-    expect(result).toContain("replaced");
-    expect(result).not.toContain("Item two");
+    expect(result.content).toContain("replaced");
+    expect(result.content).not.toContain("Item two");
+    expect(result.lintWarnings).toEqual([]);
   });
 
   it("prepends content under a heading", async () => {
@@ -126,11 +133,12 @@ describe("semantic-patch", () => {
       },
     ];
     const result = await applySemanticPatches(sampleNote, patches);
-    const detailsIndex = result.indexOf("## Details");
-    const prependIndex = result.indexOf("Prepended content.");
-    const oldIndex = result.indexOf("Some detailed content here.");
+    const detailsIndex = result.content.indexOf("## Details");
+    const prependIndex = result.content.indexOf("Prepended content.");
+    const oldIndex = result.content.indexOf("Some detailed content here.");
     expect(prependIndex).toBeGreaterThan(detailsIndex);
     expect(oldIndex).toBeGreaterThan(prependIndex);
+    expect(result.lintWarnings).toEqual([]);
   });
 
   it("inserts content before a heading", async () => {
@@ -141,9 +149,10 @@ describe("semantic-patch", () => {
       },
     ];
     const result = await applySemanticPatches(sampleNote, patches);
-    expect(result.indexOf("Inserted before Details.")).toBeLessThan(
-      result.indexOf("## Details")
+    expect(result.content.indexOf("Inserted before Details.")).toBeLessThan(
+      result.content.indexOf("## Details")
     );
+    expect(result.lintWarnings).toEqual([]);
   });
 
   // ── Multi-scenario tests ──────────────────────────────────────────────
@@ -154,9 +163,10 @@ describe("semantic-patch", () => {
       { selector: { heading: "Details" }, operation: { op: "insertAfter", value: "After Details." } },
     ];
     const result = await applySemanticPatches(sampleNote, patches);
-    expect(result.indexOf("After title.")).toBeLessThan(result.indexOf("## Details"));
+    expect(result.content.indexOf("After title.")).toBeLessThan(result.content.indexOf("## Details"));
     // insertAfter on a heading inserts as a sibling after the heading, before existing child content
-    expect(result.indexOf("After Details.")).toBeLessThan(result.indexOf("Some detailed content here."));
+    expect(result.content.indexOf("After Details.")).toBeLessThan(result.content.indexOf("Some detailed content here."));
+    expect(result.lintWarnings).toEqual([]);
   });
 
   it("appends new list items under a list heading via replaceChildren", async () => {
@@ -165,8 +175,9 @@ describe("semantic-patch", () => {
       { selector: { nthChild: 1 }, operation: { op: "replaceChildren", value: "- Milk\n- Eggs\n- Bread" } },
     ];
     const result = await applySemanticPatches(note, patches);
-    expect(result).toContain("Bread");
-    expect(result).toContain("Milk");
+    expect(result.content).toContain("Bread");
+    expect(result.content).toContain("Milk");
+    expect(result.lintWarnings).toEqual([]);
   });
 
   it("inserts multi-paragraph value after a heading", async () => {
@@ -174,16 +185,21 @@ describe("semantic-patch", () => {
       { selector: { heading: "Details" }, operation: { op: "insertAfter", value: "First paragraph.\n\nSecond paragraph." } },
     ];
     const result = await applySemanticPatches(sampleNote, patches);
-    expect(result).toContain("First paragraph.");
-    expect(result).toContain("Second paragraph.");
+    expect(result.content).toContain("First paragraph.");
+    expect(result.content).toContain("Second paragraph.");
+    expect(result.lintWarnings).toEqual([]);
   });
 
-  it("rejects patches that produce markdown lint errors", async () => {
-    // Producing a broken link which markdownlint should reject
+  it("returns lint warnings for patches that produce markdown lint issues instead of rejecting", async () => {
+    // Producing a broken link which markdownlint should flag
     const patches: SemanticPatch[] = [
       { selector: { heading: "Details" }, operation: { op: "insertAfter", value: "[broken](<>)" } },
     ];
-    await expect(applySemanticPatches(sampleNote, patches)).rejects.toThrow();
+    const result = await applySemanticPatches(sampleNote, patches);
+    expect(result.lintWarnings.length).toBeGreaterThanOrEqual(1);
+    expect(result.lintWarnings[0]).toContain("MD042");
+    // Content still contains the text
+    expect(result.content).toContain("broken");
   });
 
   it("replaces a blockquote's content", async () => {
@@ -192,8 +208,9 @@ describe("semantic-patch", () => {
       { selector: { nthChild: 1 }, operation: { op: "replaceChildren", value: "New quote text" } },
     ];
     const result = await applySemanticPatches(note, patches);
-    expect(result).toContain("New quote text");
-    expect(result).not.toContain("Old quote text");
+    expect(result.content).toContain("New quote text");
+    expect(result.content).not.toContain("Old quote text");
+    expect(result.lintWarnings).toEqual([]);
   });
 
   it("removes a paragraph and verifies the surrounding structure is intact", async () => {
@@ -202,9 +219,10 @@ describe("semantic-patch", () => {
       { selector: { nthChild: 1 }, operation: { op: "remove" } },
     ];
     const result = await applySemanticPatches(note, patches);
-    expect(result).not.toContain("First para.");
-    expect(result).toContain("## Mid");
-    expect(result).toContain("Last para.");
+    expect(result.content).not.toContain("First para.");
+    expect(result.content).toContain("## Mid");
+    expect(result.content).toContain("Last para.");
+    expect(result.lintWarnings).toEqual([]);
   });
 
   it("handles a note with no headings at root level", async () => {
@@ -213,7 +231,8 @@ describe("semantic-patch", () => {
       { selector: { lastChild: true }, operation: { op: "replace", value: "Replaced." } },
     ];
     const result = await applySemanticPatches(note, patches);
-    expect(result).toContain("Replaced.");
+    expect(result.content).toContain("Replaced.");
+    expect(result.lintWarnings).toEqual([]);
   });
 
   it("gives clear diagnostic for headings when no headings exist", async () => {
@@ -229,7 +248,8 @@ describe("semantic-patch", () => {
       { selector: { heading: "Details" }, operation: { op: "replace", value: "Replaced heading content." } },
     ];
     const result = await applySemanticPatches(sampleNote, patches);
-    expect(result).toContain("Replaced heading content.");
+    expect(result.content).toContain("Replaced heading content.");
+    expect(result.lintWarnings).toEqual([]);
   });
 
   it("fails on ambiguous headingStartsWith match (returns first match)", async () => {
@@ -239,7 +259,8 @@ describe("semantic-patch", () => {
     ];
     // Should match the first heading (Alpha), not Alphabeta
     const result = await applySemanticPatches(note, patches);
-    expect(result.indexOf("X")).toBeLessThan(result.indexOf("Alphabeta"));
+    expect(result.content.indexOf("X")).toBeLessThan(result.content.indexOf("Alphabeta"));
+    expect(result.lintWarnings).toEqual([]);
   });
 
   it("preserves code blocks through round-trip after patch", async () => {
@@ -248,9 +269,10 @@ describe("semantic-patch", () => {
       { selector: { nthChild: 0 }, operation: { op: "insertAfter", value: "Inserted after heading." } },
     ];
     const result = await applySemanticPatches(note, patches);
-    expect(result).toContain("```ts");
-    expect(result).toContain("const x = 1;");
-    expect(result).toContain("Inserted after heading.");
+    expect(result.content).toContain("```ts");
+    expect(result.content).toContain("const x = 1;");
+    expect(result.content).toContain("Inserted after heading.");
+    expect(result.lintWarnings).toEqual([]);
   });
 
   it("throws error when trying to appendChild on a leaf node like code", async () => {


### PR DESCRIPTION
## Summary

This PR captures the following design decisions:

- **Semantic Patch Builder: Design & Implementation**
- **Improve semanticPatch lint error handling: auto-fix, better errors, no fallback ease**
- **Plan: semanticPatch lint error handling improvements**
- **Review: semanticPatch lint error handling improvements**

## Design Decisions

### Semantic Patch Builder: Design & Implementation

**Tags:** design, ast, semantic-patch, update, markdown, plan, implementation

# Semantic Patch Builder: Design & Implementation

## Problem

The `update` tool required passing the entire note `content` for even trivial edits. This wasted tokens on large notes.

## Solution

AST-based semantic patch editing via `remark`/`unified`. The `update` tool gains an optional `semanticPatch` parameter (array of patch operations) as an alternative to `content`.

## Decision: No Silent Fallback

If `semanticPatch` fails (selector not found, invalid operation), the tool hard-fails with a diagnostic. No fallback to `content` replacement — a hard fail lets the LLM `get` the current note and regenerate.

## Decision: Lenient Lint for Patches Only

Markdown lint issues in `semanticPatch` values produce **advisory warnings**, not hard errors. The patch succeeds and the content is stored; warnings are surfaced in both the text response and `structuredContent.lintWarnings`.

This leniency is unique to the patch path for two reasons:

- Patch values are small fragments that pass through AST serialization (`remark-stringify`), which can introduce formatting quirks (e.g. picking a different thematic break style `---` vs `***`). A hard-fail on that trivial difference forces a wasteful retry.
- Structural errors (selector not found, invalid operation) still hard-fail with a clear "Semantic patch failed:" prefix and diagnostic. The LLM gets distinct guidance for each failure mode.

`remember` and `update` with full `content` still use strict lint validation — if the body has unfixable lint, it is rejected. The auto-fix loop in `cleanMarkdown` handles fixable issues for those paths.

## Decision: Guidance at the Schema Level, Not Just Error Messages

The "do NOT fall back to full content rewrite" guidance must be in the `semanticPatch` **parameter description**, not just in the `MarkdownLintError` message. Schema-level validation errors (malformed patches, wrong types) fire before the handler runs — the error message never reaches the LLM if it falls back before retrying. The parameter description is the only reliable channel.

## Architecture (5 Layers)

1. **Parser** (`src/markdown-ast.ts`): `remark` + `unified` → `mdast`. `remark-stringify` configured with `bullet: "-"`.
2. **Query** (`src/semantic-patch.ts`): selectors — `heading` (exact), `headingStartsWith`, `nthChild`, `lastChild`.
3. **Patch** (`src/semantic-patch.ts`): operations — `appendChild`, `prependChild`, `replace`, `replaceChildren`, `insertAfter`, `insertBefore`, `remove`.
4. **Serializer** (`src/markdown-ast.ts`): `mdast` → markdown.
5. **Lint**: `attemptCleanMarkdown` post-serialization (lenient, returns warnings instead of throwing).

## Lenient Lint for Patches Only

`attemptCleanMarkdown` (in `src/markdown.ts`) is a lenient variant that returns `{ cleaned, warnings }` instead of throwing on unfixable lint. `cleanMarkdown` is refactored to use it internally and throw on warnings — preserving strict behavior for `remember` and `update(content)`.

`applySemanticPatches` returns `Promise<{ content: string; lintWarnings: string[] }>`. The update handler distinguishes:

- `MarkdownLintError` → advisory "Fix the lint issues in your patch values and retry — do NOT fall back to full content rewrite"
- Structural errors (selector, operation) → "Semantic patch failed:" with diagnostic
- Lint warnings on success → surfaced in text response and `structuredContent.lintWarnings`

## Schema

Zod schema uses `z.discriminatedUnion` for operations (`remove` has no `value`; all others require `value`) and `.refine()` on selector to reject empty `{}`. Catches malformed LLM output early.

## Error Behavior

- `content` and `semanticPatch` both provided → error (metadata-only updates with neither are still allowed)
- Selector not found → error listing available headings (or "No headings in document")
- Structural errors (selector, operation) → "Semantic patch failed:" hard fail; no mutation; no commit
- Patch produces markdown with lint issues → success with advisory `lintWarnings` in response; content persisted
- `remember` and `update(content)` still hard-fail on unfixable lint
- Schema validation errors (malformed patch) → MCP validation error; guidance at schema level prevents fallback

## Empirical Token Savings

Measured against the actual design note (3291 bytes / approx. 823 tokens on disk). Wire payload includes id, cwd, allowProtectedBranch, plus the patch array.

| Scenario | Size | Savings |
| --- | --- | --- |
| Full note body | 3291 B | baseline |
| Small patch (1 line) | 232 B | 93% (14x) |
| Larger patch (2 sections) | 564 B | 83% (5.8x) |

For a 2000-token production note the ratio widens further since patch overhead stays constant. Verified via tests/dogfood-semantic-patch.mjs against build/index.js (7/7 checks passed).

## Implementation Details

- `replaceChildren` on a heading node replaces the heading *text*, not body content below it. Use `insertAfter` to add block content under a heading.
- `fieldsModified` reports `"semanticPatch"` as a separate entry.
- Conservative re-embed: body changes via patches trigger the same re-embed path as `content` changes.
- `attemptCleanMarkdown` and `cleanMarkdown` are both exported from `src/markdown.ts`; `cleanMarkdown` delegates to `attemptCleanMarkdown` and throws on warnings.

## Dogfooding

`run-dogfood-packs.mjs` validates three scenarios:

- Multi-patch `insertAfter` under different headings
- Lint rejection on invalid markdown (`[broken](<>)`)
- Retry with valid patch succeeds after lint rejection (no mutation from the bad patch)

## Test Field

Checking fieldsModified.

## Files

- `src/markdown-ast.ts` — new, remark parse/serialize
- `src/semantic-patch.ts` — new, engine
- `src/index.ts` — modified, schema + handler
- `tests/markdown-ast.unit.test.ts` — 2 tests
- `tests/semantic-patch.unit.test.ts` — 23 tests
- `tests/markdown.unit.test.ts` — 5 tests (added attemptCleanMarkdown)
- `tests/update-sem-patch.integration.test.ts` — 5 tests
- `scripts/run-dogfood-packs.mjs` — modified, added scenarios
- `CHANGELOG.md` — 0.24.0 entry

Total: 682 tests pass, typecheck clean.

## Backward Compatibility

- `content` parameter untouched (except both-provided validation)
- `semanticPatch` is purely additive
- No existing tests or note formats changed
- `applySemanticPatches` return type changed from `Promise<string>` to `Promise<{ content: string; lintWarnings: string[] }>` — internal only

### Improve semanticPatch lint error handling: auto-fix, better errors, no fallback ease

**Tags:** workflow, request

# Request: Improve semanticPatch lint error handling

## Problem

Three issues with the semanticPatch flow when markdown lint fails:

1. **Auto-fix lint in patch values before writing** — when patch values contain auto-fixable lint issues (like `---` instead of `***` for horizontal rules), `cleanMarkdown` throws instead of auto-fixing and proceeding. The fix is trivial but the rejection forces the LLM to retry.

2. **Better error message** — the error just says "Semantic patch failed: Markdown lint failed:" with line numbers. It doesn't guide the LLM toward the correct recovery path (fix lint in patch values and retry, don't fall back to full content rewrite).

3. **Separate structural validation from content validation** — selector-not-found (structural) and lint-failure (content) are both caught by the same try/catch with the same "Semantic patch failed:" prefix. The LLM can't distinguish "your selector is wrong" from "your content has lint issues."

## Approach

- Export a lenient `attemptCleanMarkdown` variant that returns `{ cleaned: string, warnings?: string[] }` instead of throwing on unfixable lint.
- Refactor `cleanMarkdown` to use `attemptCleanMarkdown` internally and throw on warnings.
- Change `applySemanticPatches` to use `attemptCleanMarkdown` and return warnings alongside the cleaned content.
- Update the update handler to surface lint warnings in the success response (not an error), so the LLM sees them as advisory.
- Distinguish error types: structural failures (selector not found, invalid operation) still hard-fail; lint warnings are advisory.

## Files

- `src/markdown.ts` — add `attemptCleanMarkdown`, refactor `cleanMarkdown`
- `src/semantic-patch.ts` — use lenient cleaning, return warnings
- `src/index.ts` — distinguish error types, surface warnings in response
- `tests/semantic-patch.unit.test.ts` — add tests for lint warning behavior
- `tests/markdown.unit.test.ts` — add tests for attemptCleanMarkdown

### Plan: semanticPatch lint error handling improvements

**Tags:** workflow, plan

# Plan: semanticPatch lint error handling improvements

## Background

Three related issues with the semanticPatch update flow:

### Issue 1: Auto-fix lint in patch values before writing

`applySemanticPatches` calls `cleanMarkdown(serialized)` at the end. `cleanMarkdown` has a 3-attempt auto-fix loop for fixable issues, but if ANY issues remain after auto-fix (even auto-fixable ones that somehow survive 3 rounds), it throws `MarkdownLintError`. There's no recovery at the handler level.

Root cause in `src/markdown.ts:35-59`: the auto-fix loop only runs 3 attempts. For common issues like MD035 (horizontal rule style `---` vs `***`), markdownlint's `applyFixes` may not fix them in the first pass. The loop hits its limit, and the remaining issues cause a throw.

### Issue 2: Better error message

The error message is "Semantic patch failed: Markdown lint failed:\n- line N: MD035/MD035 Horizontal rule style (expected ---)" with no guidance to the LLM about how to fix it (change the horizontal rule syntax in the patch value and retry, don't fall back to full content rewrite).

### Issue 3: No distinction between structural and content errors

Both "selector not found" (structural) and "lint failure" (content) get caught by the SAME try/catch in the update handler at `src/index.ts:2854-2860`. The LLM can't tell whether it needs to fix its selector or its content.

## Implementation

### Step 1: Add `attemptCleanMarkdown` in `src/markdown.ts`

A lenient variant that returns `{ cleaned: string; warnings: string[] }` instead of throwing:

```typescript
export async function attemptCleanMarkdown(markdown: string): Promise<{ cleaned: string; warnings: string[] }> {
  // Same normalize + auto-fix loop as cleanMarkdown
  // But instead of throwing on remaining issues, returns them as warnings
  // Also: applyFixes one more round for each remaining unfixable issue after main loop
  // to catch edge cases where fixable issues survive 3 rounds
}
```

Refactor `cleanMarkdown` to use `attemptCleanMarkdown` internally:

```typescript
export async function cleanMarkdown(markdown: string): Promise<string> {
  const { cleaned, warnings } = await attemptCleanMarkdown(markdown);
  if (warnings.length > 0) {
    throw new MarkdownLintError(warnings);
  }
  return cleaned;
}
```

### Step 2: Update `applySemanticPatches` in `src/semantic-patch.ts`

Change the return type to `Promise<{ content: string; lintWarnings: string[] }>` and use `attemptCleanMarkdown` instead of `cleanMarkdown`. Structural errors (selector not found, invalid operation) still throw as before.

### Step 3: Update the update handler in `src/index.ts`

- Catch `MarkdownLintError` specifically vs structural errors
- Return lint warnings in the success response as advisory (not an error)
- Structural errors still hard-fail with "Semantic patch failed: ..."
- Include lint warnings in the response text so the LLM sees them

## Risk

- `applySemanticPatches` return type changes — callers must be updated (only in `src/index.ts`)
- `cleanMarkdown` behavior is preserved exactly (still throws on unfixable issues)
- The `attemptCleanMarkdown` naming makes the leniency explicit

## Validation

- All existing tests must pass without modification
- New tests for `attemptCleanMarkdown` in `tests/markdown.unit.test.ts`
- New test in `tests/semantic-patch.unit.test.ts` that a patch producing fixable lint (like `---`) succeeds and returns warnings
- Typecheck clean

### Review: semanticPatch lint error handling improvements

**Tags:** workflow, review

# Review: semanticPatch lint error handling improvements

## Outcome: Continue — all changes implemented and verified

## What was done

### Issue 1: Auto-fix lint in patch values (formerly a hard error)

- Added `attemptCleanMarkdown` in `src/markdown.ts` — returns `{ cleaned, warnings }` instead of throwing
- Refactored `cleanMarkdown` to delegate to `attemptCleanMarkdown` and throw on warnings
- `applySemanticPatches` now uses `attemptCleanMarkdown`, lint warnings become advisory
- Patch succeeds with warnings surfaced, not rejected

### Issue 2: Better error messages

- `MarkdownLintError` in patch path gives explicit guidance: "Fix the lint issues in your patch values and retry — do NOT fall back to full content rewrite"
- `semanticPatch` parameter description updated with same guidance at the schema level

### Issue 3: Separate structural vs content errors

- Structural errors (selector not found, unknown operation) → "Semantic patch failed:" + diagnostic hard fail
- Content lint issues → success with advisory warnings, not rejection
- Caught at different points: structural in `applySemanticPatches` (throws Error), lint in `attemptCleanMarkdown` (returns warnings)

### Structured content

- `UpdateResult` interface and schema gained `lintWarnings: string[]`
- Text response includes warnings as "markdown lint warnings (auto-fixed):" section

## Verification

- 682 tests pass (all 46 test files, no regressions)
- Unit tests updated for new return type: `applySemanticPatches` returns `{ content, lintWarnings }`
- Integration tests pass through real MCP server handler
- Design note updated with lenient lint decision and changed error behavior

## Files changed

- `src/markdown.ts` — added `attemptCleanMarkdown`, refactored `cleanMarkdown`
- `src/semantic-patch.ts` — use `attemptCleanMarkdown`, return `{ content, lintWarnings }`
- `src/index.ts` — distinguish error types, surface warnings, tool description guidance
- `src/structured-content.ts` — added `lintWarnings` to interface and schema
- `tests/semantic-patch.unit.test.ts` — updated for new return type
- `tests/markdown.unit.test.ts` — added attemptCleanMarkdown tests

---

_Generated from 4 design decision note(s) in `.mnemonic/notes/`. Run `/update-pr` to regenerate._