### PR TITLE
Add replaceChildren+heading pitfall hint to semanticPatch description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 
 ## [Unreleased]
 
+## [0.25.4] - 2026-04-25
+
+### Changed
+
+- `semanticPatch` parameter description and `mnemonic-workflow-hint` prompt now include a concise callout that `replaceChildren` on a `heading` selector targets the heading itself, not the body below it, with guidance to use `appendChild` or `replace` instead. This addresses a common structural misunderstanding when patching note sections via heading selectors.
+
 ## [0.25.3] - 2026-04-25
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.25.3",
+  "version": "0.25.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.25.3",
+  "version": "0.25.4",
   "description": "A local MCP memory server backed by markdown + JSON files, synced via git",
   "type": "module",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2785,7 +2785,8 @@ server.registerTool(
           "  { \"selector\": { \"heading\": \"Findings\" }, \"operation\": { \"op\": \"appendChild\", \"value\": \"A new paragraph.\" } },\n" +
           "  { \"selector\": { \"heading\": \"Recommendation\" }, \"operation\": { \"op\": \"replaceChildren\", \"value\": \"Updated recommendation.\" } },\n" +
           "  { \"selector\": { \"heading\": \"Old Section\" }, \"operation\": { \"op\": \"remove\" } }\n" +
-          "]"
+          "]\n\n" +
+          "`replaceChildren` on a `heading` selector targets the heading itself, not the body below it. Use `appendChild` or `replace` instead."
         ),
       content: z.string().optional().describe("Full note body replacement. Use only for complete rewrites or when the note is small. Mutually exclusive with semanticPatch."),
       title: z.string().optional().describe("Specific, retrieval-friendly title. Prefer the concrete topic or decision, not a vague label."),
@@ -6155,7 +6156,8 @@ server.registerPrompt(
             "- `operation` has an `op` key plus `value` (except `remove` which has no value).\n" +
             "- The parameter must be a JSON array, NOT a string.\n" +
             "- Use `get` first to read exact heading text, then use those headings (without `##` prefix) as selector values.\n" +
-            "- Common mistake: writing `{ \"op\": \"appendChild\", \"value\": \"...\" }` at the top level instead of nesting inside `operation`. Correct shape: `{ \"selector\": { \"heading\": \"Findings\" }, \"operation\": { \"op\": \"appendChild\", \"value\": \"text\" } }`",
+            "- Common mistake: writing `{ \"op\": \"appendChild\", \"value\": \"...\" }` at the top level instead of nesting inside `operation`. Correct shape: `{ \"selector\": { \"heading\": \"Findings\" }, \"operation\": { \"op\": \"appendChild\", \"value\": \"text\" } }`\n" +
+            "- `replaceChildren` on a `heading` selector targets the heading itself, not the body below it. Use `appendChild` or `replace` instead.",
         },
       },
     ],


### PR DESCRIPTION
The heading selector targets the heading node itself, not the body below it. replaceChildren on a heading replaces the heading's children, not the section. Use appendChild or replace instead.

Added in both:
- update tool inputSchema (parameter description)
- mnemonic-workflow-hint prompt (semanticPatch format section)

Addresses a real pitfall when updating note sections via semanticPatch.