### PR TITLE
RPIR workflow design for mnemonic: research→plan→implement→review

### DIFF
--- a/.mnemonic/notes/reference-mnemonic-rpi-workflow-skill-improvement-opportunit-1b944a63.md
+++ b/.mnemonic/notes/reference-mnemonic-rpi-workflow-skill-improvement-opportunit-1b944a63.md
@@ -10,11 +10,14 @@ tags:
   - phase2
 lifecycle: permanent
 createdAt: '2026-04-25T07:47:46.589Z'
-updatedAt: '2026-04-25T07:47:46.589Z'
+updatedAt: '2026-04-25T07:47:56.352Z'
 role: reference
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: rpir-workflow-design-for-mnemonic-research-plan-implement-re-80b00851
+    type: related-to
 memoryVersion: 1
 ---
 # Reference: mnemonic-rpi-workflow skill improvement opportunities from Phase 2 execution

--- a/.mnemonic/notes/reference-mnemonic-rpi-workflow-skill-improvement-opportunit-1b944a63.md
+++ b/.mnemonic/notes/reference-mnemonic-rpi-workflow-skill-improvement-opportunit-1b944a63.md
@@ -1,0 +1,109 @@
+---
+title: >-
+  Reference: mnemonic-rpi-workflow skill improvement opportunities from Phase 2
+  execution
+tags:
+  - workflow
+  - rpir
+  - skill-improvement
+  - commit-hygiene
+  - phase2
+lifecycle: permanent
+createdAt: '2026-04-25T07:47:46.589Z'
+updatedAt: '2026-04-25T07:47:46.589Z'
+role: reference
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+# Reference: mnemonic-rpi-workflow skill improvement opportunities from Phase 2 execution
+
+This note captures practical improvements observed while running a full Phase 2 RPIR cycle (research/plan/implement/review/consolidate) with multiple work and memory commits.
+
+## Primary finding
+
+Commit hygiene still needs repeated human reminders for many LLMs, even when RPIR is followed.
+
+The current skill gives good commit-class guidance, but it would be stronger with explicit guardrails that are hard to skip in long sessions.
+
+## Recommended skill improvements
+
+### 1) Add a mandatory "commit hygiene gate" before every work commit
+
+Require a short, explicit sequence in the skill:
+
+1. `git status --short`
+2. `git diff -- <target-files>`
+3. confirm only intended files are staged
+4. commit only those files
+5. `git status --short` post-commit
+
+Why: this prevents accidental inclusion of unrelated changes in dirty worktrees.
+
+### 2) Add a required "dirty tree policy" section
+
+The skill should explicitly say:
+
+- never mix unrelated dirty files into the work commit
+- if unrelated files exist, stage only exact intended paths
+- if uncertain, stop and ask the user whether to split commits
+
+Why: this is the most common failure mode under real branch conditions.
+
+### 3) Strengthen commit-class protocol into a checklist with state transitions
+
+Current classes are strong conceptually (memory -> work -> memory), but should be operationalized:
+
+- mark class as active
+- list required artifacts for that class
+- block transition to next class until verification evidence is recorded
+
+Why: reduces drift where memory notes or review evidence are skipped under time pressure.
+
+### 4) Add a "verification evidence block" requirement to the review stage
+
+Require storing concrete command evidence in review artifacts:
+
+- command run
+- pass/fail outcome
+- key counts (e.g., tests passed)
+
+Why: ensures review notes are auditable and not summary-only.
+
+### 5) Add a "closeout consolidation template" for permanent notes
+
+When closing a phase, require two durable captures by template:
+
+- permanent decision note (what was decided and why)
+- permanent summary note (what shipped, what was verified, final status)
+
+Why: improves consistency and discoverability of completed work.
+
+### 6) Add branch-finish handshake guidance
+
+At workflow end, explicitly route to branch-finalization options (merge/PR/keep/discard) and require a clean status check first.
+
+Why: avoids ambiguity after implementation is done.
+
+### 7) Add optional anti-brittleness guidance for dogfooding checks
+
+If dogfooding produces advisory-only failures, require root-cause classification:
+
+- product regression vs. heuristic brittleness
+- if heuristic brittleness, update check logic and re-verify
+
+Why: prevents overfitting product code to brittle quality gates.
+
+## Suggested concrete additions to skill text
+
+- Add a "Commit Hygiene Checklist" subsection under Implement + Consolidate stages.
+- Add a "Dirty Worktree Safety Rules" block near Commit Discipline.
+- Add a "Phase Closeout Checklist" requiring decision+summary permanent notes and branch-finish handoff.
+
+## Expected impact
+
+- Fewer accidental mixed commits
+- More consistent evidence-backed reviews
+- Better reliability across weaker/less disciplined models
+- More predictable phase completion quality

--- a/.mnemonic/notes/reference-mnemonic-rpi-workflow-skill-improvement-opportunit-1b944a63.md
+++ b/.mnemonic/notes/reference-mnemonic-rpi-workflow-skill-improvement-opportunit-1b944a63.md
@@ -10,7 +10,7 @@ tags:
   - phase2
 lifecycle: permanent
 createdAt: '2026-04-25T07:47:46.589Z'
-updatedAt: '2026-04-25T07:47:56.352Z'
+updatedAt: '2026-04-25T07:47:56.559Z'
 role: reference
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -18,6 +18,8 @@ projectName: mnemonic
 relatedTo:
   - id: rpir-workflow-design-for-mnemonic-research-plan-implement-re-80b00851
     type: related-to
+  - id: summary-phase-2-reciprocal-rank-fusion-completed-with-adviso-b5f823ef
+    type: derives-from
 memoryVersion: 1
 ---
 # Reference: mnemonic-rpi-workflow skill improvement opportunities from Phase 2 execution

--- a/.mnemonic/notes/rpir-workflow-design-for-mnemonic-research-plan-implement-re-80b00851.md
+++ b/.mnemonic/notes/rpir-workflow-design-for-mnemonic-research-plan-implement-re-80b00851.md
@@ -8,7 +8,7 @@ tags:
   - decision
 lifecycle: permanent
 createdAt: '2026-04-20T21:36:57.480Z'
-updatedAt: '2026-04-24T15:35:56.372Z'
+updatedAt: '2026-04-25T07:47:56.352Z'
 role: decision
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -24,6 +24,8 @@ relatedTo:
     type: example-of
   - id: rpir-workflow-phase-3-implementation-plan-22ac514b
     type: example-of
+  - id: reference-mnemonic-rpi-workflow-skill-improvement-opportunit-1b944a63
+    type: related-to
 memoryVersion: 1
 ---
 Approved design for evolving mnemonic into a canonical workflow artifact store with first-class research/plan/review support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 
 ## [Unreleased]
 
+## [0.25.5] - 2026-04-25
+
+### Changed
+
+- `mnemonic-rpi-workflow` skill revised for conciseness (112 lines, down from 149): removed redundant "When to Use" section, consolidated relationship guidance, tightened commit discipline into a script-like sequence, and moved closeout templates to a separate `closeout-templates.md` for progressive disclosure.
+- Skill now requires verification evidence in review notes and includes dirty worktree safety rules, closeout templates (decision + summary), and explicit commit-class separation.
+
 ## [0.25.4] - 2026-04-25
 
 ### Changed

--- a/Formula/mnemonic-mcp.rb
+++ b/Formula/mnemonic-mcp.rb
@@ -1,8 +1,8 @@
 class MnemonicMcp < Formula
   desc "Local MCP memory server backed by markdown + JSON files, synced via git"
   homepage "https://github.com/danielmarbach/mnemonic"
-  url "https://registry.npmjs.org/@danielmarbach/mnemonic-mcp/-/mnemonic-mcp-0.25.4.tgz"
-  sha256 "c70c0398879c9f3cfa1d2a26ab7ad5895d782aca59a70f6a73a2affd3e8007c2"
+  url "https://registry.npmjs.org/@danielmarbach/mnemonic-mcp/-/mnemonic-mcp-0.25.5.tgz"
+  sha256 "PLACEHOLDER_UPDATE_AFTER_PUBLISH"
   license "Apache-2.0"
 
   depends_on "node"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.25.4",
+  "version": "0.25.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@danielmarbach/mnemonic-mcp",
-      "version": "0.25.3",
+      "version": "0.25.5",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.1",
         "gray-matter": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.25.4",
+  "version": "0.25.5",
   "description": "A local MCP memory server backed by markdown + JSON files, synced via git",
   "type": "module",
   "repository": {

--- a/skills/mnemonic-rpi-workflow/SKILL.md
+++ b/skills/mnemonic-rpi-workflow/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: mnemonic-rpir-workflow
+name: mnemonic-rpi-workflow
 description: Executes multi-step research-plan-implement-review workflows using mnemonic for workflow artifacts. Triggers on multi-step feature or bugfix work, subagent handoffs, plan-heavy tasks, or any work needing structured RPIR artifacts with explicit handoffs and consistent role/relationship conventions.
 ---
 

--- a/skills/mnemonic-rpi-workflow/SKILL.md
+++ b/skills/mnemonic-rpi-workflow/SKILL.md
@@ -1,151 +1,113 @@
 ---
-name: mnemonic-rpi-workflow
-description: Use when executing multi-step research-plan-implement-review workflows, especially when you need explicit handoffs, one current plan note, and consistent role/relationship conventions.
+name: mnemonic-rpir-workflow
+description: Executes multi-step research-plan-implement-review workflows using mnemonic for workflow artifacts. Triggers on multi-step feature or bugfix work, subagent handoffs, plan-heavy tasks, or any work needing structured RPIR artifacts with explicit handoffs and consistent role/relationship conventions.
 ---
 
-# Skill: mnemonic-rpi-workflow
-
-# RPIR Workflow: Research -> Plan -> Implement -> Review
-
-Use this skill when work needs structured workflow artifacts.
-
-## When to Use
-
-- Multi-step feature or bugfix work where you need research, plan, execution, and review artifacts.
-- Work delegated to subagents that needs explicit handoff and continuity.
-- Tasks where plan drift risk is high and you want one current plan note.
+# RPIR Workflow: Research → Plan → Implement → Review
 
 ## Core Principle
 
-mnemonic is the canonical store for workflow artifacts, not the workflow runtime.
+mnemonic stores workflow artifacts; it does not run the workflow.
+
+## Relationship Conventions
+
+Use `derives-from` for lineage and `follows` for sequence by default. Fall back to `related-to` only when direction is unclear. Keep relationships sparse — link only to immediate upstream artifacts.
 
 ## Stage Checklists
 
 ### 1. Research
 
-- Create or update one request root note with `role: context`, `lifecycle: temporary`, `tags: ["workflow", "request"]`.
-- Before creating new notes, call `recall` for related prior work.
-- Create research notes with `role: research`, `lifecycle: temporary`.
-- Distill a short research summary when findings are scattered.
-- Link research notes to request root. Prefer `derives-from` when lineage is explicit; otherwise use `related-to`.
+- Create or update one request root: `role: context`, `lifecycle: temporary`, `tags: ["workflow", "request"]`.
+- Call `recall` before creating notes to avoid duplicates.
+- Create research notes: `role: research`, `lifecycle: temporary`.
+- Distill when findings are scattered.
+- Link research to request root (`derives-from` preferred).
 
 ### 2. Plan
 
-- Create or update one current plan note with `role: plan`, `lifecycle: temporary`.
-- Link plan note to request root and key research notes. Prefer `derives-from` for lineage and `follows` for sequence; fallback to `related-to` when direction is unclear.
-- Keep the plan concise, executable, and scoped to the current request.
-- Prefer one current plan per request; update or supersede as needed.
-- If the plan changes materially, update the plan note before continuing implementation.
-
-Material plan changes include architecture direction, file/module scope, ordering/dependencies, validation strategy, and key assumptions.
+- Create or update one current plan note: `role: plan`, `lifecycle: temporary`.
+- Link to request root and key research notes (`derives-from` for lineage, `follows` for sequence).
+- Keep the plan concise and executable.
+- One current plan per request; update or supersede as needed.
+- Update plan note before continuing if scope, architecture, dependencies, or assumptions change materially.
 
 ### 3. Implement
 
-- Create apply/task notes as `lifecycle: temporary`, tagged with `apply`.
-- Use `role: plan` for intended executable steps.
-- Use `role: context` for observations, checkpoints, and execution notes.
-- Link apply/task notes to the plan note. Prefer `follows` for ordered execution steps.
-- For non-trivial work, dispatch a subagent with narrow scope and explicit handoff context.
+- Create apply/task notes: `lifecycle: temporary`, tagged `apply`.
+- `role: plan` for executable steps; `role: context` for observations and checkpoints.
+- Link to plan note (`follows` for ordered steps).
+- For non-trivial work, dispatch a subagent with narrow scope (see [handoff template](#subagent-handoff-template)).
 
 ### 4. Review
 
-- Create review notes with `role: review`, `lifecycle: temporary`.
-- Link review notes to apply/task notes or plan. Use `derives-from` when review conclusions derive from specific artifacts.
-- Record outcomes: continue, block, or update plan.
+- Create review notes: `role: review`, `lifecycle: temporary`.
+- Link to apply/task notes or plan (`derives-from` when conclusions derive from specific artifacts).
+- Record outcome: continue, block, or update plan.
 - If review causes a material plan change, update plan note first.
+- Every review note must include verification evidence:
+
+```text
+- Command: <run command>
+- Result: pass | fail | partial
+- Details: <counts, errors>
+```
 
 ### 5. Consolidate
 
-- Create permanent decision note(s) for resolved approaches.
-- Create permanent summary note(s) for outcomes and verification.
+- Create permanent decision note(s) and summary note(s).
 - Promote reusable patterns into permanent reference notes.
-- Let pure temporary scaffolding expire when no longer useful.
+- Let temporary scaffolding expire.
+
+Use the templates in [closeout-templates.md](closeout-templates.md).
 
 ## Subagent Handoff Template
 
-Use this template for subagent delegation:
-
 ```text
-Request note:
-- <note-id/title>
-
-Current plan note (or relevant slice):
-- <note-id/title>
-
-Relevant research notes:
-- <note-id/title>
-- <note-id/title>
-
-Durable recalled context:
-- <note-id/title>
-- <note-id/title>
+Request note:      <note-id/title>
+Plan note:         <note-id/title>
+Research notes:    <note-id/title>, ...
+Durable context:   <note-id/title>, ...
 
 Task scope:
 - Files/modules: <paths>
 - Goal: <what to change>
 - Validation: <tests/checks>
 
-Subagent must return:
-1) Updated apply note content
-2) Optional review note content
-3) Recommendation: continue | block | update plan
+Must return: apply note content, optional review note, recommendation (continue | block | update plan)
 ```
 
-## Note Conventions
-
-- Request root: one per workflow, `role: context`, `lifecycle: temporary`, `tags: workflow/request`.
-- Apply/task split: no new role; use existing `plan` and `context` roles plus `apply` tag.
-- Relationship density: keep sparse; link only to immediate upstream artifacts.
-- Plan currency: one current plan note per request.
-
-Relationship preference order:
-
-1. `derives-from` for explicit lineage.
-2. `follows` for explicit sequence.
-3. `related-to` only when direction is unknown or intentionally generic.
-
-Canonical graph:
+## Canonical Graph
 
 ```text
 request root (context, temporary)
-  -> research (temporary)
-  -> plan (temporary)
-  -> apply/task (temporary; plan for steps, context for observations)
-  -> review (temporary)
-  -> outcome/decision/summary (permanent)
+  → research (temporary)
+  → plan (temporary)
+  → apply/task (temporary; plan for steps, context for observations)
+  → review (temporary)
+  → outcome/decision/summary (permanent)
 ```
 
 ## Commit Discipline
 
-Use three commit classes through the workflow:
+Three commit classes:
 
-1. Memory commit: research/plan/review artifacts.
-2. Work commit: code/test/docs implementation.
-3. Memory commit: consolidation and promotion of durable knowledge.
+1. **Memory** — research/plan/review artifacts
+2. **Work** — code/test/docs implementation
+3. **Memory** — consolidation of durable knowledge
 
-If plan changes materially during implementation, do memory update first, then continue work.
+Never mix classes. Before every commit, run this sequence:
+
+1. `git status --short`
+2. Stage only intended paths (never `git add .` or `git add -A`)
+3. If unsure whether dirty files belong together, ask before committing
+4. `git status --short` after commit to confirm
+
+Material plan changes during implementation: commit the memory update first.
 
 ## Examples
 
-### Example 1: Research-heavy bug investigation
+**Research-heavy bug:** request root + research notes → plan with validation → apply + review → permanent decision + summary.
 
-- Create request root + two research notes.
-- Link research to request.
-- Write one plan note with validation steps.
-- Execute with apply notes and one review note.
-- Consolidate into permanent decision + summary notes.
+**Multi-file refactor:** request root + concise plan → subagent handoff → apply note + recommendation → review, consolidate.
 
-### Example 2: Multi-file refactor with subagent
-
-- Create request root and concise plan note.
-- Hand subagent request/plan/research plus narrow file list.
-- Receive updated apply note + recommendation.
-- Add review note, update plan if material drift occurred.
-- Promote reusable patterns into reference note.
-
-### Example 3: Small task with no iteration
-
-- Create/update request root and one plan note.
-- Implement directly with one apply note.
-- Review note says continue and close.
-- Consolidate to one permanent summary note.
+**Small task:** request root + plan → one apply note → review says continue → one permanent summary.

--- a/skills/mnemonic-rpi-workflow/closeout-templates.md
+++ b/skills/mnemonic-rpi-workflow/closeout-templates.md
@@ -1,0 +1,19 @@
+# Closeout Templates
+
+## Decision Note (`role: decision`)
+
+```text
+**Decision:** <one-line ruling>
+**Rationale:** <why, not what>
+**Alternatives considered:** <brief list>
+**Consequences:** <what this enables or prevents>
+```
+
+## Summary Note (`role: summary`)
+
+```text
+**What shipped:** <change list>
+**Verification:** <test counts, commands run, outcomes>
+**Status:** complete | partial | blocked
+**Open items:** <remaining work or known gaps>
+```


### PR DESCRIPTION
## Summary

This PR captures the following design decisions:

- **RPIR workflow design for mnemonic: research→plan→implement→review**
- **Reference: mnemonic-rpi-workflow skill improvement opportunities from Phase 2 execution**

## Design Decisions

### RPIR workflow design for mnemonic: research→plan→implement→review

**Tags:** workflow, rpir, design, roles, decision

Approved design for evolving mnemonic into a canonical workflow artifact store with first-class research/plan/review support.

## Phase status (as of 2026-04-24)

- **Phase 1 — complete:** roles (`research`, `review`), role parameter support, role-based lifecycle defaults, tests, and workflow-hint alignment shipped.
- **Phase 2 — complete:** workflow prompt + skill delivery conventions shipped with docs and prompt coverage tests.
- **Phase 3 — complete (branch):** `recall(mode: "workflow")` plus directional relationship types shipped with additive compatibility behavior.
- **Phase 4 — pending:** real-task validation cycle not run yet.
- **Phase 5 — pending:** orchestrator decision deferred until validation evidence exists.

## Core principle

mnemonic is the canonical store for workflow artifacts, not the workflow runtime.

## Important Phase 3 revelations

- **Always-on rollout (no flags):** Phase 3 ships directly without feature flags.
- **No migration:** relationship changes are additive only; no bulk rewriting of existing notes.
- **Indefinite compatibility fallback:** workflow reconstruction keeps `related-to` fallback indefinitely.
- **External-user posture:** compatibility is treated as a long-term public contract, not a short-lived internal bridge.
- **Precision path:** `derives-from` and `follows` improve chain quality but are optional; mixed graphs are first-class.

## Design choices locked in- **Post-hoc classification:** explicit role assignment after note creation is a first-class workflow requirement; `update` must support it directly and expose role changes in structured output for verification and retrieval confidence

- Add `research` and `review` roles for workflow artifacts.
- Keep apply/task notes on existing roles (`plan` for intended steps, `context` for execution observations) with `apply` tag.
- Keep role inference conservative (existing roles only); skill/prompt drives explicit workflow role usage.
- Use role-based lifecycle soft defaults at creation time only.
- Keep one request-root convention (`role: context`, temporary, workflow/request tags).
- Keep one current plan note per request as the default operating model.
- Keep relationship graph sparse, immediate-upstream focused.
- Use directional types as additive precision, never as mandatory requirement.
- Keep prompts and skills complementary.
- Keep orchestration runtime out of mnemonic core.

## Canonical note graph

```text
request root (role: context, temporary)
  → research (temporary)
  → plan (temporary)
  → apply/task notes (temporary; role: plan for steps, role: context for observations)
  → review (temporary)
  → outcome/decision/summary (permanent)
```

## Relationship conventions

Minimal set, immediate upstream links only:

- research `related-to` request
- plan `related-to` request + key research notes
- apply/task `related-to` plan
- review `related-to` apply or plan
- outcome `related-to` plan (optionally request)

Directional additions for explicit derivation/ordering:

- `derives-from`
- `follows`

Workflow recall supports mixed legacy and directional graphs.

## Stage protocol

1. Research — create/update request root note, create research notes, distill when needed.
2. Plan — create/update plan note linked to request/research, keep concise and executable.
3. Implement — create temporary apply/task notes, hand narrow context to subagent if non-trivial.
4. Review — create review notes, fix or mark blockers, update plan first if review changes execution materially.
5. Iterate — only when checks/review warrant it.

## Convention delivery decisions

- Workflow prompt name: `mnemonic-rpi-workflow`.
- Workflow skill location/name: `skills/mnemonic-rpi-workflow/SKILL.md`.
- Memory protocol prompt remains separate: `mnemonic-workflow-hint`.

## Skill packaging decision essentials

- Skills are part of the product experience and ship with mnemonic releases.
- Packaging includes a repeatable install/update flow for local client skill directories.
- Target distribution includes Claude, OpenCode, and custom client paths.

## Commit discipline

Three classes: memory (research/plan/review artifacts), work (code/test/docs), memory (consolidation/promotion).

## Phase 4 validation

Run RPIR on 3-5 real tasks: research-heavy, plan-heavy refactor, multi-step implementation, review/fix cycle. Measure token cost, plan drift, temporary-note cleanup burden, retrieval quality, and graph readability.

## Phase 5 orchestrator decision

Build a separate orchestration layer only if real usage consistently wants automated subagent dispatch/review looping. mnemonic remains artifact backbone; orchestrator remains thin.

## Non-goals

- No orchestration runtime in core
- No full task engine in core
- No mandatory loop model
- No rich task-state schema in core

## Open questions

- One plan note vs. plan revisions in long-running work
- Whether memory commits become too noisy

### Reference: mnemonic-rpi-workflow skill improvement opportunities from Phase 2 execution

**Tags:** workflow, rpir, skill-improvement, commit-hygiene, phase2

# Reference: mnemonic-rpi-workflow skill improvement opportunities from Phase 2 execution

This note captures practical improvements observed while running a full Phase 2 RPIR cycle (research/plan/implement/review/consolidate) with multiple work and memory commits.

## Primary finding

Commit hygiene still needs repeated human reminders for many LLMs, even when RPIR is followed.

The current skill gives good commit-class guidance, but it would be stronger with explicit guardrails that are hard to skip in long sessions.

## Recommended skill improvements

### 1) Add a mandatory "commit hygiene gate" before every work commit

Require a short, explicit sequence in the skill:

1. `git status --short`
2. `git diff -- <target-files>`
3. confirm only intended files are staged
4. commit only those files
5. `git status --short` post-commit

Why: this prevents accidental inclusion of unrelated changes in dirty worktrees.

### 2) Add a required "dirty tree policy" section

The skill should explicitly say:

- never mix unrelated dirty files into the work commit
- if unrelated files exist, stage only exact intended paths
- if uncertain, stop and ask the user whether to split commits

Why: this is the most common failure mode under real branch conditions.

### 3) Strengthen commit-class protocol into a checklist with state transitions

Current classes are strong conceptually (memory -> work -> memory), but should be operationalized:

- mark class as active
- list required artifacts for that class
- block transition to next class until verification evidence is recorded

Why: reduces drift where memory notes or review evidence are skipped under time pressure.

### 4) Add a "verification evidence block" requirement to the review stage

Require storing concrete command evidence in review artifacts:

- command run
- pass/fail outcome
- key counts (e.g., tests passed)

Why: ensures review notes are auditable and not summary-only.

### 5) Add a "closeout consolidation template" for permanent notes

When closing a phase, require two durable captures by template:

- permanent decision note (what was decided and why)
- permanent summary note (what shipped, what was verified, final status)

Why: improves consistency and discoverability of completed work.

### 6) Add branch-finish handshake guidance

At workflow end, explicitly route to branch-finalization options (merge/PR/keep/discard) and require a clean status check first.

Why: avoids ambiguity after implementation is done.

### 7) Add optional anti-brittleness guidance for dogfooding checks

If dogfooding produces advisory-only failures, require root-cause classification:

- product regression vs. heuristic brittleness
- if heuristic brittleness, update check logic and re-verify

Why: prevents overfitting product code to brittle quality gates.

## Suggested concrete additions to skill text

- Add a "Commit Hygiene Checklist" subsection under Implement + Consolidate stages.
- Add a "Dirty Worktree Safety Rules" block near Commit Discipline.
- Add a "Phase Closeout Checklist" requiring decision+summary permanent notes and branch-finish handoff.

## Expected impact

- Fewer accidental mixed commits
- More consistent evidence-backed reviews
- Better reliability across weaker/less disciplined models
- More predictable phase completion quality

---

_Generated from 2 design decision note(s) in `.mnemonic/notes/`. Run `/update-pr` to regenerate._