### PR TITLE
Update mnemonic-mcp formula to 0.25.5

### DIFF
--- a/Formula/mnemonic-mcp.rb
+++ b/Formula/mnemonic-mcp.rb
@@ -2,7 +2,7 @@ class MnemonicMcp < Formula
   desc "Local MCP memory server backed by markdown + JSON files, synced via git"
   homepage "https://github.com/danielmarbach/mnemonic"
   url "https://registry.npmjs.org/@danielmarbach/mnemonic-mcp/-/mnemonic-mcp-0.25.5.tgz"
-  sha256 "PLACEHOLDER_UPDATE_AFTER_PUBLISH"
+  sha256 "706f7b29d9994778d46bbee08ea781d3c4a7dafddd3240e94f9c4f8b09fb1086"
   license "Apache-2.0"
 
   depends_on "node"


### PR DESCRIPTION
Automated Homebrew formula update generated by the publish workflow.

- Formula: `Formula/mnemonic-mcp.rb`
- Version: `0.25.5`
- Tarball URL: `https://registry.npmjs.org/@danielmarbach/mnemonic-mcp/-/mnemonic-mcp-0.25.5.tgz`
