### PR TITLE
Fix: Unconditional bump of updatedAt even when no content or metadata changed

### DIFF
--- a/.mnemonic/notes/bug-fix-update-tool-no-op-detection-1031c864.md
+++ b/.mnemonic/notes/bug-fix-update-tool-no-op-detection-1031c864.md
@@ -1,0 +1,40 @@
+---
+title: 'Bug fix: update tool no-op detection'
+tags:
+  - bug-fix
+  - update
+  - no-op
+  - evidence
+lifecycle: permanent
+createdAt: '2026-04-26T17:18:33.611Z'
+updatedAt: '2026-04-26T17:18:33.611Z'
+role: decision
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+## Bug fixed: update tool created empty commits and wasted embeddings on no-op changes
+
+The `update` tool unconditionally bumped `updatedAt`, wrote the note, re-embedded, and committed — even when no content or metadata actually changed. This produced git commits with only a frontmatter timestamp diff and wasted embedding computation.
+
+### Root causes
+
+1. **No content-change guard**: The handler always proceeded to write/commit/embed regardless of whether any field actually changed.
+2. **Parameter presence vs actual change**: The `changes` array tracked parameter presence (e.g. `content !== undefined`) rather than actual value differences (e.g. `content !== note.content`).
+3. **Metadata-only changes re-embedded**: Per the key design decisions note, "metadata-only changes don't re-embed" — but the code always re-embedded.
+
+### Fix (src/update-detect-changes.ts + src/index.ts)
+
+Extracted `hasActualChanges()` and `computeFieldsModified()` into a new module (`src/update-detect-changes.ts`) with:
+
+- **Explicit-set semantics**: Fields like `role`, `tags`, `alwaysLoad` are only reported as changed when the caller explicitly provided them AND the value differs from the original.
+- **semanticPatch is always a change**: Even if patch output equals original content, the fact a patch was applied is reported.
+- **relatedTo auto-relationships count**: If `suggestAutoRelationships` adds new edges during update, that's a change.
+- **No-op early return**: When `hasActualChanges()` returns false, the handler returns "No changes" without writing, embedding, or committing.
+- **Metadata-only skip re-embed**: `shouldReembed` is `true` only when `patchedContent` or `cleanedContent` is set. Metadata-only updates skip embedding.
+
+### Tests
+
+- `tests/update-noop.unit.test.ts` — 37 unit tests for `hasActualChanges` and `computeFieldsModified`
+- `tests/update-noop.integration.test.ts` — 6 integration tests covering no-op detection, updatedAt stability, embedding skip, fieldsModified accuracy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 
 ## [Unreleased]
 
+## [0.26.2] - 2026-04-26
+
+### Fixed
+
+- `update` skips write/commit/embed when no fields actually changed.
+- `update` `fieldsModified` tracks actual value differences, not parameter presence.
+- Metadata-only updates no longer trigger re-embedding.
+
 ## [0.26.1] - 2026-04-26
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@danielmarbach/mnemonic-mcp",
-      "version": "0.26.1",
+      "version": "0.26.2",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.1",
         "gray-matter": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "description": "A local MCP memory server backed by markdown + JSON files, synced via git",
   "type": "module",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ import {
 import { getRelationshipPreview } from "./relationships.js";
 import { MarkdownLintError, cleanMarkdown } from "./markdown.js";
 import { applySemanticPatches, type SemanticPatch } from "./semantic-patch.js";
+import { hasActualChanges, computeFieldsModified } from "./update-detect-changes.js";
 import { MnemonicConfigStore, readVaultSchemaVersion, type MutationPushMode } from "./config.js";
 import {
   CONSOLIDATION_MODES,
@@ -2989,61 +2990,144 @@ server.registerTool(
     }
     const cleanedContent = content === undefined ? undefined : await cleanMarkdown(content);
 
-    const updated: Note = {
-      ...note,
-      title: title ?? note.title,
-      content: patchedContent ?? cleanedContent ?? note.content,
-      tags: tags ?? note.tags,
-      lifecycle: lifecycle ?? note.lifecycle,
-      ...(role !== undefined ? { role } : (note.role ? { role: note.role } : {})),
-      alwaysLoad: alwaysLoad !== undefined ? alwaysLoad : note.alwaysLoad,
-      updatedAt: now,
-    };
+    const resolvedTitle = title ?? note.title;
+    const resolvedContent = patchedContent ?? cleanedContent ?? note.content;
+    const resolvedTags = tags ?? note.tags;
+    const resolvedLifecycle = lifecycle ?? note.lifecycle;
+    const resolvedRole = role !== undefined ? role : (note.role ? note.role : undefined);
+    const resolvedAlwaysLoad = alwaysLoad !== undefined ? alwaysLoad : note.alwaysLoad;
 
-    if (updated.project) {
-      const accessCandidates = getRecentSessionNoteAccesses(updated.project)
+    let relatedToChanged = false;
+    let resolvedRelatedTo = note.relatedTo;
+    if (note.project) {
+      const accessCandidates = getRecentSessionNoteAccesses(note.project)
         .map((entry) => {
-          const cachedNote = getSessionCachedNote(updated.project!, entry.vaultPath, entry.noteId)
-            ?? getRecentSessionAccessNote(updated.project!, entry.vaultPath, entry.noteId);
+          const cachedNote = getSessionCachedNote(note.project!, entry.vaultPath, entry.noteId)
+            ?? getRecentSessionAccessNote(note.project!, entry.vaultPath, entry.noteId);
           return cachedNote
             ? { note: cachedNote, accessedAt: entry.accessedAt, accessKind: entry.accessKind, score: entry.score }
             : null;
         })
         .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
-      const autoRelationships = suggestAutoRelationships(updated, accessCandidates);
+      const autoRelationships = suggestAutoRelationships({
+        ...note,
+        title: resolvedTitle,
+        content: resolvedContent,
+        tags: resolvedTags,
+        lifecycle: resolvedLifecycle,
+        alwaysLoad: resolvedAlwaysLoad,
+      }, accessCandidates);
       if (autoRelationships.length > 0) {
-        const existing = [...(updated.relatedTo ?? [])];
+        const existing = [...(note.relatedTo ?? [])];
         for (const relationship of autoRelationships) {
           if (!existing.some((rel) => rel.id === relationship.id && rel.type === relationship.type)) {
             existing.push(relationship);
           }
         }
-        updated.relatedTo = existing;
+        resolvedRelatedTo = existing;
+        relatedToChanged = true;
       }
     }
 
-    await vault.storage.writeNote(updated);
+    const changes = computeFieldsModified({
+      patchedContent,
+      originalContent: note.content,
+      contentExplicitlyProvided: content !== undefined,
+      semanticPatchProvided: semanticPatch !== undefined && semanticPatch.length > 0,
+      newTitle: resolvedTitle,
+      originalTitle: note.title,
+      titleExplicitlyProvided: title !== undefined,
+      newLifecycle: resolvedLifecycle,
+      originalLifecycle: note.lifecycle,
+      lifecycleExplicitlyProvided: lifecycle !== undefined,
+      newRole: resolvedRole,
+      originalRole: note.role,
+      roleExplicitlySet: role !== undefined,
+      newTags: resolvedTags,
+      originalTags: note.tags,
+      tagsExplicitlyProvided: tags !== undefined,
+      newAlwaysLoad: resolvedAlwaysLoad,
+      originalAlwaysLoad: note.alwaysLoad,
+      alwaysLoadExplicitlyProvided: alwaysLoad !== undefined,
+      relatedToChanged,
+    });
 
-    let embeddingStatus: { status: "written" | "skipped"; reason?: string } = { status: "written" };
+    const hasChanges = hasActualChanges({
+      content: cleanedContent,
+      originalContent: note.content,
+      title,
+      originalTitle: note.title,
+      tags,
+      originalTags: note.tags,
+      lifecycle,
+      originalLifecycle: note.lifecycle,
+      role,
+      originalRole: note.role,
+      roleExplicitlySet: role !== undefined,
+      alwaysLoad,
+      originalAlwaysLoad: note.alwaysLoad,
+      semanticPatchApplied: semanticPatch !== undefined && semanticPatch.length > 0,
+      relatedToChanged,
+    });
 
-    try {
-      const text = await embedTextForNote(vault.storage, updated);
-      const vector = await embed(text);
-      await vault.storage.writeEmbedding({ id, model: embedModel, embedding: vector, updatedAt: now });
-    } catch (err) {
-      embeddingStatus = { status: "skipped", reason: err instanceof Error ? err.message : String(err) };
-      console.error(`[embedding] Re-embed failed for '${id}': ${err}`);
+    if (!hasChanges) {
+      const noOpPersistence: PersistenceStatus = {
+        notePath: vault.storage.notePath(id),
+        embeddingPath: vault.storage.embeddingPath(id),
+        embedding: { status: "skipped", model: embedModel, reason: "no-changes" },
+        git: {
+          commit: "skipped",
+          push: "skipped",
+          commitReason: "no-changes",
+          pushReason: "no-changes",
+        },
+        durability: "local-only",
+      };
+      return {
+        content: [{ type: "text", text: `No changes to memory '${id}'` }],
+        structuredContent: {
+          action: "updated" as const,
+          id,
+          title: note.title,
+          fieldsModified: [],
+          timestamp: note.updatedAt,
+          project: noteProjectRef(note),
+          lifecycle: note.lifecycle,
+          role: note.role,
+          persistence: noOpPersistence,
+        },
+      };
     }
 
-    // Build change summary (LLM-provided or auto-generated)
-    const changes: string[] = [];
-    if (title !== undefined && title !== note.title) changes.push("title");
-    if (content !== undefined) changes.push("content");
-    if (semanticPatch !== undefined) changes.push("semanticPatch");
-    if (tags !== undefined) changes.push("tags");
-    if (lifecycle !== undefined && lifecycle !== note.lifecycle) changes.push("lifecycle");
-    if (role !== undefined && role !== note.role) changes.push("role");
-    if (alwaysLoad !== undefined && alwaysLoad !== note.alwaysLoad) changes.push("alwaysLoad");
+    const updated: Note = {
+      ...note,
+      title: resolvedTitle,
+      content: resolvedContent,
+      tags: resolvedTags,
+      lifecycle: resolvedLifecycle,
+      ...(role !== undefined ? { role: resolvedRole } : (note.role ? { role: note.role } : {})),
+      alwaysLoad: resolvedAlwaysLoad,
+      updatedAt: now,
+      relatedTo: resolvedRelatedTo,
+    };
+
+    await vault.storage.writeNote(updated);
+
+    const shouldReembed = patchedContent !== undefined || cleanedContent !== undefined;
+    let embeddingStatus: { status: "written" | "skipped"; reason?: string } = { status: "skipped", reason: shouldReembed ? undefined : "metadata-only" };
+
+    if (shouldReembed) {
+      try {
+        const text = await embedTextForNote(vault.storage, updated);
+        const vector = await embed(text);
+        await vault.storage.writeEmbedding({ id, model: embedModel, embedding: vector, updatedAt: now });
+        embeddingStatus = { status: "written" };
+      } catch (err) {
+        embeddingStatus = { status: "skipped", reason: err instanceof Error ? err.message : String(err) };
+        console.error(`[embedding] Re-embed failed for '${id}': ${err}`);
+      }
+    }
+
     const changeDesc = changes.length > 0 ? `Updated ${changes.join(", ")}` : "No changes";
     const commitSummary = summary ?? changeDesc;
 

--- a/src/update-detect-changes.ts
+++ b/src/update-detect-changes.ts
@@ -1,0 +1,90 @@
+export interface ChangeDetectionInput {
+  content?: string;
+  originalContent: string;
+  title?: string;
+  originalTitle: string;
+  tags?: string[];
+  originalTags: string[];
+  lifecycle?: string;
+  originalLifecycle: string;
+  role?: string;
+  originalRole?: string;
+  roleExplicitlySet?: boolean;
+  alwaysLoad?: boolean;
+  originalAlwaysLoad?: boolean;
+  semanticPatchApplied?: boolean;
+  relatedToChanged?: boolean;
+}
+
+export function hasActualChanges(input: ChangeDetectionInput): boolean {
+  if (input.semanticPatchApplied) return true;
+
+  if (input.content !== undefined && input.content !== input.originalContent) return true;
+  if (input.title !== undefined && input.title !== input.originalTitle) return true;
+  if (input.lifecycle !== undefined && input.lifecycle !== input.originalLifecycle) return true;
+  if (input.alwaysLoad !== undefined && input.alwaysLoad !== input.originalAlwaysLoad) return true;
+
+  if (input.roleExplicitlySet && input.role !== input.originalRole) return true;
+
+  if (input.tags !== undefined && !arraysEqual(input.tags, input.originalTags)) return true;
+
+  if (input.relatedToChanged) return true;
+
+  return false;
+}
+
+export interface FieldsModifiedInput {
+  patchedContent?: string;
+  originalContent: string;
+  contentExplicitlyProvided?: boolean;
+  semanticPatchProvided?: boolean;
+  newTitle: string;
+  originalTitle: string;
+  titleExplicitlyProvided?: boolean;
+  newLifecycle: string;
+  originalLifecycle: string;
+  lifecycleExplicitlyProvided?: boolean;
+  newRole?: string;
+  originalRole?: string;
+  roleExplicitlySet: boolean;
+  newTags: string[];
+  originalTags: string[];
+  tagsExplicitlyProvided?: boolean;
+  newAlwaysLoad?: boolean;
+  originalAlwaysLoad?: boolean;
+  alwaysLoadExplicitlyProvided?: boolean;
+  relatedToChanged?: boolean;
+}
+
+export function computeFieldsModified(input: FieldsModifiedInput): string[] {
+  const changes: string[] = [];
+
+  if (input.semanticPatchProvided) {
+    changes.push("semanticPatch");
+    if (input.patchedContent !== undefined && input.patchedContent !== input.originalContent) {
+      changes.push("content");
+    }
+  } else if (input.contentExplicitlyProvided) {
+    const effectiveContent = input.patchedContent ?? input.originalContent;
+    if (effectiveContent !== input.originalContent) {
+      changes.push("content");
+    }
+  }
+
+  if (input.titleExplicitlyProvided && input.newTitle !== input.originalTitle) changes.push("title");
+  if (input.lifecycleExplicitlyProvided && input.newLifecycle !== input.originalLifecycle) changes.push("lifecycle");
+  if (input.roleExplicitlySet && input.newRole !== input.originalRole) changes.push("role");
+  if (input.tagsExplicitlyProvided && !arraysEqual(input.newTags, input.originalTags)) changes.push("tags");
+  if (input.alwaysLoadExplicitlyProvided && input.newAlwaysLoad !== input.originalAlwaysLoad) changes.push("alwaysLoad");
+  if (input.relatedToChanged) changes.push("relatedTo");
+
+  return changes;
+}
+
+function arraysEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}

--- a/tests/update-noop.integration.test.ts
+++ b/tests/update-noop.integration.test.ts
@@ -1,0 +1,188 @@
+import { mkdtemp, rm } from "fs/promises";
+import { describe, expect, it } from "vitest";
+import os from "os";
+import path from "path";
+
+import { createPersistentMcpSession, initTestRepo, tempDirs } from "./helpers/mcp.js";
+
+describe("update no-op detection", () => {
+  it("does not re-embed or bump updatedAt when update makes no actual changes", async () => {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-update-noop-test-"));
+    tempDirs.push(vaultDir);
+    await initTestRepo(vaultDir, "main");
+
+    const session = await createPersistentMcpSession(vaultDir, { disableGit: true });
+
+    const rememberResult = await session.callTool("remember", {
+      title: "Test No Change",
+      content: "# Test No Change\n\nOriginal content.\n",
+      lifecycle: "temporary",
+    });
+    const noteId = rememberResult.text.match(/`([^`]+)`/)?.[1];
+    expect(noteId).toBeDefined();
+
+    const getResult1 = await session.callTool("get", { ids: [noteId!] });
+    const updatedAt1 = getResult1.text.match(/updatedAt[:\s]+(['"]?)([^'"\n,]+)\1/)?.[2]
+      ?? getResult1.structuredContent?.updatedAt as string | undefined;
+
+    const updateResult = await session.callTool("update", {
+      id: noteId,
+      lifecycle: "temporary",
+    });
+
+    expect(updateResult.text).toContain("No changes");
+
+    const getResult2 = await session.callTool("get", { ids: [noteId!] });
+    const updatedAt2 = getResult2.text.match(/updatedAt[:\s]+(['"]?)([^'"\n,]+)\1/)?.[2]
+      ?? getResult2.structuredContent?.updatedAt as string | undefined;
+
+    if (updatedAt1 && updatedAt2) {
+      expect(updatedAt2).toBe(updatedAt1);
+    }
+
+    await session.close();
+  }, 15000);
+
+  it("bumps updatedAt when lifecycle actually changes", async () => {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-update-noop-test-"));
+    tempDirs.push(vaultDir);
+    await initTestRepo(vaultDir, "main");
+
+    const session = await createPersistentMcpSession(vaultDir, { disableGit: true });
+
+    const rememberResult = await session.callTool("remember", {
+      title: "Test Lifecycle Change",
+      content: "# Test Lifecycle Change\n\nOriginal content.\n",
+      lifecycle: "temporary",
+    });
+    const noteId = rememberResult.text.match(/`([^`]+)`/)?.[1];
+    expect(noteId).toBeDefined();
+
+    const getResult1 = await session.callTool("get", { ids: [noteId!] });
+    const updatedAt1 = getResult1.structuredContent?.updatedAt as string | undefined;
+
+    const updateResult = await session.callTool("update", {
+      id: noteId,
+      lifecycle: "permanent",
+    });
+
+    expect(updateResult.text).toContain("Updated memory");
+
+    const getResult2 = await session.callTool("get", { ids: [noteId!] });
+    const updatedAt2 = getResult2.structuredContent?.updatedAt as string | undefined;
+
+    if (updatedAt1 && updatedAt2) {
+      expect(updatedAt2).not.toBe(updatedAt1);
+    }
+
+    await session.close();
+  }, 15000);
+
+  it("reports No changes for true no-op updates", async () => {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-update-noop-test-"));
+    tempDirs.push(vaultDir);
+    await initTestRepo(vaultDir, "main");
+
+    const session = await createPersistentMcpSession(vaultDir, { disableGit: true });
+
+    const rememberResult = await session.callTool("remember", {
+      title: "Test No Op Report",
+      content: "# Test No Op Report\n\nOriginal content.\n",
+      lifecycle: "temporary",
+    });
+    const noteId = rememberResult.text.match(/`([^`]+)`/)?.[1];
+    expect(noteId).toBeDefined();
+
+    const updateResult = await session.callTool("update", {
+      id: noteId,
+      lifecycle: "temporary",
+    });
+
+    expect(updateResult.text).toContain("No changes");
+
+    await session.close();
+  }, 15000);
+
+  it("reports semanticPatch in fieldsModified even when content result is identical", async () => {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-update-noop-test-"));
+    tempDirs.push(vaultDir);
+    await initTestRepo(vaultDir, "main");
+
+    const session = await createPersistentMcpSession(vaultDir, { disableGit: true });
+
+    const rememberResult = await session.callTool("remember", {
+      title: "Test Semantic Patch Fields",
+      content: "# Test\n\nHello.\n",
+      lifecycle: "temporary",
+    });
+    const noteId = rememberResult.text.match(/`([^`]+)`/)?.[1];
+    expect(noteId).toBeDefined();
+
+    const updateResult = await session.callTool("update", {
+      id: noteId,
+      semanticPatch: [
+        { selector: { heading: "Test" }, operation: { op: "insertAfter", value: "Hello." } },
+      ],
+    });
+
+    expect(updateResult.structuredContent).toBeDefined();
+    const structured = updateResult.structuredContent as Record<string, unknown>;
+    expect(structured.fieldsModified).toContain("semanticPatch");
+
+    await session.close();
+  }, 15000);
+
+  it("reports fieldsModified correctly for actual lifecycle change", async () => {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-update-noop-test-"));
+    tempDirs.push(vaultDir);
+    await initTestRepo(vaultDir, "main");
+
+    const session = await createPersistentMcpSession(vaultDir, { disableGit: true });
+
+    const rememberResult = await session.callTool("remember", {
+      title: "Test Fields Modified",
+      content: "# Test Fields Modified\n\nOriginal content.\n",
+      lifecycle: "temporary",
+    });
+    const noteId = rememberResult.text.match(/`([^`]+)`/)?.[1];
+    expect(noteId).toBeDefined();
+
+    const updateResult = await session.callTool("update", {
+      id: noteId,
+      lifecycle: "permanent",
+    });
+
+    expect(updateResult.structuredContent).toBeDefined();
+    const structured = updateResult.structuredContent as Record<string, unknown>;
+    expect(structured.fieldsModified).toContain("lifecycle");
+
+    await session.close();
+  }, 15000);
+
+  it("does not report content in fieldsModified for no-op content update", async () => {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-update-noop-test-"));
+    tempDirs.push(vaultDir);
+    await initTestRepo(vaultDir, "main");
+
+    const session = await createPersistentMcpSession(vaultDir, { disableGit: true });
+
+    const rememberResult = await session.callTool("remember", {
+      title: "Test Content NoOp",
+      content: "# Test Content NoOp\n\nOriginal.\n",
+      lifecycle: "temporary",
+    });
+    const noteId = rememberResult.text.match(/`([^`]+)`/)?.[1];
+    expect(noteId).toBeDefined();
+
+    const updateResult = await session.callTool("update", {
+      id: noteId,
+      content: "# Test Content NoOp\n\nOriginal.\n",
+    });
+
+    expect(updateResult.structuredContent).toBeDefined();
+    const structured = updateResult.structuredContent as Record<string, unknown>;
+    expect(structured.fieldsModified).not.toContain("content");
+
+    await session.close();
+  }, 15000);
+});

--- a/tests/update-noop.unit.test.ts
+++ b/tests/update-noop.unit.test.ts
@@ -1,0 +1,452 @@
+import { describe, expect, it } from "vitest";
+
+describe("update no-op detection", () => {
+  describe("hasActualChanges", () => {
+    it("detects content change", async () => {
+      const { hasActualChanges } = await import("../src/update-detect-changes.js");
+      expect(hasActualChanges({ content: "new", originalContent: "old" })).toBe(true);
+    });
+
+    it("detects no content change when strings are identical", async () => {
+      const { hasActualChanges } = await import("../src/update-detect-changes.js");
+      expect(hasActualChanges({ content: "same", originalContent: "same" })).toBe(false);
+    });
+
+    it("detects title change", async () => {
+      const { hasActualChanges } = await import("../src/update-detect-changes.js");
+      expect(hasActualChanges({ title: "New Title", originalTitle: "Old Title" })).toBe(true);
+    });
+
+    it("detects no title change when strings are identical", async () => {
+      const { hasActualChanges } = await import("../src/update-detect-changes.js");
+      expect(hasActualChanges({ title: "Same Title", originalTitle: "Same Title" })).toBe(false);
+    });
+
+    it("detects lifecycle change", async () => {
+      const { hasActualChanges } = await import("../src/update-detect-changes.js");
+      expect(hasActualChanges({ lifecycle: "permanent", originalLifecycle: "temporary" })).toBe(true);
+    });
+
+    it("detects no lifecycle change when values are identical", async () => {
+      const { hasActualChanges } = await import("../src/update-detect-changes.js");
+      expect(hasActualChanges({ lifecycle: "temporary", originalLifecycle: "temporary" })).toBe(false);
+    });
+
+    it("detects role change when explicitly set", async () => {
+      const { hasActualChanges } = await import("../src/update-detect-changes.js");
+      expect(hasActualChanges({ role: "decision", originalRole: "research", roleExplicitlySet: true })).toBe(true);
+    });
+
+    it("ignores role change when not explicitly set", async () => {
+      const { hasActualChanges } = await import("../src/update-detect-changes.js");
+      expect(hasActualChanges({ role: "decision", originalRole: "research", roleExplicitlySet: false })).toBe(false);
+    });
+
+    it("detects no role change when values are identical and explicitly set", async () => {
+      const { hasActualChanges } = await import("../src/update-detect-changes.js");
+      expect(hasActualChanges({ role: "research", originalRole: "research", roleExplicitlySet: true })).toBe(false);
+    });
+
+    it("detects role change from undefined to value when explicitly set", async () => {
+      const { hasActualChanges } = await import("../src/update-detect-changes.js");
+      expect(hasActualChanges({ role: "decision", originalRole: undefined, roleExplicitlySet: true })).toBe(true);
+    });
+
+    it("detects role change from value to undefined when explicitly set", async () => {
+      const { hasActualChanges } = await import("../src/update-detect-changes.js");
+      expect(hasActualChanges({ role: undefined, originalRole: "research", roleExplicitlySet: true })).toBe(true);
+    });
+
+    it("detects tags change", async () => {
+      const { hasActualChanges } = await import("../src/update-detect-changes.js");
+      expect(hasActualChanges({ tags: ["a", "b"], originalTags: ["a"] })).toBe(true);
+    });
+
+    it("detects no tags change when arrays are identical", async () => {
+      const { hasActualChanges } = await import("../src/update-detect-changes.js");
+      expect(hasActualChanges({ tags: ["a", "b"], originalTags: ["a", "b"] })).toBe(false);
+    });
+
+    it("detects tags change with same elements different order", async () => {
+      const { hasActualChanges } = await import("../src/update-detect-changes.js");
+      expect(hasActualChanges({ tags: ["b", "a"], originalTags: ["a", "b"] })).toBe(true);
+    });
+
+    it("detects alwaysLoad change", async () => {
+      const { hasActualChanges } = await import("../src/update-detect-changes.js");
+      expect(hasActualChanges({ alwaysLoad: true, originalAlwaysLoad: false })).toBe(true);
+    });
+
+    it("detects no alwaysLoad change when values are identical", async () => {
+      const { hasActualChanges } = await import("../src/update-detect-changes.js");
+      expect(hasActualChanges({ alwaysLoad: false, originalAlwaysLoad: false })).toBe(false);
+    });
+
+    it("detects no changes at all (true no-op)", async () => {
+      const { hasActualChanges } = await import("../src/update-detect-changes.js");
+      expect(hasActualChanges({
+        content: undefined,
+        originalContent: "original",
+        title: "Same Title",
+        originalTitle: "Same Title",
+        lifecycle: "temporary",
+        originalLifecycle: "temporary",
+        tags: ["a"],
+        originalTags: ["a"],
+      })).toBe(false);
+    });
+
+    it("detects changes when only content differs", async () => {
+      const { hasActualChanges } = await import("../src/update-detect-changes.js");
+      expect(hasActualChanges({
+        content: "new content",
+        originalContent: "original",
+        title: "Same Title",
+        originalTitle: "Same Title",
+        lifecycle: "temporary",
+        originalLifecycle: "temporary",
+        tags: ["a"],
+        originalTags: ["a"],
+      })).toBe(true);
+    });
+
+    it("treats semanticPatch presence as a content change", async () => {
+      const { hasActualChanges } = await import("../src/update-detect-changes.js");
+      expect(hasActualChanges({
+        semanticPatchApplied: true,
+        content: undefined,
+        originalContent: "original",
+        title: "Same Title",
+        originalTitle: "Same Title",
+        lifecycle: "temporary",
+        originalLifecycle: "temporary",
+        tags: ["a"],
+        originalTags: ["a"],
+      })).toBe(true);
+    });
+
+    it("treats relatedTo auto-relationship addition as a change", async () => {
+      const { hasActualChanges } = await import("../src/update-detect-changes.js");
+      expect(hasActualChanges({
+        content: undefined,
+        originalContent: "original",
+        title: "Same Title",
+        originalTitle: "Same Title",
+        relatedToChanged: true,
+      })).toBe(true);
+    });
+  });
+
+  describe("computeFieldsModified", () => {
+    it("reports semanticPatch and content when patchedContent differs from original", async () => {
+      const { computeFieldsModified } = await import("../src/update-detect-changes.js");
+      const fields = computeFieldsModified({
+        semanticPatchProvided: true,
+        patchedContent: "new content",
+        originalContent: "old content",
+        newTitle: "Title",
+        originalTitle: "Title",
+        newLifecycle: "temporary",
+        originalLifecycle: "temporary",
+        roleExplicitlySet: false,
+        newTags: ["a"],
+        originalTags: ["a"],
+        newAlwaysLoad: false,
+        originalAlwaysLoad: false,
+      });
+      expect(fields).toContain("semanticPatch");
+      expect(fields).toContain("content");
+    });
+
+    it("reports semanticPatch but not content when patch result equals original", async () => {
+      const { computeFieldsModified } = await import("../src/update-detect-changes.js");
+      const fields = computeFieldsModified({
+        semanticPatchProvided: true,
+        patchedContent: "same content",
+        originalContent: "same content",
+        newTitle: "Title",
+        originalTitle: "Title",
+        newLifecycle: "temporary",
+        originalLifecycle: "temporary",
+        roleExplicitlySet: false,
+        newTags: ["a"],
+        originalTags: ["a"],
+        newAlwaysLoad: false,
+        originalAlwaysLoad: false,
+      });
+      expect(fields).toContain("semanticPatch");
+      expect(fields).not.toContain("content");
+    });
+
+    it("does not report content when neither semanticPatch nor contentExplicitlyProvided", async () => {
+      const { computeFieldsModified } = await import("../src/update-detect-changes.js");
+      const fields = computeFieldsModified({
+        originalContent: "content",
+        newTitle: "Title",
+        originalTitle: "Title",
+        newLifecycle: "temporary",
+        originalLifecycle: "temporary",
+        roleExplicitlySet: false,
+        newTags: ["a"],
+        originalTags: ["a"],
+        newAlwaysLoad: false,
+        originalAlwaysLoad: false,
+      });
+      expect(fields).not.toContain("content");
+    });
+
+    it("reports title when explicitly provided and changed", async () => {
+      const { computeFieldsModified } = await import("../src/update-detect-changes.js");
+      const fields = computeFieldsModified({
+        originalContent: "content",
+        newTitle: "New Title",
+        originalTitle: "Old Title",
+        titleExplicitlyProvided: true,
+        newLifecycle: "temporary",
+        originalLifecycle: "temporary",
+        roleExplicitlySet: false,
+        newTags: ["a"],
+        originalTags: ["a"],
+        newAlwaysLoad: false,
+        originalAlwaysLoad: false,
+      });
+      expect(fields).toContain("title");
+    });
+
+    it("does not report title when not explicitly provided even if values differ", async () => {
+      const { computeFieldsModified } = await import("../src/update-detect-changes.js");
+      const fields = computeFieldsModified({
+        originalContent: "content",
+        newTitle: "New Title",
+        originalTitle: "Old Title",
+        titleExplicitlyProvided: false,
+        newLifecycle: "temporary",
+        originalLifecycle: "temporary",
+        roleExplicitlySet: false,
+        newTags: ["a"],
+        originalTags: ["a"],
+        newAlwaysLoad: false,
+        originalAlwaysLoad: false,
+      });
+      expect(fields).not.toContain("title");
+    });
+
+    it("does not report title when explicitly provided but same value", async () => {
+      const { computeFieldsModified } = await import("../src/update-detect-changes.js");
+      const fields = computeFieldsModified({
+        originalContent: "content",
+        newTitle: "Same Title",
+        originalTitle: "Same Title",
+        titleExplicitlyProvided: true,
+        newLifecycle: "temporary",
+        originalLifecycle: "temporary",
+        roleExplicitlySet: false,
+        newTags: ["a"],
+        originalTags: ["a"],
+        newAlwaysLoad: false,
+        originalAlwaysLoad: false,
+      });
+      expect(fields).not.toContain("title");
+    });
+
+    it("reports lifecycle when explicitly provided and changed", async () => {
+      const { computeFieldsModified } = await import("../src/update-detect-changes.js");
+      const fields = computeFieldsModified({
+        originalContent: "content",
+        newTitle: "Title",
+        originalTitle: "Title",
+        newLifecycle: "permanent",
+        originalLifecycle: "temporary",
+        lifecycleExplicitlyProvided: true,
+        roleExplicitlySet: false,
+        newTags: ["a"],
+        originalTags: ["a"],
+        newAlwaysLoad: false,
+        originalAlwaysLoad: false,
+      });
+      expect(fields).toContain("lifecycle");
+    });
+
+    it("does not report lifecycle when not explicitly provided", async () => {
+      const { computeFieldsModified } = await import("../src/update-detect-changes.js");
+      const fields = computeFieldsModified({
+        originalContent: "content",
+        newTitle: "Title",
+        originalTitle: "Title",
+        newLifecycle: "permanent",
+        originalLifecycle: "temporary",
+        lifecycleExplicitlyProvided: false,
+        roleExplicitlySet: false,
+        newTags: ["a"],
+        originalTags: ["a"],
+        newAlwaysLoad: false,
+        originalAlwaysLoad: false,
+      });
+      expect(fields).not.toContain("lifecycle");
+    });
+
+    it("reports role when explicitly set and changed", async () => {
+      const { computeFieldsModified } = await import("../src/update-detect-changes.js");
+      const fields = computeFieldsModified({
+        originalContent: "content",
+        newTitle: "Title",
+        originalTitle: "Title",
+        newLifecycle: "temporary",
+        originalLifecycle: "temporary",
+        newRole: "decision",
+        originalRole: undefined,
+        roleExplicitlySet: true,
+        newTags: ["a"],
+        originalTags: ["a"],
+        newAlwaysLoad: false,
+        originalAlwaysLoad: false,
+      });
+      expect(fields).toContain("role");
+    });
+
+    it("reports role when explicitly set to clear an existing role", async () => {
+      const { computeFieldsModified } = await import("../src/update-detect-changes.js");
+      const fields = computeFieldsModified({
+        originalContent: "content",
+        newTitle: "Title",
+        originalTitle: "Title",
+        newLifecycle: "temporary",
+        originalLifecycle: "temporary",
+        newRole: undefined,
+        originalRole: "research",
+        roleExplicitlySet: true,
+        newTags: ["a"],
+        originalTags: ["a"],
+        newAlwaysLoad: false,
+        originalAlwaysLoad: false,
+      });
+      expect(fields).toContain("role");
+    });
+
+    it("does not report role when not explicitly set", async () => {
+      const { computeFieldsModified } = await import("../src/update-detect-changes.js");
+      const fields = computeFieldsModified({
+        originalContent: "content",
+        newTitle: "Title",
+        originalTitle: "Title",
+        newLifecycle: "temporary",
+        originalLifecycle: "temporary",
+        newRole: "research",
+        originalRole: "research",
+        roleExplicitlySet: false,
+        newTags: ["a"],
+        originalTags: ["a"],
+        newAlwaysLoad: false,
+        originalAlwaysLoad: false,
+      });
+      expect(fields).not.toContain("role");
+    });
+
+    it("reports tags when explicitly provided and changed", async () => {
+      const { computeFieldsModified } = await import("../src/update-detect-changes.js");
+      const fields = computeFieldsModified({
+        originalContent: "content",
+        newTitle: "Title",
+        originalTitle: "Title",
+        newLifecycle: "temporary",
+        originalLifecycle: "temporary",
+        roleExplicitlySet: false,
+        newTags: ["a", "b"],
+        originalTags: ["a"],
+        tagsExplicitlyProvided: true,
+        newAlwaysLoad: false,
+        originalAlwaysLoad: false,
+      });
+      expect(fields).toContain("tags");
+    });
+
+    it("does not report tags when not explicitly provided", async () => {
+      const { computeFieldsModified } = await import("../src/update-detect-changes.js");
+      const fields = computeFieldsModified({
+        originalContent: "content",
+        newTitle: "Title",
+        originalTitle: "Title",
+        newLifecycle: "temporary",
+        originalLifecycle: "temporary",
+        roleExplicitlySet: false,
+        newTags: ["a", "b"],
+        originalTags: ["a"],
+        tagsExplicitlyProvided: false,
+        newAlwaysLoad: false,
+        originalAlwaysLoad: false,
+      });
+      expect(fields).not.toContain("tags");
+    });
+
+    it("reports alwaysLoad when explicitly provided and changed", async () => {
+      const { computeFieldsModified } = await import("../src/update-detect-changes.js");
+      const fields = computeFieldsModified({
+        originalContent: "content",
+        newTitle: "Title",
+        originalTitle: "Title",
+        newLifecycle: "temporary",
+        originalLifecycle: "temporary",
+        roleExplicitlySet: false,
+        newTags: ["a"],
+        originalTags: ["a"],
+        newAlwaysLoad: true,
+        originalAlwaysLoad: false,
+        alwaysLoadExplicitlyProvided: true,
+      });
+      expect(fields).toContain("alwaysLoad");
+    });
+
+    it("does not report alwaysLoad when not explicitly provided", async () => {
+      const { computeFieldsModified } = await import("../src/update-detect-changes.js");
+      const fields = computeFieldsModified({
+        originalContent: "content",
+        newTitle: "Title",
+        originalTitle: "Title",
+        newLifecycle: "temporary",
+        originalLifecycle: "temporary",
+        roleExplicitlySet: false,
+        newTags: ["a"],
+        originalTags: ["a"],
+        newAlwaysLoad: true,
+        originalAlwaysLoad: false,
+        alwaysLoadExplicitlyProvided: false,
+      });
+      expect(fields).not.toContain("alwaysLoad");
+    });
+
+    it("returns empty array when nothing changed", async () => {
+      const { computeFieldsModified } = await import("../src/update-detect-changes.js");
+      const fields = computeFieldsModified({
+        originalContent: "content",
+        newTitle: "Title",
+        originalTitle: "Title",
+        newLifecycle: "temporary",
+        originalLifecycle: "temporary",
+        roleExplicitlySet: false,
+        newTags: ["a"],
+        originalTags: ["a"],
+        newAlwaysLoad: false,
+        originalAlwaysLoad: false,
+      });
+      expect(fields).toEqual([]);
+    });
+
+    it("reports relatedTo when auto-relationships were added", async () => {
+      const { computeFieldsModified } = await import("../src/update-detect-changes.js");
+      const fields = computeFieldsModified({
+        originalContent: "content",
+        newTitle: "Title",
+        originalTitle: "Title",
+        newLifecycle: "temporary",
+        originalLifecycle: "temporary",
+        roleExplicitlySet: false,
+        newTags: ["a"],
+        originalTags: ["a"],
+        newAlwaysLoad: false,
+        originalAlwaysLoad: false,
+        relatedToChanged: true,
+      });
+      expect(fields).toContain("relatedTo");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The `update` tool unconditionally bumped `updatedAt`, wrote the note, re-embedded, and committed — even when no content or metadata actually changed. This produced git commits with only a frontmatter timestamp diff and wasted embedding computation.

## Notes / References

_Detailed notes in `.mnemonic/notes/`:_

- `.mnemonic/notes/bug-fix-update-tool-no-op-detection-1031c864.md` — Bug fix: update tool no-op detection

---

_Generated from 1 design decision note(s) in `.mnemonic/notes/`. Run `/update-pr` to regenerate._