### PR TITLE
Semantic Path failure fallbacks

### DIFF
--- a/.mnemonic/notes/fix-semanticpatch-llm-usability-example-guidance-and-string--e7686b14.md
+++ b/.mnemonic/notes/fix-semanticpatch-llm-usability-example-guidance-and-string--e7686b14.md
@@ -6,13 +6,15 @@ tags:
   - llm-usability
 lifecycle: permanent
 createdAt: '2026-05-01T11:48:36.821Z'
-updatedAt: '2026-05-01T11:48:52.890Z'
+updatedAt: '2026-05-01T12:03:09.497Z'
 role: decision
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
   - id: semantic-patch-builder-design-implementation-906872f1
+    type: derives-from
+  - id: plan-fix-semanticpatch-failure-patterns-5d3771af
     type: derives-from
 memoryVersion: 1
 ---

--- a/.mnemonic/notes/fix-semanticpatch-llm-usability-example-guidance-and-string--e7686b14.md
+++ b/.mnemonic/notes/fix-semanticpatch-llm-usability-example-guidance-and-string--e7686b14.md
@@ -1,0 +1,41 @@
+---
+title: 'Fix: semanticPatch LLM usability — example, guidance, and string preprocess'
+tags:
+  - semantic-patch
+  - bug-fix
+  - llm-usability
+lifecycle: permanent
+createdAt: '2026-05-01T11:48:36.821Z'
+updatedAt: '2026-05-01T11:48:36.821Z'
+role: decision
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+## Fix: semanticPatch LLM usability — three root causes
+
+Three problems causing LLMs to waste tokens on `semanticPatch`:
+
+1. **Schema example used rejected operations**: The example in the `semanticPatch` description showed `appendChild` and `replaceChildren` with `heading` selectors — both are rejected by `getTargetChildren()` returning `undefined` for heading nodes. LLMs copied the example and got immediate failures. Fixed by replacing with `insertAfter` and `replace`.
+
+2. **Guidance text recommended rejected operations**: Line 2965 and line 6514 said "Use `appendChild` or `replace` instead" — but `appendChild` on headings also fails. Fixed to "Use `insertAfter` to add content under a heading, or `replace` to replace a heading entirely."
+
+3. **No string preprocess**: LLMs frequently pass `semanticPatch` as a JSON string literal instead of a proper JSON array. Zod rejected with a generic type error. Fixed by adding `z.preprocess()` that attempts `JSON.parse()` on string inputs and falls through for unparseable strings (letting Zod produce its normal validation error).
+
+### Validated operations on `heading` selectors
+
+- `insertAfter` — add content below a heading (most common intent)
+- `insertBefore` — add content above a heading
+- `replace` — replace the heading node entirely
+- `remove` — remove the heading
+
+### Invalid operations on `heading` selectors (return clear error)
+
+- `appendChild` — headings have inline text children, not block children
+- `prependChild` — same reason
+- `replaceChildren` — same reason
+
+### Version
+
+0.27.2

--- a/.mnemonic/notes/fix-semanticpatch-llm-usability-example-guidance-and-string--e7686b14.md
+++ b/.mnemonic/notes/fix-semanticpatch-llm-usability-example-guidance-and-string--e7686b14.md
@@ -6,11 +6,14 @@ tags:
   - llm-usability
 lifecycle: permanent
 createdAt: '2026-05-01T11:48:36.821Z'
-updatedAt: '2026-05-01T11:48:36.821Z'
+updatedAt: '2026-05-01T11:48:52.890Z'
 role: decision
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: semantic-patch-builder-design-implementation-906872f1
+    type: derives-from
 memoryVersion: 1
 ---
 ## Fix: semanticPatch LLM usability — three root causes

--- a/.mnemonic/notes/plan-fix-semanticpatch-failure-patterns-5d3771af.md
+++ b/.mnemonic/notes/plan-fix-semanticpatch-failure-patterns-5d3771af.md
@@ -1,0 +1,61 @@
+---
+title: 'Plan: Fix semanticPatch failure patterns'
+tags:
+  - workflow
+  - plan
+  - semantic-patch
+lifecycle: temporary
+createdAt: '2026-05-01T11:28:26.566Z'
+updatedAt: '2026-05-01T11:28:26.566Z'
+role: plan
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+## Plan
+
+### Fix 1: Add Zod preprocess to handle string-wrapped semanticPatch arrays
+
+**File:** `src/index.ts`
+**What:** Add a `z.preprocess()` on the `semanticPatch` field that detects string inputs and attempts `JSON.parse()`. If parsing fails, return the original value so Zod's natural validation produces its usual error. If parsing succeeds, pass the parsed array through for schema validation.
+
+**Why:** LLMs frequently wrap the JSON array in a string. Rather than relying on documentation alone, make the schema lenient on input and strict on semantics, following the existing principle of "schema-level guidance."
+
+**Scope:**
+
+- Add preprocess to the `semanticPatch` Zod schema
+- Add unit tests verifying string-wrapped arrays are parsed correctly
+- Add error tests verifying malformed strings still produce useful errors
+
+### Fix 2: Fix misleading documentation recommending `appendChild` for headings
+
+**Files:** `src/index.ts` (two locations)
+**What:** Change both instances of the guidance text:
+
+1. Line 2965: schema description — change "Use `appendChild` or `replace` instead" to "Use `insertAfter` to add block content under a heading, or `replace` to replace the heading entirely."
+2. Line 6514: workflow hint — same change.
+
+**Why:** The current text tells LLMs to use `appendChild` on headings, but the code rejects `appendChild` on headings with "Cannot appendChild to node of type 'heading'". This creates a retry loop.
+
+### Fix 3 (optional enhancement): Auto-redirect heading child operations
+
+**File:** `src/semantic-patch.ts`
+**What:** Instead of rejecting `appendChild`/`prependChild` on headings, auto-redirect:
+
+- `appendChild` on heading → `insertAfter` (semantically correct: "add content under the heading")
+- `prependChild` on heading → `insertAfter` (insert after heading, before existing body)
+- `replaceChildren` on heading → replace the heading text children (legitimate use case for changing heading wording)
+
+**Why:** Makes the API match LLM intuition. "Append under a heading" is the most natural intent and `insertAfter` is the correct implementation. Auto-redirect eliminates the entire class of errors.
+
+**Note:** This is a behavioral change. The simpler fix (Fix 2) is sufficient for now. Consider Fix 3 as a follow-up.
+
+## Checkboxes
+
+- [ ] Add Zod preprocess for string-wrapped semanticPatch arrays
+- [ ] Add tests for string input handling
+- [ ] Fix schema description guidance (line 2965)
+- [ ] Fix workflow hint guidance (line 6514)
+- [ ] Run existing test suite to verify no regressions
+- [ ] Update mnemonic research/plan notes

--- a/.mnemonic/notes/plan-fix-semanticpatch-failure-patterns-5d3771af.md
+++ b/.mnemonic/notes/plan-fix-semanticpatch-failure-patterns-5d3771af.md
@@ -6,13 +6,15 @@ tags:
   - semantic-patch
 lifecycle: temporary
 createdAt: '2026-05-01T11:28:26.566Z'
-updatedAt: '2026-05-01T12:02:58.190Z'
+updatedAt: '2026-05-01T12:03:03.372Z'
 role: plan
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
   - id: review-semanticpatch-llm-usability-fixes-4d4022ce
+    type: derives-from
+  - id: research-semanticpatch-failure-patterns-analysis-43e810a6
     type: derives-from
 memoryVersion: 1
 ---

--- a/.mnemonic/notes/plan-fix-semanticpatch-failure-patterns-5d3771af.md
+++ b/.mnemonic/notes/plan-fix-semanticpatch-failure-patterns-5d3771af.md
@@ -6,7 +6,7 @@ tags:
   - semantic-patch
 lifecycle: temporary
 createdAt: '2026-05-01T11:28:26.566Z'
-updatedAt: '2026-05-01T12:03:03.372Z'
+updatedAt: '2026-05-01T12:03:09.497Z'
 role: plan
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -15,6 +15,8 @@ relatedTo:
   - id: review-semanticpatch-llm-usability-fixes-4d4022ce
     type: derives-from
   - id: research-semanticpatch-failure-patterns-analysis-43e810a6
+    type: derives-from
+  - id: fix-semanticpatch-llm-usability-example-guidance-and-string--e7686b14
     type: derives-from
 memoryVersion: 1
 ---

--- a/.mnemonic/notes/plan-fix-semanticpatch-failure-patterns-5d3771af.md
+++ b/.mnemonic/notes/plan-fix-semanticpatch-failure-patterns-5d3771af.md
@@ -6,11 +6,14 @@ tags:
   - semantic-patch
 lifecycle: temporary
 createdAt: '2026-05-01T11:28:26.566Z'
-updatedAt: '2026-05-01T11:28:26.566Z'
+updatedAt: '2026-05-01T12:02:58.190Z'
 role: plan
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: review-semanticpatch-llm-usability-fixes-4d4022ce
+    type: derives-from
 memoryVersion: 1
 ---
 ## Plan

--- a/.mnemonic/notes/research-semanticpatch-failure-patterns-analysis-43e810a6.md
+++ b/.mnemonic/notes/research-semanticpatch-failure-patterns-analysis-43e810a6.md
@@ -7,13 +7,15 @@ tags:
   - bug
 lifecycle: temporary
 createdAt: '2026-05-01T11:27:01.925Z'
-updatedAt: '2026-05-01T12:02:56.881Z'
+updatedAt: '2026-05-01T12:03:03.372Z'
 role: research
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
   - id: review-semanticpatch-llm-usability-fixes-4d4022ce
+    type: derives-from
+  - id: plan-fix-semanticpatch-failure-patterns-5d3771af
     type: derives-from
 memoryVersion: 1
 ---

--- a/.mnemonic/notes/research-semanticpatch-failure-patterns-analysis-43e810a6.md
+++ b/.mnemonic/notes/research-semanticpatch-failure-patterns-analysis-43e810a6.md
@@ -1,0 +1,55 @@
+---
+title: 'Research: semanticPatch failure patterns analysis'
+tags:
+  - workflow
+  - research
+  - semantic-patch
+  - bug
+lifecycle: temporary
+createdAt: '2026-05-01T11:27:01.925Z'
+updatedAt: '2026-05-01T11:27:01.925Z'
+role: research
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+## Failure pattern 1: JSON parsing error — string instead of array
+
+LLMs (including strong models) pass `semanticPatch` as a JSON string literal instead of a JSON array. The MCP tool schema correctly defines it as `z.array(...)`, but LLMs serialize it as a string before invocation.
+
+**Root cause:** LLM construction problem, not a transport bug. MCP JSON-RPC serializes arrays correctly. The LLM wraps the array in quotes.
+
+**Current mitigations (already implemented):**
+
+- Schema description includes explicit type unions and a 3-patch working example
+- Workflow hint includes `### semanticPatch format` section with nesting example
+- "Common mistake" callout showing flattening error
+- "JSON array, NOT a string" reminder
+- Selector error messages include format reminder with corrected example
+
+**Assessment:** These mitigations address the symptom but the fundamental issue remains — LLM tool invocation frameworks sometimes serialize complex array parameters as strings. The Zod schema validates correctly at the server level, so malformed data gets caught, but the error experience is poor because the LLM gets an MCP validation error rather than a helpful diagnostic.
+
+**Potential improvement directions:**
+
+1. In the handler, detect when `semanticPatch` is a string and attempt `JSON.parse` with a helpful error message
+2. Extend the Zod schema with a preprocess step that parses string inputs
+3. Both of the above
+
+## Failure pattern 2: appendChild/replaceChildren on heading nodes
+
+When using `{ heading: "..." }` selector with `appendChild`, `prependChild`, or `replaceChildren`, the operation targets the heading node's own children (the heading text), not the body content below the heading.
+
+**Root cause:** In mdast, a heading node's `children` are the inline text/phrasing content children, not the block content that follows the heading. This is correct AST semantics but counter-intuitive for LLMs who expect "append under heading" to add body content after the heading.
+
+**Current mitigations (already implemented):**
+
+- `getTargetChildren()` returns `undefined` for heading nodes, causing explicit errors
+- Schema description and workflow hint provide guidance
+
+**Bug found:** Both the schema description (line 2965) and workflow hint (line 6514) say to use `appendChild` on headings, but `appendChild` on headings is REJECTED by the code. The correct guidance should be: "Use `insertAfter` to add content under a heading."
+
+**Fix for pattern 2:**
+
+1. Fix the misleading documentation in both places to recommend `insertAfter` instead of `appendChild`
+2. Consider whether `appendChild`/`prependChild`/`replaceChildren` on a heading selector should be auto-redirected to semantically equivalent operations instead of rejecting outright

--- a/.mnemonic/notes/research-semanticpatch-failure-patterns-analysis-43e810a6.md
+++ b/.mnemonic/notes/research-semanticpatch-failure-patterns-analysis-43e810a6.md
@@ -7,11 +7,14 @@ tags:
   - bug
 lifecycle: temporary
 createdAt: '2026-05-01T11:27:01.925Z'
-updatedAt: '2026-05-01T11:27:01.925Z'
+updatedAt: '2026-05-01T12:02:56.881Z'
 role: research
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: review-semanticpatch-llm-usability-fixes-4d4022ce
+    type: derives-from
 memoryVersion: 1
 ---
 ## Failure pattern 1: JSON parsing error — string instead of array

--- a/.mnemonic/notes/review-semanticpatch-llm-usability-fixes-4d4022ce.md
+++ b/.mnemonic/notes/review-semanticpatch-llm-usability-fixes-4d4022ce.md
@@ -6,13 +6,15 @@ tags:
   - semantic-patch
 lifecycle: temporary
 createdAt: '2026-05-01T12:02:05.224Z'
-updatedAt: '2026-05-01T12:02:56.881Z'
+updatedAt: '2026-05-01T12:02:58.190Z'
 role: review
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
   - id: research-semanticpatch-failure-patterns-analysis-43e810a6
+    type: derives-from
+  - id: plan-fix-semanticpatch-failure-patterns-5d3771af
     type: derives-from
 memoryVersion: 1
 ---

--- a/.mnemonic/notes/review-semanticpatch-llm-usability-fixes-4d4022ce.md
+++ b/.mnemonic/notes/review-semanticpatch-llm-usability-fixes-4d4022ce.md
@@ -6,11 +6,14 @@ tags:
   - semantic-patch
 lifecycle: temporary
 createdAt: '2026-05-01T12:02:05.224Z'
-updatedAt: '2026-05-01T12:02:05.224Z'
+updatedAt: '2026-05-01T12:02:56.881Z'
 role: review
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: research-semanticpatch-failure-patterns-analysis-43e810a6
+    type: derives-from
 memoryVersion: 1
 ---
 ## Review: semanticPatch LLM usability fixes

--- a/.mnemonic/notes/review-semanticpatch-llm-usability-fixes-4d4022ce.md
+++ b/.mnemonic/notes/review-semanticpatch-llm-usability-fixes-4d4022ce.md
@@ -1,0 +1,35 @@
+---
+title: 'Review: semanticPatch LLM usability fixes'
+tags:
+  - workflow
+  - review
+  - semantic-patch
+lifecycle: temporary
+createdAt: '2026-05-01T12:02:05.224Z'
+updatedAt: '2026-05-01T12:02:05.224Z'
+role: review
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+## Review: semanticPatch LLM usability fixes
+
+### Research requirements to Implementation coverage
+
+- Fix schema example (appendChild/replaceChildren with heading selectors to insertAfter/replace): **Covered** — example now uses insertAfter + replace + remove
+- Fix guidance text in 2 locations (appendChild to insertAfter): **Covered** — both schema description and workflow hint corrected
+- Add string preprocess for JSON arrays: **Covered** — z.preprocess auto-parses strings
+- Fix 3 (optional — auto-redirect heading child ops): **Deferred** — behavioral change, not needed now
+
+### Verification evidence (fresh, not reused from implementation)
+
+- Command: `npm run build && vitest` — Result: pass (827 tests)
+- Command: `vitest tests/update-sem-patch.integration.test.ts` — Result: pass (7 tests, including 2 new)
+- Command: dogfood via MCP local server — string-wrapped array auto-parsed, heading appendChild still rejected, schema description corrected
+
+### Unchecked items
+
+None — all plan checkboxes addressed.
+
+### Recommendation: continue

--- a/.mnemonic/notes/semantic-patch-builder-design-implementation-906872f1.md
+++ b/.mnemonic/notes/semantic-patch-builder-design-implementation-906872f1.md
@@ -10,13 +10,15 @@ tags:
   - implementation
 lifecycle: permanent
 createdAt: '2026-04-24T11:09:39.750Z'
-updatedAt: '2026-04-28T16:06:00.250Z'
+updatedAt: '2026-05-01T11:48:52.890Z'
 role: reference
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
   - id: theme-semantic-patch-improvements-lint-error-handling-headin-f2c4ced1
     type: explains
+  - id: fix-semanticpatch-llm-usability-example-guidance-and-string--e7686b14
+    type: derives-from
 memoryVersion: 1
 ---
 # Semantic Patch Builder: Design & Implementation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 
 ## [Unreleased]
 
+## [0.27.2] - 2026-05-01
+
+### Fixed
+
+- `semanticPatch` schema example and guidance now use `insertAfter` instead of the rejected `appendChild`/`replaceChildren` on `heading` selectors.
+- `semanticPatch` workflow hint corrected: recommends `insertAfter` for adding content under headings instead of `appendChild`, which the code rejects.
+- `semanticPatch` parameter now auto-parses string-wrapped JSON arrays, recovering gracefully when LLMs serialize the array as a string instead of a proper JSON array.
+
 ## [0.27.1] - 2026-04-28
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@danielmarbach/mnemonic-mcp",
-      "version": "0.27.1",
+      "version": "0.27.2",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.1",
         "gray-matter": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "description": "A local MCP memory server backed by markdown + JSON files, synced via git",
   "type": "module",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2927,7 +2927,14 @@ server.registerTool(
     inputSchema: z.object({
       id: z.string().describe("Exact memory id. Use an id returned by `recall`, `list`, `recent_memories`, or `where_is`."),
       semanticPatch: z
-        .array(z.object({
+        .preprocess(
+          (val) => {
+            if (typeof val === "string") {
+              try { return JSON.parse(val); } catch { return val; }
+            }
+            return val;
+          },
+          z.array(z.object({
           selector: z.object({
             heading: z.string().optional(),
             headingStartsWith: z.string().optional(),
@@ -2949,20 +2956,20 @@ server.registerTool(
             z.object({ op: z.literal("insertBefore"), value: z.string() }),
             z.object({ op: z.literal("remove") }),
           ]),
-        }))
+        })))
         .optional()
         .describe(
           "Targeted edits to note sections. Array of {selector, operation} objects. Mutually exclusive with content. " +
           "If this fails, fix the issue in your patch values and retry — do NOT fall back to full content rewrite.\n\n" +
           "selector: exactly one of { heading: \"exact heading text\" } | { headingStartsWith: \"prefix\" } | { lastChild: true } | { nthChild: 0-based-index }\n" +
           "operation: { op: \"appendChild\", value: \"content\" } | { op: \"prependChild\", value: \"content\" } | { op: \"replace\", value: \"new content\" } | { op: \"replaceChildren\", value: \"new children\" } | { op: \"insertAfter\", value: \"content\" } | { op: \"insertBefore\", value: \"content\" } | { op: \"remove\" }\n\n" +
-          "Example — append a paragraph under ## Findings, replace ## Recommendation body, remove ## Old Section:\n" +
+          "Example — add a paragraph under ## Findings, replace body under ## Recommendation, remove ## Old Section:\n" +
           "[\n" +
-          "  { \"selector\": { \"heading\": \"Findings\" }, \"operation\": { \"op\": \"appendChild\", \"value\": \"A new paragraph.\" } },\n" +
-          "  { \"selector\": { \"heading\": \"Recommendation\" }, \"operation\": { \"op\": \"replaceChildren\", \"value\": \"Updated recommendation.\" } },\n" +
+          "  { \"selector\": { \"heading\": \"Findings\" }, \"operation\": { \"op\": \"insertAfter\", \"value\": \"A new paragraph.\" } },\n" +
+          "  { \"selector\": { \"heading\": \"Recommendation\" }, \"operation\": { \"op\": \"replace\", \"value\": \"## Recommendation\\n\\nUpdated recommendation.\" } },\n" +
           "  { \"selector\": { \"heading\": \"Old Section\" }, \"operation\": { \"op\": \"remove\" } }\n" +
           "]\n\n" +
-          "`replaceChildren` on a `heading` selector targets the heading itself, not the body below it. Use `appendChild` or `replace` instead."
+          "IMPORTANT: `appendChild`, `prependChild`, and `replaceChildren` do NOT work with `heading` selectors (headings only contain inline text, not block content). To add or replace content under a heading, use `insertAfter`. To replace a heading entirely, use `replace`."
         ),
       content: z.string().optional().describe("Full note body replacement. Use only for complete rewrites or when the note is small. Mutually exclusive with semanticPatch."),
       title: z.string().optional().describe("Specific, retrieval-friendly title. Prefer the concrete topic or decision, not a vague label."),
@@ -6510,8 +6517,8 @@ server.registerPrompt(
             "- `operation` has an `op` key plus `value` (except `remove` which has no value).\n" +
             "- The parameter must be a JSON array, NOT a string.\n" +
             "- Use `get` first to read exact heading text, then use those headings (without `##` prefix) as selector values.\n" +
-            "- Common mistake: writing `{ \"op\": \"appendChild\", \"value\": \"...\" }` at the top level instead of nesting inside `operation`. Correct shape: `{ \"selector\": { \"heading\": \"Findings\" }, \"operation\": { \"op\": \"appendChild\", \"value\": \"text\" } }`\n" +
-            "- `replaceChildren` on a `heading` selector targets the heading itself, not the body below it. Use `appendChild` or `replace` instead.",
+            "- Common mistake: writing `{ \"op\": \"appendChild\", \"value\": \"...\" }` at the top level instead of nesting inside `operation`. Correct shape: `{ \"selector\": { \"heading\": \"Findings\" }, \"operation\": { \"op\": \"insertAfter\", \"value\": \"text\" } }`\n" +
+            "- `appendChild`, `prependChild`, and `replaceChildren` do NOT work with `heading` selectors. To add content under a heading, use `insertAfter`. To replace a heading, use `replace`.",
         },
       },
     ],

--- a/tests/update-sem-patch.integration.test.ts
+++ b/tests/update-sem-patch.integration.test.ts
@@ -153,4 +153,59 @@ describe("update with semanticPatch", () => {
 
     await session.close();
   }, 15000);
+
+  it("accepts string-wrapped JSON array for semanticPatch", async () => {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-update-test-"));
+    tempDirs.push(vaultDir);
+    await initTestRepo(vaultDir, "main");
+
+    const session = await createPersistentMcpSession(vaultDir, { disableGit: true });
+
+    const rememberResult = await session.callTool("remember", {
+      title: "String Patch Test",
+      content: "# String Patch Test\n\n## Findings\n\nOriginal finding.\n",
+      lifecycle: "temporary",
+    });
+    const idMatch = rememberResult.text.match(/`([^`]+)`/);
+    expect(idMatch).not.toBeNull();
+    const noteId = idMatch![1];
+
+    const updateResult = await session.callTool("update", {
+      id: noteId,
+      semanticPatch: JSON.stringify([{ selector: { heading: "Findings" }, operation: { op: "insertAfter", value: "Patched via string." } }]) as any,
+    });
+
+    expect(updateResult.text).toContain("Updated memory");
+
+    const getResult = await session.callTool("get", { ids: [noteId] });
+    expect(getResult.text).toContain("Patched via string.");
+
+    await session.close();
+  }, 15000);
+
+  it("rejects malformed string for semanticPatch", async () => {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-update-test-"));
+    tempDirs.push(vaultDir);
+    await initTestRepo(vaultDir, "main");
+
+    const session = await createPersistentMcpSession(vaultDir, { disableGit: true });
+
+    const rememberResult = await session.callTool("remember", {
+      title: "Bad String Test",
+      content: "# Bad String Test\n\nContent.\n",
+      lifecycle: "temporary",
+    });
+    const idMatch = rememberResult.text.match(/`([^`]+)`/);
+    expect(idMatch).not.toBeNull();
+    const noteId = idMatch![1];
+
+    const updateResult = await session.callTool("update", {
+      id: noteId,
+      semanticPatch: "not valid json" as any,
+    });
+
+    expect(updateResult.text).toContain("error");
+
+    await session.close();
+  }, 15000);
 });


### PR DESCRIPTION
## Summary

This PR captures the following design decisions:

- **Semantic Patch Builder: Design & Implementation**
- **Fix: semanticPatch LLM usability — example, guidance, and string preprocess**

## Changes

### Semantic Patch Builder: Design & Implementation

**Tags:** design, ast, semantic-patch, update, markdown, plan, implementation

The `update` tool required passing the entire note `content` for even trivial edits. This wasted tokens on large notes.

### Fix: semanticPatch LLM usability — example, guidance, and string preprocess

**Tags:** semantic-patch, bug-fix, llm-usability

Three problems causing LLMs to waste tokens on `semanticPatch`:

## Workflow Artifacts

**Research:**

- Research: semanticPatch failure patterns analysis — LLMs (including strong models) pass `semanticPatch` as a JSON string literal instead of a JSON array.

**Plan:**

- Plan: Fix semanticPatch failure patterns — **File:** `src/index.ts`
**What:** Add a `z.preprocess()` on the `semanticPatch` field that detects string inputs and attempts `JSON.parse()`.

## Notes / References

_Detailed notes in `.mnemonic/notes/`:_

- `.mnemonic/notes/research-semanticpatch-failure-patterns-analysis-43e810a6.md` — Research: semanticPatch failure patterns analysis _(research)_
- `.mnemonic/notes/semantic-patch-builder-design-implementation-906872f1.md` — Semantic Patch Builder: Design & Implementation
- `.mnemonic/notes/fix-semanticpatch-llm-usability-example-guidance-and-string--e7686b14.md` — Fix: semanticPatch LLM usability — example, guidance, and string preprocess
- `.mnemonic/notes/plan-fix-semanticpatch-failure-patterns-5d3771af.md` — Plan: Fix semanticPatch failure patterns _(plan)_

---

_Generated from 4 design decision note(s) in `.mnemonic/notes/`. Run `/update-pr` to regenerate._