### PR TITLE
MarkdownLintError propagates as a raw MCP tool error with no actionable guidance

### DIFF
--- a/.mnemonic/notes/markdown-linting-for-memory-content-259a1c85.md
+++ b/.mnemonic/notes/markdown-linting-for-memory-content-259a1c85.md
@@ -7,7 +7,7 @@ tags:
   - dogfooding
 lifecycle: permanent
 createdAt: '2026-03-07T18:37:11.013Z'
-updatedAt: '2026-03-07T18:42:51.656Z'
+updatedAt: '2026-05-01T12:53:00.975Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
@@ -24,5 +24,17 @@ Implementation details:
 - Reject non-fixable issues after auto-fix so low-quality markdown does not get stored.
 - Disable `MD013` (line length) and `MD041` (first line must be an H1) because note bodies are content fragments, not standalone documents.
 - `get`, `relate`, `unrelate`, and `forget` now accept `cwd` so a fresh project-scoped server can resolve project-vault notes reliably.
+
+### Error handling for `remember` and `update(content)`
+
+When `remember` or `update(content)` fails lint validation, the tool catches `MarkdownLintError` and returns a structured error response with:
+
+- `content`: actionable text telling the LLM to fix the specific lint issues and retry, with explicit "note was NOT stored" messaging
+- `structuredContent`: `LintErrorResult` with `action: "lint_error"`, `tool: "remember" | "update"`, and `issues: string[]`
+- `isError: true`
+
+This mirrors the pattern already used for `semanticPatch` lint errors, which returns advisory guidance instead of a raw exception.
+
+The `content` parameter description for both `remember` and `update` also includes proactive schema-level guidance about markdown lint requirements (auto-fixable vs. unfixable issues, common gotchas like MD040 fenced code blocks needing language tags).
 
 Dogfooding note: the repo MCP server was rebuilt locally and this note was created and related through the local `mnemonic` MCP server, not by writing the vault files directly.

--- a/.mnemonic/notes/plan-add-actionable-lint-error-guidance-to-remember-and-upda-86542d51.md
+++ b/.mnemonic/notes/plan-add-actionable-lint-error-guidance-to-remember-and-upda-86542d51.md
@@ -1,0 +1,76 @@
+---
+title: 'Plan: Add actionable lint error guidance to remember and update'
+tags:
+  - workflow
+  - plan
+  - linting
+  - error-handling
+lifecycle: temporary
+createdAt: '2026-05-01T12:14:25.947Z'
+updatedAt: '2026-05-01T12:14:25.947Z'
+role: plan
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+relatedTo:
+  - id: markdown-linting-for-memory-content-259a1c85
+    type: related-to
+  - id: semantic-patch-builder-design-implementation-906872f1
+    type: related-to
+memoryVersion: 1
+---
+## Context
+
+request root: research-remember-update-lint-error-lacking-llm-retry-guidan-505523cc
+
+Problem: LLMs sometimes ignore markdown lint errors from `remember`/`update(content)` and carry on as if the note was stored. The root cause is missing try/catch with actionable retry guidance — the `semanticPatch` path already has this.
+
+## Plan
+
+### Fix 1: Add try/catch for MarkdownLintError in `remember` handler
+
+**File:** `src/index.ts` (around line 1963)
+**What:** Wrap `const cleanedContent = await cleanMarkdown(content);` in a try/catch that catches `MarkdownLintError` and returns a structured MCP error response with:
+
+```text
+Markdown lint issues prevented this note from being stored. Fix the specific lint errors listed below in your content and retry the remember call — the note was NOT stored.
+
+{err.message}
+```
+
+**Why:** `cleanMarkdown` throws `MarkdownLintError` for unfixable lint. Without a catch, this propagates as a generic MCP error with no actionable guidance. LLMs see the error but don't know they should fix and retry, so they sometimes carry on.
+
+### Fix 2: Add try/catch for MarkdownLintError in `update(content)` handler
+
+**File:** `src/index.ts` (around line 3061)
+**What:** Wrap `const cleanedContent = content === undefined ? undefined : await cleanMarkdown(content);` in a try/catch that catches `MarkdownLintError` and returns a structured MCP error response with:
+
+```text
+Markdown lint issues prevented the update. Fix the specific lint errors listed below in your content and retry — do NOT fall back to semanticPatch for this.
+
+{err.message}
+```
+
+**Why:** Same problem as `remember`. The `update` handler already catches lint errors from `semanticPatch` but not from the `content` path.
+
+### Fix 3: Add markdown lint guidance to `content` parameter description
+
+**File:** `src/index.ts`
+**What:** Add a brief note to the `content` parameter description in both `remember` and `update` tools mentioning:
+
+- Content must pass markdown lint (auto-fixable issues are fixed automatically)
+- Common unfixable issues: fenced code blocks need language tags, broken links
+- If lint fails, fix the specific issues and retry
+
+**Why:** Following the existing design principle from `semantic-patch-builder-design-implementation` — "Guidance at the Schema Level, Not Just Error Messages." Schema-level guidance fires before the handler runs, preventing wasted retries. LLMs commonly produce fenced code blocks without language tags (MD040).
+
+### Fix 4: Update the linting decision note
+
+**What:** Update `markdown-linting-for-memory-content-259a1c85` to document the new error handling approach: `remember` and `update(content)` now catch `MarkdownLintError` and return structured errors with retry guidance, mirroring the `semanticPatch` pattern.
+
+## Checkboxes
+
+- [ ] Add try/catch for MarkdownLintError in remember handler
+- [ ] Add try/catch for MarkdownLintError in update(content) handler
+- [ ] Add lint guidance to content parameter descriptions
+- [ ] Update linting decision note

--- a/.mnemonic/notes/plan-add-actionable-lint-error-guidance-to-remember-and-upda-86542d51.md
+++ b/.mnemonic/notes/plan-add-actionable-lint-error-guidance-to-remember-and-upda-86542d51.md
@@ -7,7 +7,7 @@ tags:
   - error-handling
 lifecycle: temporary
 createdAt: '2026-05-01T12:14:25.947Z'
-updatedAt: '2026-05-01T12:14:25.947Z'
+updatedAt: '2026-05-01T12:14:40.977Z'
 role: plan
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -17,6 +17,8 @@ relatedTo:
     type: related-to
   - id: semantic-patch-builder-design-implementation-906872f1
     type: related-to
+  - id: research-remember-update-lint-error-lacking-llm-retry-guidan-505523cc
+    type: derives-from
 memoryVersion: 1
 ---
 ## Context

--- a/.mnemonic/notes/plan-add-actionable-lint-error-guidance-to-remember-and-upda-86542d51.md
+++ b/.mnemonic/notes/plan-add-actionable-lint-error-guidance-to-remember-and-upda-86542d51.md
@@ -7,7 +7,7 @@ tags:
   - error-handling
 lifecycle: temporary
 createdAt: '2026-05-01T12:14:25.947Z'
-updatedAt: '2026-05-01T12:45:51.493Z'
+updatedAt: '2026-05-01T12:56:21.212Z'
 role: plan
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -18,6 +18,8 @@ relatedTo:
   - id: semantic-patch-builder-design-implementation-906872f1
     type: related-to
   - id: research-remember-update-lint-error-lacking-llm-retry-guidan-505523cc
+    type: derives-from
+  - id: review-add-actionable-lint-error-guidance-to-remember-and-up-f7c923f9
     type: derives-from
 memoryVersion: 1
 ---

--- a/.mnemonic/notes/plan-add-actionable-lint-error-guidance-to-remember-and-upda-86542d51.md
+++ b/.mnemonic/notes/plan-add-actionable-lint-error-guidance-to-remember-and-upda-86542d51.md
@@ -7,7 +7,7 @@ tags:
   - error-handling
 lifecycle: temporary
 createdAt: '2026-05-01T12:14:25.947Z'
-updatedAt: '2026-05-01T12:14:40.977Z'
+updatedAt: '2026-05-01T12:45:51.493Z'
 role: plan
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -27,52 +27,64 @@ request root: research-remember-update-lint-error-lacking-llm-retry-guidan-50552
 
 Problem: LLMs sometimes ignore markdown lint errors from `remember`/`update(content)` and carry on as if the note was stored. The root cause is missing try/catch with actionable retry guidance — the `semanticPatch` path already has this.
 
+**Self-dogfooding evidence:** In this very conversation, the first `remember` call for the research note hit MD040 (fenced code blocks without language tags). The raw error gave no guidance — I had to manually know to fix the lint issues and retry. This is exactly the problem we're fixing.
+
+**structuredContent pattern:** The project consistently returns both `content` (text for LLM) and `structuredContent` (machine-readable data) from tool handlers. Error responses must follow this same dual pattern. `UpdateResult` already has `lintWarnings?: string[]`. For lint error rejections, we need a `LintErrorResult` with `action: "lint_error"`, `tool`, and `issues`.
+
 ## Plan
 
-### Fix 1: Add try/catch for MarkdownLintError in `remember` handler
+### Fix 1: Add LintErrorResult to structured-content.ts
+
+**File:** `src/structured-content.ts`
+**What:** Add a `LintErrorResult` interface and `LintErrorResultSchema`:
+
+- `action: "lint_error"`
+- `tool: "remember" | "update"`
+- `issues: string[]`
+
+**Why:** Error responses need structured content too, not just text. This follows the project's dual-response pattern.
+
+### Fix 2: Add try/catch for MarkdownLintError in `remember` handler
 
 **File:** `src/index.ts` (around line 1963)
-**What:** Wrap `const cleanedContent = await cleanMarkdown(content);` in a try/catch that catches `MarkdownLintError` and returns a structured MCP error response with:
+**What:** Wrap `const cleanedContent = await cleanMarkdown(content);` in a try/catch that catches `MarkdownLintError` and returns:
 
-```text
-Markdown lint issues prevented this note from being stored. Fix the specific lint errors listed below in your content and retry the remember call — the note was NOT stored.
+- `content`: text message "Markdown lint issues prevented this note from being stored. Fix the specific lint errors listed below in your content and retry the remember call — the note was NOT stored.\n\n{err.message}"
+- `structuredContent`: `LintErrorResult` with `action: "lint_error"`, `tool: "remember"`, `issues: err.issues`
+- `isError: true`
 
-{err.message}
-```
+**Why:** `cleanMarkdown` throws `MarkdownLintError` for unfixable lint. Without a catch, this propagates as a generic MCP error with no actionable guidance. LLMs see the error but don't know they should fix and retry.
 
-**Why:** `cleanMarkdown` throws `MarkdownLintError` for unfixable lint. Without a catch, this propagates as a generic MCP error with no actionable guidance. LLMs see the error but don't know they should fix and retry, so they sometimes carry on.
-
-### Fix 2: Add try/catch for MarkdownLintError in `update(content)` handler
+### Fix 3: Add try/catch for MarkdownLintError in `update(content)` handler
 
 **File:** `src/index.ts` (around line 3061)
-**What:** Wrap `const cleanedContent = content === undefined ? undefined : await cleanMarkdown(content);` in a try/catch that catches `MarkdownLintError` and returns a structured MCP error response with:
+**What:** Wrap `const cleanedContent = content === undefined ? undefined : await cleanMarkdown(content);` in a try/catch with the same dual-response pattern:
 
-```text
-Markdown lint issues prevented the update. Fix the specific lint errors listed below in your content and retry — do NOT fall back to semanticPatch for this.
+- `content`: text message "Markdown lint issues prevented the update. Fix the specific lint errors in your content and retry — do NOT fall back to semanticPatch for this.\n\n{err.message}"
+- `structuredContent`: `LintErrorResult` with `action: "lint_error"`, `tool: "update"`, `issues: err.issues`
+- `isError: true`
 
-{err.message}
-```
+**Why:** Same problem as `remember`. The `update` handler already catches lint errors from `semanticPatch` but not from the `content` path. The "do NOT fall back to semanticPatch" text mirrors the existing semanticPatch lint error message pattern.
 
-**Why:** Same problem as `remember`. The `update` handler already catches lint errors from `semanticPatch` but not from the `content` path.
-
-### Fix 3: Add markdown lint guidance to `content` parameter description
+### Fix 4: Add markdown lint guidance to `content` parameter description
 
 **File:** `src/index.ts`
 **What:** Add a brief note to the `content` parameter description in both `remember` and `update` tools mentioning:
 
 - Content must pass markdown lint (auto-fixable issues are fixed automatically)
-- Common unfixable issues: fenced code blocks need language tags, broken links
-- If lint fails, fix the specific issues and retry
+- Common unfixable issues: fenced code blocks need language tags (e.g. use `text` not bare fences), broken links
+- If lint fails, fix the specific issues listed in the error and retry
 
-**Why:** Following the existing design principle from `semantic-patch-builder-design-implementation` — "Guidance at the Schema Level, Not Just Error Messages." Schema-level guidance fires before the handler runs, preventing wasted retries. LLMs commonly produce fenced code blocks without language tags (MD040).
+**Why:** Following the existing design principle from `semantic-patch-builder-design-implementation` — "Guidance at the Schema Level, Not Just Error Messages." Schema-level guidance fires before the handler runs, preventing wasted retries. MD040 is the most common LLM-triggered lint failure (fenced code blocks without language tags).
 
-### Fix 4: Update the linting decision note
+### Fix 5: Update the linting decision note
 
-**What:** Update `markdown-linting-for-memory-content-259a1c85` to document the new error handling approach: `remember` and `update(content)` now catch `MarkdownLintError` and return structured errors with retry guidance, mirroring the `semanticPatch` pattern.
+**What:** Update `markdown-linting-for-memory-content-259a1c85` to document the new error handling approach: `remember` and `update(content)` now catch `MarkdownLintError` and return structured errors with retry guidance + `LintErrorResult` structured content, mirroring the `semanticPatch` pattern.
 
 ## Checkboxes
 
-- [ ] Add try/catch for MarkdownLintError in remember handler
-- [ ] Add try/catch for MarkdownLintError in update(content) handler
+- [ ] Add LintErrorResult interface and schema to structured-content.ts
+- [ ] Add try/catch for MarkdownLintError in remember handler (text + structuredContent)
+- [ ] Add try/catch for MarkdownLintError in update(content) handler (text + structuredContent)
 - [ ] Add lint guidance to content parameter descriptions
 - [ ] Update linting decision note

--- a/.mnemonic/notes/research-remember-update-lint-error-lacking-llm-retry-guidan-505523cc.md
+++ b/.mnemonic/notes/research-remember-update-lint-error-lacking-llm-retry-guidan-505523cc.md
@@ -7,7 +7,7 @@ tags:
   - error-handling
 lifecycle: temporary
 createdAt: '2026-05-01T12:13:34.565Z'
-updatedAt: '2026-05-01T12:13:34.565Z'
+updatedAt: '2026-05-01T12:14:40.977Z'
 role: research
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -15,6 +15,8 @@ projectName: mnemonic
 relatedTo:
   - id: markdown-linting-for-memory-content-259a1c85
     type: related-to
+  - id: plan-add-actionable-lint-error-guidance-to-remember-and-upda-86542d51
+    type: derives-from
 memoryVersion: 1
 ---
 ## Problem

--- a/.mnemonic/notes/research-remember-update-lint-error-lacking-llm-retry-guidan-505523cc.md
+++ b/.mnemonic/notes/research-remember-update-lint-error-lacking-llm-retry-guidan-505523cc.md
@@ -1,0 +1,78 @@
+---
+title: 'Research: Remember/Update lint error lacking LLM retry guidance'
+tags:
+  - workflow
+  - research
+  - linting
+  - error-handling
+lifecycle: temporary
+createdAt: '2026-05-01T12:13:34.565Z'
+updatedAt: '2026-05-01T12:13:34.565Z'
+role: research
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+relatedTo:
+  - id: markdown-linting-for-memory-content-259a1c85
+    type: related-to
+memoryVersion: 1
+---
+## Problem
+
+When `remember` or `update(content)` fails due to markdown lint errors, the `MarkdownLintError` propagates as a raw MCP tool error with no actionable guidance. LLMs see the lint issues but:
+
+1. Don't understand they should fix the specific lint errors and retry the same tool call
+2. Sometimes carry on as if the note was successfully written
+3. Don't get clear "this note was NOT stored" messaging
+
+In contrast, `update(semanticPatch)` has explicit try/catch (lines 3048-3059 in `src/index.ts`) with actionable messages like "Fix the lint issues in your patch values and retry — do NOT fall back to full content rewrite."
+
+## Root Cause
+
+`remember` calls `cleanMarkdown(content)` at line 1963 with NO try/catch. `update(content)` calls `cleanMarkdown(content)` at line 3061 with NO try/catch. The `MarkdownLintError` just propagates as a generic MCP error.
+
+`MarkdownLintError.message` format is:
+
+```text
+Markdown lint failed:
+- line 200: MD040/fenced-code-language Fenced code blocks should have a language specified (```)
+```
+
+This tells the LLM *what* is wrong but not *what to do* (fix and retry).
+
+## Contrast with semanticPatch
+
+The `semanticPatch` path (lines 3048-3059) catches `MarkdownLintError` explicitly and returns:
+
+```text
+Semantic patch produced content with markdown lint issues. Fix the lint issues in your patch values and retry — do NOT fall back to full content rewrite.
+
+Markdown lint failed:
+- ...
+```
+
+This is returned as `{ content: [{ type: "text", text: message }], isError: true }` — a structured MCP error response, not an unhandled exception.
+
+## What We Need
+
+1. Wrap `cleanMarkdown` calls in `remember` and `update(content)` with try/catch for `MarkdownLintError`
+2. Return a structured MCP error with clear guidance: fix the specific lint issues and retry
+3. Make explicit that the note was NOT stored — the current raw error doesn't convey this clearly enough
+4. Consider if the `content` parameter description should mention markdown lint requirements proactively (some lint rules like MD040 are common gotchas for LLMs generating fenced code blocks without language tags)
+
+## Code Locations
+
+- `src/markdown.ts:28-33` — `MarkdownLintError` class definition
+- `src/markdown.ts:62-68` — `cleanMarkdown` throws on unfixable warnings
+- `src/index.ts:1963` — `remember` handler calls `cleanMarkdown` without try/catch
+- `src/index.ts:3061` — `update` handler calls `cleanMarkdown` for content path without try/catch
+- `src/index.ts:3048-3059` — `update` handler for `semanticPatch` has proper try/catch with actionable message (reference implementation)
+
+## Existing Design Decision
+
+The permanent note `markdown-linting-for-memory-content-259a1c85` says:
+
+- Auto-apply fixable issues, reject non-fixable issues after auto-fix
+- MD013 (line length) and MD041 (first line H1) are disabled
+
+The design is sound. The gap is in error communication, not in the linting logic itself.

--- a/.mnemonic/notes/review-add-actionable-lint-error-guidance-to-remember-and-up-f7c923f9.md
+++ b/.mnemonic/notes/review-add-actionable-lint-error-guidance-to-remember-and-up-f7c923f9.md
@@ -1,0 +1,39 @@
+---
+title: 'Review: Add actionable lint error guidance to remember and update'
+tags:
+  - workflow
+  - review
+  - linting
+  - error-handling
+lifecycle: temporary
+createdAt: '2026-05-01T12:56:17.051Z'
+updatedAt: '2026-05-01T12:56:17.051Z'
+role: review
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+## Implementation Summary
+
+Implemented 5 changes to add actionable lint error handling for `remember` and `update(content)`:
+
+1. **LintErrorResult** (`src/structured-content.ts`): Added interface and Zod schema for structured error responses with `action: "lint_error"`, `tool: "remember" | "update"`, `issues: string[]`.
+
+2. **Remember handler try/catch** (`src/index.ts:1962-1975`): Catches `MarkdownLintError` from `cleanMarkdown` and returns dual response (text + structuredContent) with "note was NOT stored" guidance and `isError: true`.
+
+3. **Update(content) handler try/catch** (`src/index.ts:3076-3092`): Same pattern, with "do NOT fall back to semanticPatch" guidance mirroring the existing semanticPatch lint error message.
+
+4. **Content parameter descriptions** (`src/index.ts:1902-1906`, `src/index.ts:2993`): Added proactive lint guidance (auto-fixable vs. unfixable, MD040 common gotcha, fix-and-retry instruction).
+
+5. **Linting decision note** updated with the new error handling approach.
+
+## Verification
+
+- TypeCheck: clean (0 errors)
+- Unit tests: 827 pass, 0 fail
+- 1 pre-existing MCP integration test failure (missing export `applyCanonicalExplanationPromotion`) — not related to these changes
+
+## Dogfooding observation
+
+This fix was triggered by an exact self-dogfooding incident: the first `remember` call in this conversation failed with MD040 (fenced code blocks without language tags), and the raw error provided no guidance to fix and retry. After implementing the fix, the same pattern would now produce a clear actionable message.

--- a/.mnemonic/notes/review-add-actionable-lint-error-guidance-to-remember-and-up-f7c923f9.md
+++ b/.mnemonic/notes/review-add-actionable-lint-error-guidance-to-remember-and-up-f7c923f9.md
@@ -7,11 +7,14 @@ tags:
   - error-handling
 lifecycle: temporary
 createdAt: '2026-05-01T12:56:17.051Z'
-updatedAt: '2026-05-01T12:56:17.051Z'
+updatedAt: '2026-05-01T12:56:21.212Z'
 role: review
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: plan-add-actionable-lint-error-guidance-to-remember-and-upda-86542d51
+    type: derives-from
 memoryVersion: 1
 ---
 ## Implementation Summary

--- a/.mnemonic/notes/semantic-patch-builder-design-implementation-906872f1.md
+++ b/.mnemonic/notes/semantic-patch-builder-design-implementation-906872f1.md
@@ -10,7 +10,7 @@ tags:
   - implementation
 lifecycle: permanent
 createdAt: '2026-04-24T11:09:39.750Z'
-updatedAt: '2026-05-01T11:48:52.890Z'
+updatedAt: '2026-05-01T12:14:42.455Z'
 role: reference
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
@@ -18,6 +18,8 @@ relatedTo:
   - id: theme-semantic-patch-improvements-lint-error-handling-headin-f2c4ced1
     type: explains
   - id: fix-semanticpatch-llm-usability-example-guidance-and-string--e7686b14
+    type: derives-from
+  - id: plan-add-actionable-lint-error-guidance-to-remember-and-upda-86542d51
     type: derives-from
 memoryVersion: 1
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 
 ### Fixed
 
+- `remember` and `update(content)` now return structured error responses with actionable retry guidance when markdown lint fails, instead of propagating raw errors that LLMs sometimes ignore.
+- `remember` and `update` `content` parameter descriptions include proactive lint guidance (auto-fixable vs. unfixable issues, common MD040 fenced-code-language gotcha).
+
+### Changed
+
 - `semanticPatch` schema example and guidance now use `insertAfter` instead of the rejected `appendChild`/`replaceChildren` on `heading` selectors.
 - `semanticPatch` workflow hint corrected: recommends `insertAfter` for adding content under headings instead of `appendChild`, which the code rejects.
 - `semanticPatch` parameter now auto-parses string-wrapped JSON arrays, recovering gracefully when LLMs serialize the array as a string instead of a proper JSON array.

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,7 +135,8 @@ import type {
   AnchorNote,
   RelationshipPreview,
   RetrievalEvidence,
-  ConsolidateExecuteMergeEvidence,
+   ConsolidateExecuteMergeEvidence,
+   LintErrorResult,
 } from "./structured-content.js";
 import {
   RememberResultSchema,
@@ -157,6 +158,7 @@ import {
   MigrationExecuteResultSchema,
   PolicyResultSchema,
   DiscoverTagsResultSchema,
+  LintErrorResultSchema,
 } from "./structured-content.js";
 
 // ── CLI Migration Command ─────────────────────────────────────────────────────
@@ -1898,7 +1900,9 @@ server.registerTool(
     inputSchema: z.object({
       title: z.string().describe("Specific, retrieval-friendly title. Prefer the concrete topic or decision, not a vague label."),
       content: z.string().describe(
-        "Markdown note body. Put the key fact, decision, or outcome in the opening lines, then supporting detail. Embeddings weight early content more heavily."
+        "Markdown note body. Put the key fact, decision, or outcome in the opening lines, then supporting detail. Embeddings weight early content more heavily. " +
+        "Content must pass markdown lint. Auto-fixable issues are fixed automatically. Common unfixable issues: fenced code blocks need a language tag (e.g. use ```text not bare ```), and broken links are rejected. " +
+        "If lint fails, fix the specific issues listed in the error and retry the same call."
       ),
       tags: z.array(z.string()).optional().default([]).describe("Optional tags for later filtering. Use a small number of stable, meaningful tags."),
       lifecycle: z
@@ -1960,7 +1964,20 @@ server.registerTool(
     await ensureBranchSynced(cwd);
 
     const project = await resolveProject(cwd);
-    const cleanedContent = await cleanMarkdown(content);
+    let cleanedContent: string;
+    try {
+      cleanedContent = await cleanMarkdown(content);
+    } catch (err) {
+      if (err instanceof MarkdownLintError) {
+        const message = `Markdown lint issues prevented this note from being stored. Fix the specific lint errors listed below in your content and retry the remember call — the note was NOT stored.\n\n${err.message}`;
+        return {
+          content: [{ type: "text" as const, text: message }],
+          structuredContent: { action: "lint_error", tool: "remember", issues: err.issues } as LintErrorResult,
+          isError: true,
+        };
+      }
+      throw err;
+    }
     const policy = project ? await configStore.getProjectPolicy(project.id) : undefined;
     const policyScope = policy?.defaultScope;
     const projectVaultExists = cwd ? Boolean(await vaultManager.getProjectVaultIfExists(cwd)) : true;
@@ -2971,7 +2988,7 @@ server.registerTool(
           "]\n\n" +
           "IMPORTANT: `appendChild`, `prependChild`, and `replaceChildren` do NOT work with `heading` selectors (headings only contain inline text, not block content). To add or replace content under a heading, use `insertAfter`. To replace a heading entirely, use `replace`."
         ),
-      content: z.string().optional().describe("Full note body replacement. Use only for complete rewrites or when the note is small. Mutually exclusive with semanticPatch."),
+      content: z.string().optional().describe("Full note body replacement. Use only for complete rewrites or when the note is small. Mutually exclusive with semanticPatch. Content must pass markdown lint. Auto-fixable issues are fixed automatically. Common unfixable issues: fenced code blocks need a language tag (e.g. use ```text not bare ```), and broken links are rejected. If lint fails, fix the specific issues and retry — do NOT fall back to semanticPatch for this."),
       title: z.string().optional().describe("Specific, retrieval-friendly title. Prefer the concrete topic or decision, not a vague label."),
       tags: z.array(z.string()).optional().describe("Optional tags for later filtering. Use a small number of stable, meaningful tags."),
       lifecycle: z
@@ -3058,7 +3075,22 @@ server.registerTool(
         return { content: [{ type: "text", text: `Semantic patch failed: ${message}` }], isError: true };
       }
     }
-    const cleanedContent = content === undefined ? undefined : await cleanMarkdown(content);
+    let cleanedContent: string | undefined;
+    if (content !== undefined) {
+      try {
+        cleanedContent = await cleanMarkdown(content);
+      } catch (err) {
+        if (err instanceof MarkdownLintError) {
+          const message = `Markdown lint issues prevented the update. Fix the specific lint errors in your content and retry — do NOT fall back to semanticPatch for this.\n\n${err.message}`;
+          return {
+            content: [{ type: "text" as const, text: message }],
+            structuredContent: { action: "lint_error", tool: "update", issues: err.issues } as LintErrorResult,
+            isError: true,
+          };
+        }
+        throw err;
+      }
+    }
 
     const resolvedTitle = title ?? note.title;
     const resolvedContent = patchedContent ?? cleanedContent ?? note.content;

--- a/src/structured-content.ts
+++ b/src/structured-content.ts
@@ -73,6 +73,12 @@ export interface ProjectRef {
   name: string;
 }
 
+export interface LintErrorResult extends Record<string, unknown> {
+  action: "lint_error";
+  tool: "remember" | "update";
+  issues: string[];
+}
+
 export interface RememberResult extends Record<string, unknown> {
   action: "remembered";
   id: string;
@@ -582,6 +588,12 @@ export const PersistenceStatusSchema = z.object({
     }),
   }).optional(),
   durability: z.enum(["local-only", "committed", "pushed"]),
+});
+
+export const LintErrorResultSchema = z.object({
+  action: z.literal("lint_error"),
+  tool: z.enum(["remember", "update"]),
+  issues: z.array(z.string()),
 });
 
 export const RememberResultSchema = z.object({


### PR DESCRIPTION
## Summary

This PR captures the following design decisions:

- **Semantic Patch Builder: Design & Implementation**
- **markdown linting for memory content**

## Changes

### Semantic Patch Builder: Design & Implementation

**Tags:** design, ast, semantic-patch, update, markdown, plan, implementation

The `update` tool required passing the entire note `content` for even trivial edits. This wasted tokens on large notes.

### markdown linting for memory content

**Tags:** markdown, linting, decisions, dogfooding

Decision: lint markdown note bodies during `remember` and `update` so recalled content stays clean and consistent.

## Workflow Artifacts

**Research:**

- Research: Remember/Update lint error lacking LLM retry guidance — When `remember` or `update(content)` fails due to markdown lint errors, the `MarkdownLintError` propagates as a raw MCP tool error with no actionable guidance.

**Plan:**

- Plan: Add actionable lint error guidance to remember and update — request root: research-remember-update-lint-error-lacking-llm-retry-guidan-505523cc

**Review:**

- Review: Add actionable lint error guidance to remember and update — Implemented 5 changes to add actionable lint error handling for `remember` and `update(content)`:

## Notes / References

_Detailed notes in `.mnemonic/notes/`:_

- `.mnemonic/notes/semantic-patch-builder-design-implementation-906872f1.md` — Semantic Patch Builder: Design & Implementation
- `.mnemonic/notes/markdown-linting-for-memory-content-259a1c85.md` — markdown linting for memory content
- `.mnemonic/notes/plan-add-actionable-lint-error-guidance-to-remember-and-upda-86542d51.md` — Plan: Add actionable lint error guidance to remember and update _(plan)_
- `.mnemonic/notes/research-remember-update-lint-error-lacking-llm-retry-guidan-505523cc.md` — Research: Remember/Update lint error lacking LLM retry guidance _(research)_
- `.mnemonic/notes/review-add-actionable-lint-error-guidance-to-remember-and-up-f7c923f9.md` — Review: Add actionable lint error guidance to remember and update _(review)_

---

_Generated from 5 design decision note(s) in `.mnemonic/notes/`. Run `/update-pr` to regenerate._