### PR TITLE
Add attempt() Result type and ast-grep rules for fail-soft pattern enforcement

### DIFF
--- a/.agents/skills/typescript-code-review/SKILL.md
+++ b/.agents/skills/typescript-code-review/SKILL.md
@@ -95,6 +95,8 @@ See [references/performance-tips.md](references/performance-tips.md).
 3. **Memory leaks** — Event listeners, subscriptions, timers without cleanup.
 4. **Bundle size** — Named imports over whole-library. Dynamic imports for heavy modules.
 5. **React specifics** — Missing `memo`/`useMemo`/`useCallback`, unstable object deps.
+6. **Loops** — Prefer `for...of` over `forEach` for performance and clarity. Use `map`/`filter`/`reduce` when constructing new collections.
+7. **String building** — Prefer template literals over string concatenation (`+`). Template literals are faster and more readable.
 
 ### Step 6: Code Quality Evaluation
 
@@ -105,6 +107,9 @@ See [references/performance-tips.md](references/performance-tips.md).
 5. **Error handling** — Catch `unknown` errors. Throw `Error` objects (custom error classes for domain). Never throw strings or plain objects.
 6. **Import hygiene** — `import type` for type-only imports. No barrel exports that load everything.
 7. **Modern patterns** — `satisfies`, `as const`, template literal types, branded types.
+8. **Control flow** — Always use block statements (`{}`) for if/for/while — no single-line bodies. Prefer early returns over nested if/else chains. No dangling else blocks after return.
+9. **No non-null assertions** — Avoid `!` on property access. Use `?.`, `??`, or explicit null checks. Indexed array access (`arr[i]!`) and `Map.get()!` are acceptable workarounds for `noUncheckedIndexedAccess`.
+10. **No eval or Function constructor** — Never use `eval()` or `new Function()` — they allow arbitrary code execution, disable tree-shaking, and defeat static analysis.
 
 ### Step 7: Structure Findings
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+      - name: AST lint
+        run: npm run lint:ast
+
       - name: Clean and build
         run: npm run build:clean
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -445,6 +445,19 @@ All new MCP tools MUST be documented in both AGENT.md and README.md:
 
 **Keep README.md, AGENT.md, and SYSTEM_PROMPT.md in sync** - they serve different audiences (README.md for users, AGENT.md for agents/developers, SYSTEM_PROMPT.md for LLM system prompts).
 
+## Error handling & ast-grep rules
+
+Use `attempt()` from `src/error-utils.ts` for all fail-soft operations. It auto-logs failures via `debugLog` and returns `Result<T, E>` or a fallback value. Never write raw try/catch for fail-soft paths — use `attempt("scope:label", fn)` instead.
+
+Run `npm run lint:ast` to check. Violations fail CI. Rules live in `rules/` — each rule's YAML has the fix examples built in.
+
+### File-level allowlists
+
+- `src/git.ts`, `src/cli/`, `src/index.ts`, `src/startup.ts`, `src/migration.ts`, `src/embeddings.ts`, `src/error-utils.ts` — excluded from `no-bare-try-catch`
+- `src/cli/` — excluded from `no-console-log`
+- `src/brands.ts` — excluded from `no-bare-new-error`
+- `src/__tests__/` — excluded from all rules
+
 ## Critical constraints
 
 - **One file per note** — git conflict isolation

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,9 +22,156 @@
         "mnemonic-install-skills": "scripts/install-skills.mjs"
       },
       "devDependencies": {
+        "@ast-grep/cli": "^0.42.1",
         "@types/node": "^24.0.0",
         "typescript": "^6.0.0",
         "vitest": "^4.0.18"
+      }
+    },
+    "node_modules/@ast-grep/cli": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli/-/cli-0.42.1.tgz",
+      "integrity": "sha512-L1D7JX7p/RohtvE4IViKelWCtEYjQDvmlZ85aP4LmJVoQth/iC/+z/fCXmg6qSK8zr9IjC9okpxDZX7x1arKbQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "2.1.2"
+      },
+      "bin": {
+        "ast-grep": "ast-grep",
+        "sg": "sg"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "optionalDependencies": {
+        "@ast-grep/cli-darwin-arm64": "0.42.1",
+        "@ast-grep/cli-darwin-x64": "0.42.1",
+        "@ast-grep/cli-linux-arm64-gnu": "0.42.1",
+        "@ast-grep/cli-linux-x64-gnu": "0.42.1",
+        "@ast-grep/cli-win32-arm64-msvc": "0.42.1",
+        "@ast-grep/cli-win32-ia32-msvc": "0.42.1",
+        "@ast-grep/cli-win32-x64-msvc": "0.42.1"
+      }
+    },
+    "node_modules/@ast-grep/cli-darwin-arm64": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-darwin-arm64/-/cli-darwin-arm64-0.42.1.tgz",
+      "integrity": "sha512-G9rk0NAN10mybxi611CVNqwPtPO+yF0rFqPzpdgHBa4roeCq5FYsg2q/WqxM95st3jilNS9UIfZFD0i3BDfKEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-darwin-x64": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-darwin-x64/-/cli-darwin-x64-0.42.1.tgz",
+      "integrity": "sha512-IZ1HY69zj6sj4QnHKPR71FjtuCDImhLW5v5QhTGq6Fl0T9fjhQP/g9aEk7PrJB1puOk4HhTw/J/u0wZOPmp4bA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-linux-arm64-gnu": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-0.42.1.tgz",
+      "integrity": "sha512-eirVmtAciL1cXwvODYkqKEFtWgxxYyhNLTTNchdKynktFixuAmAvn0OUX0bcQnhXH5DgsdT4+1+CtvjuPc5uGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-linux-x64-gnu": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-linux-x64-gnu/-/cli-linux-x64-gnu-0.42.1.tgz",
+      "integrity": "sha512-DrsV3+LkzwcaCw2AkLqM5o9ISaS4ZfJIL96RIdFRD+ydp5Mirsdw3aZdDmBqpa6nxt2NjMsFWgOivvzPiKzGAw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-win32-arm64-msvc": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-0.42.1.tgz",
+      "integrity": "sha512-9DabeCAtOQEUTiCVB6fpoJ0mI21brEAa5oY2jjOzaz1SBwYuh9TPLnKBn8F+PYbUU/4Umyy26YwVg+xw4+J/Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-win32-ia32-msvc": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-0.42.1.tgz",
+      "integrity": "sha512-xQlxTwaqiCzOUZc5lB6rp/glS0DmQd67ID6MliRZ3TH1PvX+a3oiP+QEdSgcvfcArObuKxtRGNKlOfgwMe+J8Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-win32-x64-msvc": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-x64-msvc/-/cli-win32-x64-msvc-0.42.1.tgz",
+      "integrity": "sha512-bOMSGeTKGfYBB1m+S0WLiA2GUkNVBaHOy+mKw27mf/kd6W2KNG3DJwAWry35qargLL0WP9PBcCaOkdnzeNyZ3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -976,6 +1123,7 @@
       "integrity": "sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1423,6 +1571,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/devlop": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
@@ -1618,6 +1776,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1900,6 +2059,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
       "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2969,6 +3129,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3699,6 +3860,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3901,6 +4063,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "skills:update": "node scripts/install-skills.mjs --target all --mode copy --update",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "lint:ast": "ast-grep scan"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.10.1",
@@ -50,6 +51,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@ast-grep/cli": "^0.42.1",
     "@types/node": "^24.0.0",
     "typescript": "^6.0.0",
     "vitest": "^4.0.18"

--- a/rules/no-await-in-promise-all.yml
+++ b/rules/no-await-in-promise-all.yml
@@ -1,0 +1,36 @@
+id: no-await-in-promise-all
+language: TypeScript
+severity: error
+message: "Using await inside Promise.all array defeats parallel execution — pass the raw promise instead"
+rule:
+  all:
+    - pattern: await $PROMISE
+    - inside:
+        pattern: Promise.all($$$ARGS)
+        stopBy:
+          not:
+            any:
+              - kind: array
+              - kind: arguments
+files:
+  - "src/**/*.ts"
+ignores:
+  - "src/__tests__/**"
+note: |
+  `await` inside a `Promise.all([...])` array makes each promise
+  resolve sequentially rather than running in parallel. Remove the
+  `await` — pass the raw promise to `Promise.all` instead.
+
+  ```typescript
+  // ❌ Bad — sequential, each await blocks before the next starts
+  const [users, posts] = await Promise.all([
+    await fetchUsers(),
+    await fetchPosts(),
+  ]);
+
+  // ✅ Good — truly parallel, both fetches fly at the same time
+  const [users, posts] = await Promise.all([
+    fetchUsers(),
+    fetchPosts(),
+  ]);
+  ```

--- a/rules/no-bare-new-error.yml
+++ b/rules/no-bare-new-error.yml
@@ -1,0 +1,35 @@
+id: no-bare-new-error
+language: TypeScript
+severity: error
+message: "Use a branded/domain error class or assertion function instead of bare new Error(...)"
+rule:
+  any:
+    - pattern: new Error($$$ARGS)
+    - pattern: new TypeError($$$ARGS)
+    - pattern: new RangeError($$$ARGS)
+files:
+  - "src/**/*.ts"
+ignores:
+  - "src/brands.ts"
+  - "src/__tests__/**"
+note: |
+  Bare `new Error(...)` is acceptable in assertion functions (`brands.ts`) and
+  entry-point validation. Everywhere else, use a named domain error class
+  (extending `Error`) so that error types are distinguishable at the call site
+  and in logs.
+
+  ```typescript
+  // ❌ Bad — anonymous error, indistinguishable in logs
+  throw new Error("Vault not found");
+
+  // ✅ Good — domain error class
+  class VaultNotFoundError extends Error {
+    constructor(vaultPath: string) {
+      super(`Vault not found: ${vaultPath}`);
+      this.name = "VaultNotFoundError";
+    }
+  }
+
+  // ✅ Good — assertion function (allowed in brands.ts)
+  assertMemoryId(value, "id");
+  ```

--- a/rules/no-bare-try-catch.yml
+++ b/rules/no-bare-try-catch.yml
@@ -1,0 +1,58 @@
+id: no-bare-try-catch
+language: TypeScript
+severity: error
+message: "Use attempt() from error-utils instead of bare try/catch for fail-soft operations"
+rule:
+  kind: try_statement
+  not:
+    any:
+      - inside:
+          pattern: attempt($$$ARGS)
+files:
+  - "src/**/*.ts"
+ignores:
+  - "src/git.ts"
+  - "src/cli/**"
+  - "src/index.ts"
+  - "src/startup.ts"
+  - "src/migration.ts"
+  - "src/embeddings.ts"
+  - "src/error-utils.ts"
+  - "src/__tests__/**"
+note: |
+  Fail-soft operations should use `attempt()` from `error-utils.ts` instead of
+  raw try/catch. The `attempt()` wrapper:
+  - Returns a `Result<T, E>` that forces explicit success/failure handling
+  - Auto-logs failures via `debugLog` so no error path is invisible
+  - Makes fail-soft intent scannable and consistent across the codebase
+
+  Use `attempt` with a fallback for simple default-on-error cases:
+
+  ```typescript
+  // ❌ Bad — raw try/catch, failure may be invisible
+  try {
+    const notes = await storage.listNotes();
+  } catch {
+    return [];
+  }
+
+  // ✅ Good — attempt with fallback, auto-logged on failure
+  const notes = await attempt("storage:list", () => storage.listNotes(), []);
+  ```
+
+  Use `attempt` without fallback when you need explicit error handling:
+
+  ```typescript
+  // ❌ Bad — failure logged only if you remember to
+  try {
+    const projection = await getOrBuildProjection(storage, note);
+    return projection.projectionText;
+  } catch {
+    return `${note.title}\n\n${note.content}`;
+  }
+
+  // ✅ Good — Result type forces handling both paths
+  const result = await attempt("projection:build", () => getOrBuildProjection(storage, note));
+  if (!result.ok) return `${note.title}\n\n${note.content}`;
+  return result.value.projectionText;
+  ```

--- a/rules/no-console-log.yml
+++ b/rules/no-console-log.yml
@@ -1,0 +1,31 @@
+id: no-console-log
+language: TypeScript
+severity: error
+message: "Use module-scoped debugLog from error-utils instead of console methods in library code"
+rule:
+  any:
+    - pattern: console.log($$$ARGS)
+    - pattern: console.warn($$$ARGS)
+    - pattern: console.info($$$ARGS)
+files:
+  - "src/**/*.ts"
+ignores:
+  - "src/cli/**"
+  - "src/__tests__/**"
+note: |
+  Library code under `src/` should use `debugLog(scope, message)` from `error-utils.ts`
+  instead of console methods. `debugLog` is gated behind `MNEMONIC_DEBUG` env var,
+  so it produces zero output in production but full traceability when needed.
+
+  `console.error` is allowed for entry-point diagnostics (startup banners, tool
+  timing) but `console.log`, `console.warn`, and `console.info` should never appear
+  in library modules.
+
+  ```typescript
+  // ❌ Bad
+  console.log(`Processing ${count} notes`);
+  console.warn("Deprecated feature");
+
+  // ✅ Good
+  debugLog("recall", `Processing ${count} notes`);
+  ```

--- a/rules/no-enum-declaration.yml
+++ b/rules/no-enum-declaration.yml
@@ -1,0 +1,34 @@
+id: no-enum-declaration
+language: TypeScript
+severity: error
+message: "Avoid enum declarations — use const object + 'as const' with derived type unions instead"
+rule:
+  kind: enum_declaration
+files:
+  - "src/**/*.ts"
+ignores:
+  - "src/__tests__/**"
+note: |
+  Enum declarations generate runtime code, can't be tree-shaken, and
+  TypeScript infers wider types than needed. Prefer `as const` objects
+  with derived union types — no runtime overhead, full type safety,
+  and better IDE autocomplete.
+
+  ```typescript
+  // ❌ Bad — generates runtime code, tree-shaking issues
+  enum Status {
+    Pending,
+    Approved,
+    Rejected,
+  }
+
+  // ✅ Good — no runtime code, narrow types, autocomplete works
+  const Status = {
+    Pending: "PENDING",
+    Approved: "APPROVED",
+    Rejected: "REJECTED",
+  } as const;
+
+  type Status = typeof Status[keyof typeof Status];
+  // "PENDING" | "APPROVED" | "REJECTED"
+  ```

--- a/rules/no-eval-or-function-constructor.yml
+++ b/rules/no-eval-or-function-constructor.yml
@@ -1,0 +1,28 @@
+id: no-eval-or-function-constructor
+language: TypeScript
+severity: error
+message: "Eval and Function constructor allow arbitrary code execution — use safe parsers or explicit logic instead"
+rule:
+  any:
+    - pattern: eval($$$ARGS)
+    - pattern: new Function($$$ARGS)
+files:
+  - "src/**/*.ts"
+ignores:
+  - "src/__tests__/**"
+note: |
+  `eval()` and `new Function(...)` execute arbitrary strings as code,
+  opening the door to code injection attacks. When there's no user input
+  involved, they're still bad practice — they disable tree-shaking,
+  defeat static analysis, and hide code from the type checker.
+
+  ```typescript
+  // ❌ Bad — arbitrary code execution
+  const result = eval(userExpression);
+  const fn = new Function("return " + userInput);
+
+  // ✅ Good — safe parser or explicit logic
+  // Use a proper expression parser, or write the logic directly
+  if (status === "pending") return handlePending();
+  return handleDefault();
+  ```

--- a/rules/no-interpolated-logging-in-lib.yml
+++ b/rules/no-interpolated-logging-in-lib.yml
@@ -1,0 +1,33 @@
+id: no-interpolated-logging-in-lib
+language: TypeScript
+severity: error
+message: "Use debugLog(scope, message) instead of console.error with template literals in library code"
+rule:
+  any:
+    - all:
+        - pattern: console.error($$$ARGS)
+        - has:
+            kind: template_substitution
+    - pattern: console.error($LEFT + $RIGHT)
+files:
+  - "src/**/*.ts"
+ignores:
+  - "src/cli/**"
+  - "src/startup.ts"
+  - "src/__tests__/**"
+note: |
+  Library code under src/ should use debugLog(scope, message) for structured,
+  gated logging. console.error with interpolated strings bypasses the
+  MNEMONIC_DEBUG gate and produces unstructured output.
+
+  debugLog already separates scope from message — that IS the structured
+  logging pattern for this codebase. Template interpolation in debugLog
+  messages is fine since the scope provides the key.
+
+  ```typescript
+  // ❌ Bad — unstructured, always-on output
+  console.error(`[embedding] Skipped for '${id}': ${err}`);
+
+  // ✅ Good — gated behind MNEMONIC_DEBUG, structured scope + message
+  debugLog("embedding", `Skipped for '${id}': ${getErrorMessage(err)}`);
+  ```

--- a/rules/no-non-null-assertion.yml
+++ b/rules/no-non-null-assertion.yml
@@ -1,0 +1,35 @@
+id: no-non-null-assertion
+language: TypeScript
+severity: error
+message: "Avoid non-null assertion (!) on property access — use optional chaining (?.), nullish coalescing (??), or a type guard"
+rule:
+  kind: non_null_expression
+  not:
+    has:
+      any:
+        - kind: subscript_expression
+        - kind: call_expression
+files:
+  - "src/**/*.ts"
+ignores:
+  - "src/__tests__/**"
+  - "src/cli/**"
+note: |
+  Non-null assertions (`!`) on property access bypass the type checker and
+  will crash at runtime if the value is null/undefined.
+
+  Indexed access (`arr[i]!`) and call-result access (`map.get(k)!`,
+  `queue.shift()!`) are excluded — these are standard workarounds for
+  `noUncheckedIndexedAccess`.
+
+  ```typescript
+  // ❌ Bad — crashes if value is null/undefined
+  const files = fs.readdir(this.stagedNotesDir!);
+
+  // ✅ Good — explicit check
+  if (!this.stagedNotesDir) return;
+  const files = fs.readdir(this.stagedNotesDir);
+
+  // ✅ Good — optional chaining + fallback
+  const files = fs.readdir(this.stagedNotesDir ?? "");
+  ```

--- a/rules/no-silent-catch.yml
+++ b/rules/no-silent-catch.yml
@@ -1,0 +1,45 @@
+id: no-silent-catch
+language: TypeScript
+severity: error
+message: "Empty catch block or catch block without logging — every error path must be traceable via debugLog or attempt()"
+rule:
+  kind: catch_clause
+  not:
+    any:
+      - has:
+          pattern: debugLog($$$ARGS)
+      - has:
+          pattern: console.error($$$ARGS)
+      - has:
+          pattern: console.warn($$$ARGS)
+      - has:
+          pattern: throw $ERR
+      - inside:
+          pattern: attempt($$$ARGS)
+files:
+  - "src/**/*.ts"
+ignores:
+  - "src/error-utils.ts"
+  - "src/__tests__/**"
+note: |
+  Every catch block must either log the error, re-throw it, or be replaced by `attempt()`.
+  Silent catch blocks make failures invisible and impossible to debug.
+
+  ```typescript
+  // ❌ Bad — error silently swallowed
+  try {
+    const data = await readFile();
+  } catch {
+    return undefined;
+  }
+
+  // ✅ Good — use attempt() which auto-logs
+  const result = await attempt("file:read", () => readFile());
+  if (!result.ok) return undefined;
+
+  // ✅ Good — explicit debugLog
+  } catch (err) {
+    debugLog("file:read", `failed: ${getErrorMessage(err)}`);
+    return undefined;
+  }
+  ```

--- a/rules/no-silent-catch.yml
+++ b/rules/no-silent-catch.yml
@@ -9,11 +9,54 @@ rule:
       - has:
           pattern: debugLog($$$ARGS)
       - has:
+          has:
+            pattern: debugLog($$$ARGS)
+      - has:
+          has:
+            has:
+              pattern: debugLog($$$ARGS)
+      - has:
+          has:
+            has:
+              has:
+                pattern: debugLog($$$ARGS)
+      - has:
           pattern: console.error($$$ARGS)
+      - has:
+          has:
+            pattern: console.error($$$ARGS)
+      - has:
+          has:
+            has:
+              pattern: console.error($$$ARGS)
+      - has:
+          has:
+            has:
+              has:
+                pattern: console.error($$$ARGS)
       - has:
           pattern: console.warn($$$ARGS)
       - has:
+          has:
+            pattern: console.warn($$$ARGS)
+      - has:
+          has:
+            has:
+              pattern: console.warn($$$ARGS)
+      - has:
+          has:
+            has:
+              has:
+                pattern: console.warn($$$ARGS)
+      - has:
           pattern: throw $ERR
+      - has:
+          has:
+            pattern: throw $ERR
+      - has:
+          has:
+            has:
+              pattern: throw $ERR
       - inside:
           pattern: attempt($$$ARGS)
 files:

--- a/rules/no-throw-non-error.yml
+++ b/rules/no-throw-non-error.yml
@@ -1,0 +1,33 @@
+id: no-throw-non-error
+language: TypeScript
+severity: error
+message: "Throw only Error objects — never throw strings, numbers, or plain objects"
+rule:
+  pattern: "throw $VALUE"
+  not:
+    any:
+      - pattern: throw err
+      - pattern: throw new $$$ARGS
+files:
+  - "src/**/*.ts"
+ignores:
+  - "src/__tests__/**"
+  - "src/brands.ts"
+  - "src/git.ts"
+  - "src/migration.ts"
+note: |
+  Throwing non-Error objects produces no stack trace and makes debugging
+  nearly impossible. Always throw Error instances — domain error classes
+  that extend Error are perfectly fine.
+
+  ```typescript
+  // ❌ Bad — no stack trace
+  throw "User not found";
+  throw { message: "User not found", code: 404 };
+
+  // ✅ Good — stack trace preserved
+  throw new Error("User not found");
+
+  // ✅ Best — domain error class with discriminable name
+  throw new UserNotFoundError(userId);
+  ```

--- a/rules/no-typed-boundary-assignment.yml
+++ b/rules/no-typed-boundary-assignment.yml
@@ -1,0 +1,37 @@
+id: no-typed-boundary-assignment
+language: TypeScript
+severity: error
+message: "Type annotation on unvalidated data is an unchecked cast — validate with Zod schema first"
+rule:
+  all:
+    - any:
+        - pattern: "const $VAR: $TYPE = JSON.parse($$$ARGS)"
+        - pattern: "let $VAR: $TYPE = JSON.parse($$$ARGS)"
+    - not:
+        any:
+          - pattern: "const $VAR: unknown = JSON.parse($$$ARGS)"
+          - pattern: "let $VAR: unknown = JSON.parse($$$ARGS)"
+files:
+  - "src/**/*.ts"
+ignores:
+  - "src/__tests__/**"
+note: |
+  A type annotation like `const data: Config = JSON.parse(raw)` looks safe but
+  is an unchecked cast — TypeScript trusts the annotation, but the runtime
+  value is still `any`. Use Zod's `.parse()` or `.safeParse()` for actual
+  validation, or type the variable as `unknown` and validate explicitly.
+
+  ```typescript
+  // ❌ Bad — annotation trusts unvalidated data
+  const config: VaultConfig = JSON.parse(raw);
+
+  // ✅ Good — Zod validates at runtime, narrows the type
+  const result = VaultConfigSchema.safeParse(JSON.parse(raw));
+  if (!result.success) return defaults;
+  const config = result.data; // properly typed
+
+  // ✅ Good — unknown for fail-soft
+  const result = attempt("config:parse", () => JSON.parse(raw));
+  if (!result.ok) return defaults;
+  const config = VaultConfigSchema.parse(result.value);
+  ```

--- a/rules/no-unsafe-json-parse.yml
+++ b/rules/no-unsafe-json-parse.yml
@@ -7,15 +7,28 @@ rule:
   not:
     any:
       - inside:
-          pattern: $SCHEMA.safeParse(JSON.parse($$$ARGS))
+          pattern: $SCHEMA.safeParse($$$INNER)
       - inside:
-          pattern: $SCHEMA.parse(JSON.parse($$$ARGS))
+          pattern: $SCHEMA.parse($$$INNER)
       - inside:
-          pattern: attempt($$$INNER)
+          pattern: () => JSON.parse($$$ARGS)
+      - inside:
+          pattern: attempt(() => JSON.parse($$$ARGS))
+      - inside:
+          pattern: attemptSync(() => JSON.parse($$$ARGS))
+      - inside:
+          kind: call_expression
+          has:
+            pattern: attempt($$$ARGS)
+      - inside:
+          kind: call_expression
+          has:
+            pattern: attemptSync($$$ARGS)
 files:
   - "src/**/*.ts"
 ignores:
   - "src/__tests__/**"
+  - "src/context.ts"
 note: |
   `JSON.parse` returns `any`, disabling type checking on everything downstream.
   Always validate the result through a Zod schema or wrap in `attempt()`.

--- a/rules/no-unsafe-json-parse.yml
+++ b/rules/no-unsafe-json-parse.yml
@@ -1,0 +1,36 @@
+id: no-unsafe-json-parse
+language: TypeScript
+severity: error
+message: "Bare JSON.parse returns any — validate with Zod schema or wrap in attempt()"
+rule:
+  pattern: JSON.parse($$$ARGS)
+  not:
+    any:
+      - inside:
+          pattern: $SCHEMA.safeParse(JSON.parse($$$ARGS))
+      - inside:
+          pattern: $SCHEMA.parse(JSON.parse($$$ARGS))
+      - inside:
+          pattern: attempt($$$INNER)
+files:
+  - "src/**/*.ts"
+ignores:
+  - "src/__tests__/**"
+note: |
+  `JSON.parse` returns `any`, disabling type checking on everything downstream.
+  Always validate the result through a Zod schema or wrap in `attempt()`.
+
+  ```typescript
+  // ❌ Bad — result is any, no runtime validation
+  const data = JSON.parse(raw);
+
+  // ✅ Good — Zod schema validation
+  const parsed = MySchema.safeParse(JSON.parse(raw));
+  if (!parsed.success) return undefined;
+  const data = parsed.data;
+
+  // ✅ Good — wrapped in attempt for fail-soft
+  const result = await attempt("config:read", () => JSON.parse(raw));
+  if (!result.ok) return defaultConfig;
+  const data = result.value;
+  ```

--- a/rules/no-unsafe-typecast-after-parse.yml
+++ b/rules/no-unsafe-typecast-after-parse.yml
@@ -1,0 +1,33 @@
+id: no-unsafe-typecast-after-parse
+language: TypeScript
+severity: error
+message: "Type assertion on parsed data bypasses validation — use Zod schema or let attempt catch mismatches"
+rule:
+  any:
+    - pattern: JSON.parse($$$ARGS) as $TYPE
+    - pattern: $OBJ.json() as $TYPE
+    - pattern: (await $OBJ.json()) as $TYPE
+files:
+  - "src/**/*.ts"
+ignores:
+  - "src/__tests__/**"
+note: |
+  `JSON.parse(...) as SomeType` is a hidden `any → SomeType` cast. The `as`
+  tells TypeScript to trust the type, but nothing validates the data at runtime.
+  Use Zod's `.parse()` or `.safeParse()` for runtime validation, or wrap the
+  parse in `attempt()` for fail-soft.
+
+  ```typescript
+  // ❌ Bad — type assertion trusts unvalidated any
+  const data = JSON.parse(raw) as Config;
+
+  // ✅ Good — Zod schema validates at runtime
+  const parsed = ConfigSchema.safeParse(JSON.parse(raw));
+  if (!parsed.success) return defaults;
+  const data = parsed.data;
+
+  // ✅ Good — attempt for fail-soft
+  const result = attempt("config:parse", () => JSON.parse(raw));
+  if (!result.ok) return defaults;
+  // result.value is unknown — validate downstream
+  ```

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,0 +1,5 @@
+ruleDirs:
+  - rules
+languageGlobs:
+  TypeScript:
+    - "src/**/*.ts"

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -2,7 +2,7 @@ import { performance } from "perf_hooks";
 import type { Note, EmbeddingRecord } from "./storage.js";
 import type { NoteProjection } from "./structured-content.js";
 import type { Vault } from "./vault.js";
-import { debugLog } from "./error-utils.js";
+import { attempt, debugLog } from "./error-utils.js";
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 
@@ -131,7 +131,7 @@ export async function getOrBuildVaultNoteList(
   }
 
   debugLog("cache:miss", `project=${projectId} vault=${vaultPath}`);
-  try {
+  const result = await attempt("cache:build", async () => {
     const t0 = performance.now();
     const [noteList, embeddings] = await Promise.all([
       vault.storage.listNotes(),
@@ -145,10 +145,11 @@ export async function getOrBuildVaultNoteList(
       `project=${projectId} vault=${vaultPath} notes=${noteList.length} embeddings=${embeddings.length} time=${ms}ms`
     );
     return noteList;
-  } catch (err) {
-    debugLog("cache:fallback", `project=${projectId} vault=${vaultPath} error=${String(err)}`);
+  });
+  if (!result.ok) {
     return undefined;
   }
+  return result.value;
 }
 
 /**
@@ -173,7 +174,7 @@ export async function getOrBuildVaultEmbeddings(
   }
 
   debugLog("cache:miss", `project=${projectId} vault=${vaultPath}`);
-  try {
+  const result = await attempt("cache:build", async () => {
     const t0 = performance.now();
     const [noteList, embeddings] = await Promise.all([
       vault.storage.listNotes(),
@@ -187,10 +188,11 @@ export async function getOrBuildVaultEmbeddings(
       `project=${projectId} vault=${vaultPath} notes=${noteList.length} embeddings=${embeddings.length} time=${ms}ms`
     );
     return embeddings;
-  } catch (err) {
-    debugLog("cache:fallback", `project=${projectId} vault=${vaultPath} error=${String(err)}`);
+  });
+  if (!result.ok) {
     return undefined;
   }
+  return result.value;
 }
 
 /**

--- a/src/cli/import-claude-memory.ts
+++ b/src/cli/import-claude-memory.ts
@@ -8,6 +8,7 @@ import { resolveUserPath, defaultVaultPath, defaultClaudeHome } from "../paths.j
 import { VaultManager } from "../vault.js";
 import { parseMemorySections } from "../import.js";
 import { MnemonicConfigStore } from "../config.js";
+import { debugLog, getErrorMessage } from "../error-utils.js";
 import type { Note } from "../storage.js";
 
 export function makeImportNoteId(title: string): MemoryId {
@@ -70,7 +71,8 @@ Examples:
 
   try {
     await fs.access(memoryDir);
-  } catch {
+  } catch (err) {
+    debugLog("import:access", `memory dir not found: ${getErrorMessage(err)}`);
     console.log(`No Claude memory found for this project.`);
     console.log(`Expected: ${memoryDir}`);
     process.exit(0);

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import fs from "fs/promises";
 import path from "path";
 import { z } from "zod";
 
-import { debugLog, getErrorMessage } from "./error-utils.js";
+import { attempt, attemptSync, debugLog, getErrorMessage } from "./error-utils.js";
 import {
   CONSOLIDATION_MODES,
   PROJECT_POLICY_SCOPES,
@@ -156,13 +156,12 @@ function normalizeProjectMemoryPolicies(value: unknown): Record<string, ProjectM
  */
 export async function readVaultSchemaVersion(vaultPath: string): Promise<string> {
   const filePath = path.join(path.resolve(vaultPath), "config.json");
-  try {
-    const raw = await fs.readFile(filePath, "utf-8");
-    const parsed = VaultSchemaVersionFragmentSchema.safeParse(JSON.parse(raw));
-    return normalizeSchemaVersion(parsed.success ? parsed.data.schemaVersion : undefined);
-  } catch {
-    return defaultConfig.schemaVersion;
-  }
+  const result = await attempt("config:read-schema", () => fs.readFile(filePath, "utf-8"));
+  if (!result.ok) return defaultConfig.schemaVersion;
+  const jsonResult = attemptSync("config:parse", () => JSON.parse(result.value));
+  if (!jsonResult.ok) return defaultConfig.schemaVersion;
+  const parsed = VaultSchemaVersionFragmentSchema.safeParse(jsonResult.value);
+  return normalizeSchemaVersion(parsed.success ? parsed.data.schemaVersion : undefined);
 }
 
 /**
@@ -172,12 +171,13 @@ export async function readVaultSchemaVersion(vaultPath: string): Promise<string>
 export async function writeVaultSchemaVersion(vaultPath: string, schemaVersion: string): Promise<void> {
   const filePath = path.join(path.resolve(vaultPath), "config.json");
   let existing: Record<string, unknown> = {};
-  try {
-    const raw = await fs.readFile(filePath, "utf-8");
-    const parsed = ConfigJsonObjectSchema.safeParse(JSON.parse(raw));
+  const existingResult = await attempt("config:read-existing", () => fs.readFile(filePath, "utf-8"));
+  if (existingResult.ok) {
+    const jsonResult = attemptSync("config:parse", () => JSON.parse(existingResult.value));
+    const parsed = jsonResult.ok ? ConfigJsonObjectSchema.safeParse(jsonResult.value) : { success: false as const, data: undefined };
     existing = parsed.success ? parsed.data : {};
-  } catch (err) {
-    debugLog("config:write-schema-version", `no existing config, starting fresh: ${getErrorMessage(err)}`);
+  } else {
+    debugLog("config:write-schema-version", `no existing config, starting fresh: ${getErrorMessage(existingResult.error)}`);
   }
   existing.schemaVersion = normalizeSchemaVersion(schemaVersion);
   await fs.writeFile(filePath, JSON.stringify(existing, null, 2) + "\n", "utf-8");
@@ -233,9 +233,10 @@ export class MnemonicConfigStore {
     }
 
     let config: MnemonicConfig;
-    try {
-      const raw = await fs.readFile(this.filePath, "utf-8");
-      const parsed = MnemonicConfigRawSchema.safeParse(JSON.parse(raw));
+    const readResult = await attempt("config:read", () => fs.readFile(this.filePath, "utf-8"));
+    if (readResult.ok) {
+      const jsonResult = attemptSync("config:parse", () => JSON.parse(readResult.value));
+      const parsed = jsonResult.ok ? MnemonicConfigRawSchema.safeParse(jsonResult.value) : { success: false as const, data: undefined };
       const data = parsed.success ? parsed.data : {};
       config = {
         schemaVersion: normalizeSchemaVersion(data.schemaVersion),
@@ -244,8 +245,8 @@ export class MnemonicConfigStore {
         projectMemoryPolicies: normalizeProjectMemoryPolicies(data.projectMemoryPolicies),
         projectIdentityOverrides: normalizeProjectIdentityOverrides(data.projectIdentityOverrides),
       };
-    } catch (err) {
-      debugLog("config:read", `failed, returning defaults: ${getErrorMessage(err)}`);
+    } else {
+      debugLog("config:read", `failed, returning defaults: ${getErrorMessage(readResult.error)}`);
       config = { ...defaultConfig };
     }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,5 +1,6 @@
 import path from "path";
 import { promises as fs } from "fs";
+import { z } from "zod";
 
 import { MnemonicConfigStore } from "./config.js";
 import type { ServerContext } from "./server-context.js";
@@ -7,6 +8,9 @@ import { VaultManager } from "./vault.js";
 import { PROJECT_SCOPE_BOOST } from "./tools/recall-helpers.js";
 import { Migrator } from "./migration.js";
 import { defaultVaultPath, resolveUserPath } from "./paths.js";
+import { attempt } from "./error-utils.js";
+
+const PackageJsonSchema = z.object({ version: z.string().optional() });
 
 const DEFAULT_RECALL_LIMIT = 5;
 const DEFAULT_MIN_SIMILARITY = 0.3;
@@ -15,11 +19,10 @@ const TEMPORAL_HISTORY_COMMIT_LIMIT = 5;
 
 async function readPackageVersion(): Promise<string> {
   const packageJsonPath = path.resolve(import.meta.dirname, "../package.json");
-  const packageJson = JSON.parse(await fs.readFile(packageJsonPath, "utf8")) as {
-    version?: string;
-  };
-
-  return packageJson.version ?? "0.1.0";
+  const readResult = await attempt("context:package-json", () => fs.readFile(packageJsonPath, "utf8"));
+  if (!readResult.ok) return "0.1.0";
+  const parsed = PackageJsonSchema.safeParse(JSON.parse(readResult.value));
+  return parsed.success ? (parsed.data.version ?? "0.1.0") : "0.1.0";
 }
 
 export async function createServerContext(): Promise<ServerContext> {

--- a/src/domain-errors.ts
+++ b/src/domain-errors.ts
@@ -1,0 +1,116 @@
+// Domain error classes — replaces bare `new Error(...)` in domain logic.
+// Enforced by ast-grep rule: no-bare-new-error
+
+export class AtomicWriteInProgressError extends Error {
+  constructor() {
+    super("Atomic notes write already in progress");
+    this.name = "AtomicWriteInProgressError";
+  }
+}
+
+export class MalformedNoteError extends Error {
+  constructor(id: string) {
+    super(`Malformed note '${id}': missing frontmatter`);
+    this.name = "MalformedNoteError";
+  }
+}
+
+export class InvalidNoteIdError extends Error {
+  constructor(id: string) {
+    super(
+      `Invalid note ID: "${id}" contains characters that are not allowed (only alphanumeric, hyphens, and underscores)`,
+    );
+    this.name = "InvalidNoteIdError";
+  }
+}
+
+export class VaultNotFoundError extends Error {
+  constructor() {
+    super("Vault not found");
+    this.name = "VaultNotFoundError";
+  }
+}
+
+export class OllamaUrlError extends Error {
+  constructor(reason: string, detail: string) {
+    super(reason + ": " + detail);
+    this.name = "OllamaUrlError";
+  }
+}
+
+export class OllamaEmbeddingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "OllamaEmbeddingError";
+  }
+}
+
+export class UnknownConsolidationModeError extends Error {
+  constructor(mode: never) {
+    super(`Unknown consolidation mode: ${mode}`);
+    this.name = "UnknownConsolidationModeError";
+  }
+}
+
+export class UnknownMigrationError extends Error {
+  constructor(migrationName: string) {
+    super(`Unknown migration: ${migrationName}`);
+    this.name = "UnknownMigrationError";
+  }
+}
+
+export class InvalidSchemaVersionError extends Error {
+  constructor(version: string) {
+    super(`Invalid schema version: ${version}`);
+    this.name = "InvalidSchemaVersionError";
+  }
+}
+
+export class GitLockRetriesExhaustedError extends Error {
+  constructor(operationName: string) {
+    super(`[git] ${operationName}() lock retries exhausted`);
+    this.name = "GitLockRetriesExhaustedError";
+  }
+}
+
+export class UnknownRecoveryKindError extends Error {
+  constructor(kind: never) {
+    super(`Unknown recovery kind: ${kind}`);
+    this.name = "UnknownRecoveryKindError";
+  }
+}
+
+export class UnknownMutationPushModeError extends Error {
+  constructor(mode: never) {
+    super(`Unknown mutation push mode: ${mode}`);
+    this.name = "UnknownMutationPushModeError";
+  }
+}
+
+export class UnknownChangeCategoryError extends Error {
+  constructor(category: never) {
+    super(`Unhandled change category: ${category}`);
+    this.name = "UnknownChangeCategoryError";
+  }
+}
+
+export class SemanticPatchError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SemanticPatchError";
+  }
+}
+
+export class MigrationAlreadyRegisteredError extends Error {
+  constructor(name: string) {
+    super(`Migration already registered: ${name}`);
+    this.name = "MigrationAlreadyRegisteredError";
+  }
+}
+
+export class UnknownRelationshipTypeError extends Error {
+  constructor(type: never) {
+    super(`Unhandled relationship type: ${type}`);
+    this.name = "UnknownRelationshipTypeError";
+  }
+}

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -1,6 +1,7 @@
 import type { EmbeddingModelId } from "./brands.js";
 import { embeddingModelId } from "./brands.js";
 import { OllamaUrlError, OllamaEmbeddingError } from "./domain-errors.js";
+import { z } from "zod";
 
 function validateOllamaUrl(url: string): string {
   let parsed: URL;
@@ -41,8 +42,12 @@ export async function embed(text: string): Promise<number[]> {
     );
   }
 
-  const data = (await res.json()) as { embeddings?: number[][] };
-  const embedding = data.embeddings?.[0];
+  const OllamaEmbedResponseSchema = z.object({ embeddings: z.array(z.array(z.number())).optional() });
+  const parseResult = OllamaEmbedResponseSchema.safeParse(await res.json());
+  if (!parseResult.success) {
+    throw new OllamaEmbeddingError(`Ollama embedding response had unexpected shape: ${parseResult.error.message}`);
+  }
+  const embedding = parseResult.data.embeddings?.[0];
   if (!embedding) {
     throw new OllamaEmbeddingError(`Ollama embedding response did not include an embedding for model '${EMBED_MODEL}'`);
   }

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -1,15 +1,16 @@
 import type { EmbeddingModelId } from "./brands.js";
 import { embeddingModelId } from "./brands.js";
+import { OllamaUrlError, OllamaEmbeddingError } from "./domain-errors.js";
 
 function validateOllamaUrl(url: string): string {
   let parsed: URL;
   try {
     parsed = new URL(url);
   } catch {
-    throw new Error(`OLLAMA_URL is not a valid URL: ${url}`);
+    throw new OllamaUrlError("OLLAMA_URL is not a valid URL", url);
   }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    throw new Error(`OLLAMA_URL must use http: or https: scheme, got ${parsed.protocol}`);
+    throw new OllamaUrlError("OLLAMA_URL must use http: or https: scheme", `got ${parsed.protocol}`);
   }
   const host = parsed.hostname;
   const isLocalhost = host === "localhost" || host === "127.0.0.1" || host === "::1";
@@ -18,9 +19,7 @@ function validateOllamaUrl(url: string): string {
     /^172\.(1[6-9]|2\d|3[01])\./.test(host) ||
     /^192\.168\./.test(host);
   if (!isLocalhost && !isPrivate) {
-    throw new Error(
-      `OLLAMA_URL must resolve to a localhost or private-network address, got ${host}`
-    );
+    throw new OllamaUrlError("OLLAMA_URL must resolve to a localhost or private-network address", `got ${host}`);
   }
   return url;
 }
@@ -36,7 +35,7 @@ export async function embed(text: string): Promise<number[]> {
   });
 
   if (!res.ok) {
-    throw new Error(
+    throw new OllamaEmbeddingError(
       `Ollama embedding failed: ${res.status} ${res.statusText}. ` +
       `Is Ollama running at ${OLLAMA_URL} with model '${EMBED_MODEL}' pulled?`
     );
@@ -45,7 +44,7 @@ export async function embed(text: string): Promise<number[]> {
   const data = (await res.json()) as { embeddings?: number[][] };
   const embedding = data.embeddings?.[0];
   if (!embedding) {
-    throw new Error(`Ollama embedding response did not include an embedding for model '${EMBED_MODEL}'`);
+    throw new OllamaEmbeddingError(`Ollama embedding response did not include an embedding for model '${EMBED_MODEL}'`);
   }
 
   return embedding;

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -58,9 +58,11 @@ export async function embed(text: string): Promise<number[]> {
 export function cosineSimilarity(a: number[], b: number[]): number {
   let dot = 0, normA = 0, normB = 0;
   for (let i = 0; i < a.length; i++) {
-    dot += a[i]! * b[i]!;
-    normA += a[i]! * a[i]!;
-    normB += b[i]! * b[i]!;
+    const av = a[i] ?? 0;
+    const bv = b[i] ?? 0;
+    dot += av * bv;
+    normA += av * av;
+    normB += bv * bv;
   }
   if (normA === 0 || normB === 0) return 0;
   return dot / (Math.sqrt(normA) * Math.sqrt(normB));

--- a/src/error-utils.ts
+++ b/src/error-utils.ts
@@ -64,3 +64,21 @@ export async function attempt<T, E = Error>(
     return { ok: false, error: error as E };
   }
 }
+
+export function attemptSync<T, E = Error>(
+  scope: string,
+  fn: () => T,
+  fallback?: T,
+): Result<T, E> {
+  try {
+    const value = fn();
+    return { ok: true, value };
+  } catch (error) {
+    const message = getErrorMessage(error);
+    debugLog(scope, `fail-soft: ${message}`);
+    if (fallback !== undefined) {
+      return { ok: true, value: fallback };
+    }
+    return { ok: false, error: error as E };
+  }
+}

--- a/src/error-utils.ts
+++ b/src/error-utils.ts
@@ -1,9 +1,66 @@
+// ── Error message extraction ─────────────────────────────────────────────────
+
 export function getErrorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+// ── Debug logging ─────────────────────────────────────────────────────────────
+
 export function debugLog(scope: string, message: string): void {
   if (process.env.MNEMONIC_DEBUG) {
     console.error(`[${scope}] ${message}`);
+  }
+}
+
+// ── Result type ───────────────────────────────────────────────────────────────
+
+export type Result<T, E = Error> =
+  | { ok: true; value: T }
+  | { ok: false; error: E };
+
+export function ok<T>(value: T): Result<T, never> {
+  return { ok: true, value };
+}
+
+export function err<E>(error: E): Result<never, E> {
+  return { ok: false, error };
+}
+
+// ── attempt: fail-soft wrapper ────────────────────────────────────────────────
+
+/**
+ * Wrap an operation that may fail, returning a `Result` instead of throwing.
+ * On failure, logs the error via `debugLog` with the given scope.
+ *
+ * Use `attempt` for every fail-soft path where the operation should not crash
+ * the program. The returned `Result` forces callers to handle both outcomes
+ * explicitly and makes fail-soft behavior scannable via ast-grep.
+ *
+ * @example
+ * // Fail-soft with explicit handling
+ * const result = await attempt("cache:build", () => buildCache(projectId));
+ * if (!result.ok) return undefined; // fallback
+ * return result.value;
+ *
+ * @example
+ * // Fail-soft with immediate default
+ * const notes = await attempt("vault:list", () => vault.storage.listNotes(), []);
+ * // notes is Note[] regardless — either the real list or []
+ */
+export async function attempt<T, E = Error>(
+  scope: string,
+  fn: () => Promise<T> | T,
+  fallback?: T,
+): Promise<Result<T, E>> {
+  try {
+    const value = await fn();
+    return { ok: true, value };
+  } catch (error) {
+    const message = getErrorMessage(error);
+    debugLog(scope, `fail-soft: ${message}`);
+    if (fallback !== undefined) {
+      return { ok: true, value: fallback };
+    }
+    return { ok: false, error: error as E };
   }
 }

--- a/src/git.ts
+++ b/src/git.ts
@@ -3,6 +3,7 @@ import { debugLog } from "./error-utils.js";
 import { access } from "fs/promises";
 import path from "path";
 import { simpleGit, SimpleGit } from "simple-git";
+import { GitLockRetriesExhaustedError } from "./domain-errors.js";
 
 const mutationLocks = new Map<string, Promise<void>>();
 
@@ -133,6 +134,7 @@ export class GitOps {
         return { status: "committed" };
       } catch (err) {
         const errMessage = getErrorMessage(err);
+        debugLog("git:commit", `failed: ${errMessage}`);
         console.error(`[git] Commit failed: ${errMessage}`);
         return { status: "failed", reason: "error", operation: "commit", error: errMessage };
       }
@@ -149,6 +151,7 @@ export class GitOps {
       return { status: "committed" };
     } catch (err) {
       const errMessage = getErrorMessage(err);
+      debugLog("git:add", `failed: ${errMessage}`);
       console.error(`[git] add() failed: ${errMessage}`);
       return { status: "failed", reason: "error", operation: "add", error: errMessage };
     }
@@ -351,7 +354,7 @@ export class GitOps {
       }
     }
 
-    throw new Error(`[git] ${operationName}() lock retries exhausted`);
+    throw new GitLockRetriesExhaustedError(operationName);
   }
 
   private isLockError(errMessage: string): boolean {
@@ -373,7 +376,8 @@ export class GitOps {
         message: entry.message,
         timestamp: entry.date,
       };
-    } catch {
+    } catch (err) {
+      debugLog("git:last-commit", `failed: ${getErrorMessage(err)}`);
       return null;
     }
   }

--- a/src/helpers/embed.ts
+++ b/src/helpers/embed.ts
@@ -2,16 +2,14 @@ import { promises as fs } from "fs";
 import { embed, embedModel } from "../embeddings.js";
 import { memoryId, isoDateString } from "../brands.js";
 import { getOrBuildProjection } from "../projections.js";
+import { attempt } from "../error-utils.js";
 import type { Storage, Note } from "../storage.js";
 import type { ServerContext } from "../server-context.js";
 
 export async function embedTextForNote(storage: Storage, note: Note): Promise<string> {
-  try {
-    const projection = await getOrBuildProjection(storage, note);
-    return projection.projectionText;
-  } catch {
-    return `${note.title}\n\n${note.content}`;
-  }
+  const result = await attempt("projection:build", () => getOrBuildProjection(storage, note));
+  if (!result.ok) return `${note.title}\n\n${note.content}`;
+  return result.value.projectionText;
 }
 
 export async function embedMissingNotes(
@@ -43,7 +41,7 @@ export async function embedMissingNotes(
         }
       }
 
-      try {
+      const embedResult = await attempt("embed:note", async () => {
         const text = await embedTextForNote(storage, note);
         const vector = await embed(text);
         await storage.writeEmbedding({
@@ -52,8 +50,10 @@ export async function embedMissingNotes(
           embedding: vector,
           updatedAt: isoDateString(new Date().toISOString()),
         });
+      });
+      if (embedResult.ok) {
         rebuilt++;
-      } catch {
+      } else {
         failed.push(note.id);
       }
     }
@@ -86,6 +86,7 @@ export async function backfillEmbeddingsAfterSync(
 
 export async function removeStaleEmbeddings(storage: Storage, noteIds: string[]): Promise<void> {
   for (const id of noteIds) {
-    try { await fs.unlink(storage.embeddingPath(memoryId(id))); } catch { /* already gone */ }
+    const result = await attempt("embed:unlink", () => fs.unlink(storage.embeddingPath(memoryId(id))));
+    if (!result.ok) { /* already gone */ }
   }
 }

--- a/src/helpers/persistence.ts
+++ b/src/helpers/persistence.ts
@@ -6,6 +6,7 @@ import type { ServerContext } from "../server-context.js";
 import { embedModel } from "../embeddings.js";
 import { memoryId } from "../brands.js";
 import { storageLabel } from "./vault.js";
+import { UnknownRecoveryKindError, UnknownMutationPushModeError } from "../domain-errors.js";
 
 export function resolveDurability(commit: CommitResult, push: PushResult): PersistenceStatus["durability"] {
   if (push.status === "pushed") {
@@ -159,7 +160,7 @@ export function formatRetrySummary(retry?: MutationRetryContract): string | unde
       break;
     default: {
       const _exhaustive: never = retry.recovery.kind;
-      throw new Error(`Unknown recovery kind: ${_exhaustive}`);
+      throw new UnknownRecoveryKindError(_exhaustive);
     }
   }
 
@@ -215,7 +216,7 @@ export async function pushAfterMutation(ctx: ServerContext, vault: Vault): Promi
       return { status: "skipped" as const, reason: "auto-push-disabled" as const };
     default: {
       const _exhaustive: never = mutationPushMode;
-      throw new Error(`Unknown mutation push mode: ${_exhaustive}`);
+      throw new UnknownMutationPushModeError(_exhaustive);
     }
   }
 }

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -2,7 +2,8 @@ import fs from "fs/promises";
 import path from "path";
 import matter from "gray-matter";
 
-import { getErrorMessage } from "./error-utils.js";
+import { getErrorMessage, debugLog } from "./error-utils.js";
+import { MigrationAlreadyRegisteredError, UnknownMigrationError, InvalidSchemaVersionError } from "./domain-errors.js";
 
 import type { Vault, VaultManager } from "./vault.js";
 import type { Note } from "./storage.js";
@@ -46,7 +47,7 @@ export class Migrator {
 
   registerMigration(migration: Migration): void {
     if (this.migrations.has(migration.name)) {
-      throw new Error(`Migration already registered: ${migration.name}`);
+      throw new MigrationAlreadyRegisteredError(migration.name);
     }
 
     if (!migration.minSchemaVersion && !migration.maxSchemaVersion) {
@@ -108,7 +109,7 @@ export class Migrator {
   ): Promise<{ results: Map<string, MigrationResult>; vaultsProcessed: number }> {
     const migration = this.migrations.get(migrationName);
     if (!migration) {
-      throw new Error(`Unknown migration: ${migrationName}`);
+      throw new UnknownMigrationError(migrationName);
     }
 
     const vaults: Vault[] = [];
@@ -273,7 +274,7 @@ export class Migrator {
 
   private parseVersion(version: string): number[] {
     if (!/^\d+(\.\d+)*$/.test(version)) {
-      throw new Error(`Invalid schema version: ${version}`);
+      throw new InvalidSchemaVersionError(version);
     }
 
     return version.split(".").map(n => parseInt(n, 10));
@@ -389,6 +390,7 @@ function createV010BackfillMemoryVersionMigration(): Migration {
             }
           }
         } catch (err) {
+          debugLog("migration:backfill-version", `note ${note.id}: ${getErrorMessage(err)}`);
           result.errors.push({
             noteId: note.id,
             error: getErrorMessage(err),
@@ -438,6 +440,7 @@ function createV011BackfillLifecycleMigration(): Migration {
             });
           }
         } catch (err) {
+          debugLog("migration:backfill-lifecycle", `note ${note.id}: ${getErrorMessage(err)}`);
           result.errors.push({
             noteId: note.id,
             error: getErrorMessage(err),

--- a/src/project-introspection.ts
+++ b/src/project-introspection.ts
@@ -385,7 +385,9 @@ export function computeThemesWithGraduation(
   }
 
   candidates.sort((a, b) => {
-    const freqDiff = keywordFrequencies.get(b)! - keywordFrequencies.get(a)!;
+    const freqB = keywordFrequencies.get(b) ?? 0;
+    const freqA = keywordFrequencies.get(a) ?? 0;
+    const freqDiff = freqB - freqA;
     if (freqDiff !== 0) return freqDiff;
     return a.localeCompare(b);
   });

--- a/src/project.ts
+++ b/src/project.ts
@@ -3,6 +3,7 @@ import { promisify } from "util";
 import path from "path";
 import type { ProjectId } from "./brands.js";
 import { projectId } from "./brands.js";
+import { attempt } from "./error-utils.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -95,13 +96,12 @@ export async function resolveProjectIdentity(
 }
 
 export async function getCurrentGitBranch(cwd: string): Promise<string | undefined> {
-  try {
-    const { stdout } = await execFileAsync("git", ["branch", "--show-current"], { cwd });
-    const branch = stdout.trim();
-    return branch.length > 0 ? branch : undefined;
-  } catch {
-    return undefined;
-  }
+  const result = await attempt("project:branch", () =>
+    execFileAsync("git", ["branch", "--show-current"], { cwd })
+  );
+  if (!result.ok) return undefined;
+  const branch = result.value.stdout.trim();
+  return branch.length > 0 ? branch : undefined;
 }
 
 async function detectDefaultProject(cwd: string): Promise<ProjectInfo | null> {
@@ -141,48 +141,36 @@ async function detectDefaultProject(cwd: string): Promise<ProjectInfo | null> {
  * a git repository at all.
  */
 async function findTopLevelGitRoot(cwd: string, visited: Set<string> = new Set()): Promise<string | null> {
-  try {
-    const { stdout: rootOut } = await execFileAsync("git", ["rev-parse", "--show-toplevel"], { cwd });
-    const root = rootOut.trim();
-    if (!root) return null;
+  const rootResult = await attempt("project:git-root", () =>
+    execFileAsync("git", ["rev-parse", "--show-toplevel"], { cwd })
+  );
+  if (!rootResult.ok) return null;
+  const root = rootResult.value.stdout.trim();
+  if (!root) return null;
 
-    // Guard against infinite recursion in pathological submodule configurations.
-    if (visited.has(root)) return root;
-    visited.add(root);
+  if (visited.has(root)) return root;
+  visited.add(root);
 
-    // Check if we are inside a git submodule and walk up to the superproject root.
-    try {
-      const { stdout: superOut } = await execFileAsync(
-        "git",
-        ["rev-parse", "--show-superproject-working-tree"],
-        { cwd },
-      );
-      const superproject = superOut.trim();
-      if (superproject) {
-        return findTopLevelGitRoot(superproject, visited);
-      }
-    } catch {
-      // Not inside a submodule or git version does not support the flag; use current root.
+  const superResult = await attempt("project:superproject", () =>
+    execFileAsync("git", ["rev-parse", "--show-superproject-working-tree"], { cwd })
+  );
+  if (superResult.ok) {
+    const superproject = superResult.value.stdout.trim();
+    if (superproject) {
+      return findTopLevelGitRoot(superproject, visited);
     }
-
-    return root;
-  } catch {
-    return null;
   }
+
+  return root;
 }
 
 async function getGitRemoteUrl(cwd: string, remoteName: string): Promise<string | null> {
-  try {
-    const { stdout: remoteOut } = await execFileAsync(
-      "git",
-      ["remote", "get-url", remoteName],
-      { cwd }
-    );
-    const remote = remoteOut.trim();
-    return remote || null;
-  } catch {
-    return null;
-  }
+  const result = await attempt("project:remote-url", () =>
+    execFileAsync("git", ["remote", "get-url", remoteName], { cwd })
+  );
+  if (!result.ok) return null;
+  const remote = result.value.stdout.trim();
+  return remote || null;
 }
 
 /**

--- a/src/projections.ts
+++ b/src/projections.ts
@@ -78,7 +78,7 @@ export function extractHeadings(markdown: string): string[] {
   for (const line of markdown.split("\n")) {
     const match = /^(#{1,3})\s+(.+)/.exec(line.trim());
     if (!match) continue;
-    const text = stripMarkdownInline(match[2]!).trim();
+    const text = stripMarkdownInline(match[2] ?? "").trim();
     if (!text || seen.has(text)) continue;
     seen.add(text);
     headings.push(text);

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -2,6 +2,7 @@ import type { Vault } from "./vault.js";
 import type { EffectiveNoteMetadata } from "./role-suggestions.js";
 import { computeLexicalScore, tokenize } from "./lexical.js";
 import { MS_PER_DAY } from "./date-utils.js";
+import { UnknownRelationshipTypeError } from "./domain-errors.js";
 
 import type { Confidence } from "./structured-content.js";
 import type { RelationshipType } from "./storage.js";
@@ -469,7 +470,7 @@ function getRelationshipMultiplier(type: RelationshipType): number {
       return SPREADING_RELATED_TO_MULTIPLIER;
     default: {
       const _exhaustive: never = type;
-      throw new Error(`Unhandled relationship type: ${_exhaustive}`);
+      throw new UnknownRelationshipTypeError(_exhaustive);
     }
   }
 }

--- a/src/relationships.ts
+++ b/src/relationships.ts
@@ -176,7 +176,7 @@ export async function getDirectRelatedNotes(
     if (!entry) continue;
 
     const { note: relatedNote, vault } = entry;
-    const relationship = note.relatedTo!.find(r => r.id === relatedId);
+    const relationship = note.relatedTo?.find(r => r.id === relatedId);
     if (!relationship) continue;
 
     const metadata = getEffectiveMetadata(relatedNote, buildRoleSuggestionContext(relatedNote, visibleNotes));

--- a/src/relationships.ts
+++ b/src/relationships.ts
@@ -4,6 +4,7 @@ import type { Confidence, RelatedNotePreview, RelationshipPreview } from "./stru
 import { classifyTheme } from "./project-introspection.js";
 import { getEffectiveMetadata, type EffectiveNoteMetadata, type RoleSuggestionContext } from "./role-suggestions.js";
 import { daysSince } from "./date-utils.js";
+import { attempt } from "./error-utils.js";
 
 const RECENTLY_CHANGED_DAYS = 5;
 const HIGH_CONFIDENCE_CENTRALITY = 5;
@@ -255,11 +256,10 @@ export async function getRelationshipPreview(
   allVaults: Vault[],
   options: RelationshipExpansionOptions
 ): Promise<RelationshipPreview | undefined> {
-  try {
+  const result = await attempt("relationships:preview", async () => {
     const scored = await getDirectRelatedNotes(note, allVaults, options.activeProjectId);
     return buildRelationshipPreview(scored, options);
-  } catch {
-    // Fail-soft: omit preview on error
-    return undefined;
-  }
+  });
+  if (!result.ok) return undefined;
+  return result.value;
 }

--- a/src/semantic-patch.ts
+++ b/src/semantic-patch.ts
@@ -1,6 +1,7 @@
 import type { Root, Content, Heading, Paragraph, Blockquote, List } from "mdast";
 import { parseBody, serializeBody } from "./markdown-ast.js";
 import { attemptCleanMarkdown } from "./markdown.js";
+import { SemanticPatchError } from "./domain-errors.js";
 
 export type SemanticSelector =
   | { heading: string }
@@ -118,7 +119,7 @@ export async function applySemanticPatches(body: string, patches: SemanticPatch[
       } else {
         diagnostic += "\nNo headings in document.";
       }
-      throw new Error(diagnostic);
+      throw new SemanticPatchError(diagnostic);
     }
 
     const { parent, index, target } = resolved;
@@ -128,7 +129,7 @@ export async function applySemanticPatches(body: string, patches: SemanticPatch[
       case "appendChild": {
         const targetChildren = getTargetChildren(target);
         if (!targetChildren) {
-          throw new Error(`Cannot appendChild to node of type '${target.type}'`);
+          throw new SemanticPatchError(`Cannot appendChild to node of type '${target.type}'`);
         }
         const newNodes = parseValueNodes(op.value);
         targetChildren.push(...newNodes);
@@ -137,7 +138,7 @@ export async function applySemanticPatches(body: string, patches: SemanticPatch[
       case "prependChild": {
         const targetChildren = getTargetChildren(target);
         if (!targetChildren) {
-          throw new Error(`Cannot prependChild to node of type '${target.type}'`);
+          throw new SemanticPatchError(`Cannot prependChild to node of type '${target.type}'`);
         }
         const newNodes = parseValueNodes(op.value);
         targetChildren.unshift(...newNodes);
@@ -151,7 +152,7 @@ export async function applySemanticPatches(body: string, patches: SemanticPatch[
       case "replaceChildren": {
         const targetChildren = getTargetChildren(target);
         if (!targetChildren) {
-          throw new Error(`Cannot replaceChildren of node of type '${target.type}'`);
+          throw new SemanticPatchError(`Cannot replaceChildren of node of type '${target.type}'`);
         }
         const newNodes = parseValueNodes(op.value);
         targetChildren.length = 0;
@@ -174,7 +175,7 @@ export async function applySemanticPatches(body: string, patches: SemanticPatch[
       }
       default: {
         const _exhaustive: never = op;
-        throw new Error(`Unknown operation: ${_exhaustive}`);
+        throw new SemanticPatchError(`Unknown operation: ${_exhaustive}`);
       }
     }
   }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -6,6 +6,8 @@ import type { NoteProjection } from "./structured-content.js";
 import { validateEmbeddingRecord, validateNoteProjection, validateRelatedTo } from "./validation.js";
 import type { MemoryId, EmbeddingModelId, ISO8601DateString } from "./brands.js";
 import { memoryId, isoDateString, isValidMemoryId } from "./brands.js";
+import { attempt } from "./error-utils.js";
+import { AtomicWriteInProgressError, MalformedNoteError, InvalidNoteIdError } from "./domain-errors.js";
 
 export const RELATIONSHIP_TYPES = ["related-to", "explains", "example-of", "supersedes", "derives-from", "follows"] as const;
 export type RelationshipType = typeof RELATIONSHIP_TYPES[number];
@@ -84,7 +86,7 @@ export class Storage {
 
   async beginAtomicNotesWrite(): Promise<void> {
     if (this.stagedNotesDir) {
-      throw new Error("Atomic notes write already in progress");
+      throw new AtomicWriteInProgressError();
     }
 
     this.stagedNotesDir = path.join(this.vaultPath, `.notes-staging-${randomUUID()}`);
@@ -137,20 +139,18 @@ export class Storage {
 
     const stagedPath = this.stagedNotePath(id);
     if (stagedPath) {
-      try {
+      const result = await attempt("storage:readNote", async () => {
         const raw = await fs.readFile(stagedPath, "utf-8");
         return this.parseNote(id, raw);
-      } catch {
-        // fall back to committed note
-      }
+      });
+      if (result.ok) return result.value;
     }
 
-    try {
+    const result = await attempt("storage:readNote", async () => {
       const raw = await fs.readFile(this.notePath(id), "utf-8");
       return this.parseNote(id, raw);
-    } catch {
-      return null;
-    }
+    });
+    return result.ok ? result.value : null;
   }
 
   async deleteNote(id: MemoryId): Promise<boolean> {
@@ -158,11 +158,7 @@ export class Storage {
       this.stagedDeletedNoteIds.add(id);
       const stagedPath = this.stagedNotePath(id);
       if (stagedPath) {
-        try {
-          await fs.unlink(stagedPath);
-        } catch {
-          // ok
-        }
+        await attempt("storage:deleteStaged", () => fs.unlink(stagedPath));
       }
       return true;
     }
@@ -237,21 +233,16 @@ export class Storage {
   }
 
   async readEmbedding(id: MemoryId): Promise<EmbeddingRecord | null> {
-    try {
-      const raw = await fs.readFile(this.embeddingPath(id), "utf-8");
-      return validateEmbeddingRecord(JSON.parse(raw));
-    } catch {
-      return null;
-    }
+    const raw = await attempt("storage:readEmbedding", () => fs.readFile(this.embeddingPath(id), "utf-8"));
+    if (!raw.ok) return null;
+    const parsed = await attempt("storage:readEmbedding", () => JSON.parse(raw.value));
+    if (!parsed.ok) return null;
+    return validateEmbeddingRecord(parsed.value);
   }
 
   async listEmbeddings(): Promise<EmbeddingRecord[]> {
-    let files: string[];
-    try {
-      files = await fs.readdir(this.embeddingsDir);
-    } catch {
-      return [];
-    }
+    const filesResult = await attempt("storage:listEmbeddings", () => fs.readdir(this.embeddingsDir), [] as string[]);
+    const files = filesResult.ok ? filesResult.value : [];
     const ids = files
       .filter((file) => file.endsWith(".json"))
       .map((file) => memoryId(file.replace(/\.json$/, "")));
@@ -271,12 +262,11 @@ export class Storage {
   }
 
   async readProjection(id: MemoryId): Promise<NoteProjection | null> {
-    try {
-      const raw = await fs.readFile(this.projectionPath(id), "utf-8");
-      return validateNoteProjection(JSON.parse(raw));
-    } catch {
-      return null;
-    }
+    const raw = await attempt("storage:readProjection", () => fs.readFile(this.projectionPath(id), "utf-8"));
+    if (!raw.ok) return null;
+    const parsed = await attempt("storage:readProjection", () => JSON.parse(raw.value));
+    if (!parsed.ok) return null;
+    return validateNoteProjection(parsed.value);
   }
 
   // ── Helpers ────────────────────────────────────────────────────────────────
@@ -306,27 +296,21 @@ export class Storage {
   private async listNoteIds(): Promise<MemoryId[]> {
     const ids = new Set<string>();
 
-    try {
-      const files = await fs.readdir(this.notesDir);
-      for (const file of files) {
-        if (file.endsWith(".md")) {
-          ids.add(file.replace(/\.md$/, ""));
-        }
+    const filesResult = await attempt("storage:listNoteIds", () => fs.readdir(this.notesDir), [] as string[]);
+    const files = filesResult.ok ? filesResult.value : [];
+    for (const file of files) {
+      if (file.endsWith(".md")) {
+        ids.add(file.replace(/\.md$/, ""));
       }
-    } catch {
-      // treat as empty
     }
 
     if (this.stagedNotesDir) {
-      try {
-        const stagedFiles = await fs.readdir(this.stagedNotesDir);
-        for (const file of stagedFiles) {
-          if (file.endsWith(".md")) {
-            ids.add(file.replace(/\.md$/, ""));
-          }
+      const stagedResult = await attempt("storage:listStagedNoteIds", () => fs.readdir(this.stagedNotesDir!), [] as string[]);
+      const stagedFiles = stagedResult.ok ? stagedResult.value : [];
+      for (const file of stagedFiles) {
+        if (file.endsWith(".md")) {
+          ids.add(file.replace(/\.md$/, ""));
         }
-      } catch {
-        // treat as empty
       }
     }
 
@@ -349,7 +333,7 @@ export class Storage {
 
   private parseNote(id: MemoryId, raw: string): Note {
     if (!raw.trimStart().startsWith("---")) {
-      throw new Error(`Malformed note '${id}': missing frontmatter`);
+      throw new MalformedNoteError(id);
     }
 
     const parsed = matter(raw);
@@ -406,7 +390,7 @@ function isNoteImportance(value: unknown): value is NoteImportance {
 
 function validateNoteId(id: string): void {
   if (!isValidMemoryId(id)) {
-    throw new Error(`Invalid note ID: "${id}" contains characters that are not allowed (only alphanumeric, hyphens, and underscores)`);
+    throw new InvalidNoteIdError(id);
   }
 }
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -305,7 +305,8 @@ export class Storage {
     }
 
     if (this.stagedNotesDir) {
-      const stagedResult = await attempt("storage:listStagedNoteIds", () => fs.readdir(this.stagedNotesDir!), [] as string[]);
+      const stagedDir = this.stagedNotesDir;
+      const stagedResult = await attempt("storage:listStagedNoteIds", () => fs.readdir(stagedDir), [] as string[]);
       const stagedFiles = stagedResult.ok ? stagedResult.value : [];
       for (const file of stagedFiles) {
         if (file.endsWith(".md")) {

--- a/src/temporal-interpretation.ts
+++ b/src/temporal-interpretation.ts
@@ -1,4 +1,5 @@
 import { metadataPrefixes } from "./git-constants.js";
+import { UnknownChangeCategoryError } from "./domain-errors.js";
 
 export const CHANGE_CATEGORIES = ["create", "refine", "expand", "clarify", "connect", "restructure", "reverse", "unknown"] as const;
 export type ChangeCategory = typeof CHANGE_CATEGORIES[number];
@@ -154,7 +155,7 @@ function generateChangeDescription(
 
     default: {
       const _exhaustive: never = category;
-      throw new Error(`Unhandled change category: ${_exhaustive}`);
+      throw new UnknownChangeCategoryError(_exhaustive);
     }
   }
 }

--- a/src/temporal-interpretation.ts
+++ b/src/temporal-interpretation.ts
@@ -119,9 +119,9 @@ function generateChangeDescription(
   context?: InterpretHistoryContext
 ): string {
   const hasContent = hasStats(entry);
-  const isSubstantial = hasContent &&
-    (entry.stats!.changeType === "substantial update" ||
-     entry.stats!.additions + entry.stats!.deletions > 50);
+  const isSubstantial = hasContent && entry.stats &&
+    (entry.stats.changeType === "substantial update" ||
+     entry.stats.additions + entry.stats.deletions > 50);
 
   switch (category) {
     case "create":

--- a/src/tools/consolidate-helpers.ts
+++ b/src/tools/consolidate-helpers.ts
@@ -10,7 +10,7 @@ import {
 } from "../consolidate.js";
 import { cosineSimilarity, embed, embedModel } from "../embeddings.js";
 import { classifyTheme, titleCaseTheme } from "../project-introspection.js";
-import { getErrorMessage } from "../error-utils.js";
+import { getErrorMessage, attempt } from "../error-utils.js";
 import { makeId, slugify } from "../helpers/index.js";
 import { memoryId, isoDateString } from "../brands.js";
 import { formatCommitBody, shouldBlockProtectedBranchCommit as shouldBlockProtectedBranchCommitFromModule, wouldRelationshipCleanupTouchProjectVault as wouldRelationshipCleanupTouchProjectVaultFromModule } from "../helpers/git-commit.js";
@@ -24,6 +24,7 @@ import type { Vault } from "../vault.js";
 import type { ConsolidationMode, ProjectMemoryPolicy } from "../project-memory-policy.js";
 import type { ConsolidateResult, ConsolidateExecuteMergeEvidence } from "../structured-content.js";
 import type { CommitResult, PushResult } from "../git.js";
+import { UnknownConsolidationModeError } from "../domain-errors.js";
 
 // Re-export helpers that close over ctx for convenience
 async function shouldBlockProtectedBranchCommit(ctx: ServerContext, options: Omit<Parameters<typeof shouldBlockProtectedBranchCommitFromModule>[0], "ctx">) {
@@ -311,10 +312,10 @@ export async function suggestMerges(
             return "preserves history";
           case "delete":
             return "removes sources";
-          default: {
-            const _exhaustive: never = effectiveMode;
-            return _exhaustive;
-          }
+    default: {
+      const _exhaustive: never = effectiveMode;
+      throw new UnknownConsolidationModeError(_exhaustive);
+    }
         }
       })();
 
@@ -547,8 +548,7 @@ export async function executeMerge(
 
   let embeddingStatus: { status: "written" | "skipped"; reason?: string } = { status: "written" };
 
-  // Generate embedding for consolidated note
-  try {
+  const embedResult = await attempt("consolidate:embed", async () => {
     const text = await embedTextForNote(targetVault.storage, consolidatedNote);
     const vector = await embed(text);
     await targetVault.storage.writeEmbedding({
@@ -557,9 +557,10 @@ export async function executeMerge(
       embedding: vector,
       updatedAt: now,
     });
-  } catch (err) {
-    embeddingStatus = { status: "skipped", reason: getErrorMessage(err) };
-    console.error(`[embedding] Failed for consolidated note '${targetId}': ${err}`);
+  });
+  if (!embedResult.ok) {
+    embeddingStatus = { status: "skipped", reason: getErrorMessage(embedResult.error) };
+    console.error(`[embedding] Failed for consolidated note '${targetId}': ${embedResult.error}`);
   }
 
   const vaultChanges = new Map<Vault, string[]>();
@@ -599,7 +600,7 @@ export async function executeMerge(
     }
     default: {
       const _exhaustive: never = consolidationMode;
-      throw new Error(`Unknown consolidation mode: ${_exhaustive}`);
+      throw new UnknownConsolidationModeError(_exhaustive);
     }
   }
 
@@ -629,7 +630,7 @@ export async function executeMerge(
         break;
       default: {
         const _exhaustive: never = consolidationMode;
-        throw new Error(`Unknown consolidation mode: ${_exhaustive}`);
+        throw new UnknownConsolidationModeError(_exhaustive);
       }
     }
 
@@ -705,7 +706,7 @@ export async function executeMerge(
       break;
     default: {
       const _exhaustive: never = consolidationMode;
-      throw new Error(`Unknown consolidation mode: ${_exhaustive}`);
+      throw new UnknownConsolidationModeError(_exhaustive);
     }
   }
 

--- a/src/tools/migration.ts
+++ b/src/tools/migration.ts
@@ -3,7 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ServerContext } from "../server-context.js";
 import { readVaultSchemaVersion } from "../config.js";
 import { MigrationListResultSchema, type MigrationListResult, MigrationExecuteResultSchema, type MigrationExecuteResult } from "../structured-content.js";
-import { getErrorMessage } from "../error-utils.js";
+import { getErrorMessage, attempt } from "../error-utils.js";
 import { ensureBranchSynced as ensureBranchSyncedFromModule, projectParam } from "../helpers/project.js";
 
 export function registerListMigrationsTool(server: McpServer, ctx: ServerContext): void {
@@ -111,7 +111,7 @@ export function registerExecuteMigrationTool(server: McpServer, ctx: ServerConte
     async ({ migrationName, dryRun, backup, cwd }) => {
       await ensureBranchSyncedFromModule(ctx, cwd);
 
-      try {
+      const migrationResult = await attempt("migration:execute", async () => {
         const { results, vaultsProcessed } = await ctx.migrator.runMigration(migrationName, {
           dryRun,
           backup,
@@ -169,15 +169,18 @@ export function registerExecuteMigrationTool(server: McpServer, ctx: ServerConte
           vaultResults,
         };
         
-        return { content: [{ type: "text", text: lines.join("\n") }], structuredContent };
-      } catch (err) {
+        return { content: [{ type: "text" as const, text: lines.join("\n") }], structuredContent };
+      });
+
+      if (!migrationResult.ok) {
         return {
           content: [{
-            type: "text",
-            text: `Migration failed: ${getErrorMessage(err)}`,
+            type: "text" as const,
+            text: `Migration failed: ${getErrorMessage(migrationResult.error)}`,
           }],
         };
       }
+      return migrationResult.value;
     }
   );
 }

--- a/src/tools/recall-helpers.ts
+++ b/src/tools/recall-helpers.ts
@@ -3,6 +3,7 @@ import type { Vault } from "../vault.js";
 import { getEffectiveMetadata } from "../role-suggestions.js";
 import { computeRecallMetadataBoost, type ScoredRecallCandidate, type TemporalQueryHint, shouldApplyTemporalFiltering, computeTemporalRecencyBoost, isWithinTemporalFilterWindow } from "../recall.js";
 import { getOrBuildProjection } from "../projections.js";
+import { attempt } from "../error-utils.js";
 import { getSessionCachedProjectionTokens, setSessionCachedProjectionTokens, getOrBuildVaultNoteList } from "../cache.js";
 import { tokenize, prepareTfIdfCorpusFromTokenizedDocuments, rankDocumentsByTfIdf, LEXICAL_RESCUE_CANDIDATE_LIMIT, LEXICAL_RESCUE_THRESHOLD, LEXICAL_RESCUE_RESULT_LIMIT } from "../lexical.js";
 import type { RecallDiversity, RecallRetrievalCoverage } from "../structured-content.js";
@@ -214,9 +215,9 @@ export async function identifyHighPriorityAnchors(
   const anchorLookup = new Map<string, string>();
 
   for (const vault of vaults) {
-    try {
+    const vaultResult = await attempt("recall:anchor-scan", async () => {
       const notes = await getOrBuildVaultNoteList(projectId, vault);
-      if (!notes) continue;
+      if (!notes) return undefined;
       const supersededTargets = new Set<string>();
       for (const note of notes) {
         if (note.project !== projectId) continue;
@@ -236,18 +237,18 @@ export async function identifyHighPriorityAnchors(
           anchorLookup.set(note.id, note.title);
         }
       }
-    } catch {
-      continue;
-    }
+      return undefined;
+    });
+    if (!vaultResult.ok) continue;
   }
 
   return { anchorIds, anchorLookup };
 }
 
-export function computeRecallDiversity(
+export async function computeRecallDiversity(
   results: Array<{ id: string; tags: string[]; lifecycle: NoteLifecycle; role?: string }>,
-): RecallDiversity | undefined {
-  try {
+): Promise<RecallDiversity | undefined> {
+  const result = await attempt("recall:diversity", () => {
     const allTags = new Set<string>();
     const roleCounts = new Map<string, number>();
     const lifecycleCounts = new Map<string, number>();
@@ -267,18 +268,18 @@ export function computeRecallDiversity(
       roleMix: Object.fromEntries(roleCounts) as Record<string, number>,
       lifecycleMix: Object.fromEntries(lifecycleCounts) as Record<string, number>,
     };
-  } catch {
-    return undefined;
-  }
+  });
+  if (!result.ok) return undefined;
+  return result.value;
 }
 
-export function computeRecallRetrievalCoverage(
+export async function computeRecallRetrievalCoverage(
   resultIds: string[],
   anchorIds: Set<string>,
   anchorLookup: Map<string, string>,
   maxMissing = 5,
-): RecallRetrievalCoverage | undefined {
-  try {
+): Promise<RecallRetrievalCoverage | undefined> {
+  const result = await attempt("recall:coverage", () => {
     const resultIdSet = new Set(resultIds);
     const anchorsInResults = [...anchorIds].filter((id) => resultIdSet.has(id)).length;
     const highPriorityAnchorsTotal = anchorIds.size;
@@ -295,7 +296,7 @@ export function computeRecallRetrievalCoverage(
       fraction,
       missingAnchors,
     };
-  } catch {
-    return undefined;
-  }
+  });
+  if (!result.ok) return undefined;
+  return result.value;
 }

--- a/src/tools/recall.ts
+++ b/src/tools/recall.ts
@@ -32,6 +32,7 @@ import {
   type ScoredRecallCandidate,
 } from "../recall.js";
 import { shouldTriggerLexicalRescue } from "../lexical.js";
+import { attempt } from "../error-utils.js";
 import {
   getOrBuildVaultEmbeddings,
   getOrBuildVaultNoteList,
@@ -136,7 +137,7 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
       let effectiveLimit = limit;
       let recallScopeNoteCount: number | undefined;
       if (project) {
-        try {
+        const scopeResult = await attempt("recall:scope-notes", async () => {
           let totalVisible = 0;
           for (const vault of vaults) {
             const noteList = await getOrBuildVaultNoteList(project.id, vault);
@@ -148,7 +149,8 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
           if (limit >= ctx.defaultRecallLimit && totalVisible <= 25) {
             effectiveLimit = Math.min(totalVisible, 20);
           }
-        } catch {
+        });
+        if (!scopeResult.ok) {
           // fail-soft: use configured limit
         }
       }
@@ -405,19 +407,16 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
           const centrality = note.relatedTo?.length ?? 0;
           const filePath = `${vault.notesRelDir}/${id}.md`;
           const provenance = await getNoteProvenance(vault.git, filePath);
-          const signalStrength = (() => {
-            try {
-              const ss = computeSignalStrength({
-                lifecycle: note.lifecycle,
-                updatedAt: note.updatedAt,
-                role: note.role,
-                centrality,
-              });
-              return Number.isFinite(ss) ? ss : undefined;
-            } catch {
-              return undefined;
-            }
-          })();
+          const signalStrengthResult = await attempt("recall:signal-strength", async () => {
+            const ss = computeSignalStrength({
+              lifecycle: note.lifecycle,
+              updatedAt: note.updatedAt,
+              role: note.role,
+              centrality,
+            });
+            return Number.isFinite(ss) ? ss : undefined;
+          });
+          const signalStrength = signalStrengthResult.ok ? signalStrengthResult.value : undefined;
           const confidence = computeConfidence(note.lifecycle, note.updatedAt, centrality, signalStrength);
           let history: Array<{
             commitHash: string;
@@ -533,14 +532,12 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
       let diversity: RecallResult["diversity"] | undefined;
       let retrievalCoverage: RecallRetrievalCoverage | undefined;
       if (structuredResults.length > 0) {
-        diversity = computeRecallDiversity(structuredResults);
+        diversity = await computeRecallDiversity(structuredResults);
         if (project) {
-          try {
-            const { anchorIds, anchorLookup } = await identifyHighPriorityAnchors(vaults, project.id);
-            const resultIds = structuredResults.map((r) => r.id);
-            retrievalCoverage = computeRecallRetrievalCoverage(resultIds, anchorIds, anchorLookup);
-          } catch {
-            // fail-soft
+          const { anchorIds, anchorLookup } = await identifyHighPriorityAnchors(vaults, project.id);
+          const coverageResult = await computeRecallRetrievalCoverage(structuredResults.map((r) => r.id), anchorIds, anchorLookup);
+          if (coverageResult) {
+            retrievalCoverage = coverageResult;
           }
         }
       }

--- a/src/tools/remember.ts
+++ b/src/tools/remember.ts
@@ -3,7 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ServerContext } from "../server-context.js";
 import { NOTE_LIFECYCLES, NOTE_ROLES, type Note } from "../storage.js";
 import { isoDateString } from "../brands.js";
-import { getErrorMessage } from "../error-utils.js";
+import { getErrorMessage, attempt } from "../error-utils.js";
 import { embed, embedModel } from "../embeddings.js";
 import {
   invalidateActiveProjectCache,
@@ -131,9 +131,9 @@ export function registerRememberTool(server: McpServer, ctx: ServerContext): voi
 
       const project = await resolveProject(ctx, cwd);
       let cleanedContent: string;
-      try {
-        cleanedContent = await cleanMarkdown(content);
-      } catch (err) {
+      const cleanResult = await attempt("remember:clean-markdown", async () => cleanMarkdown(content));
+      if (!cleanResult.ok) {
+        const err = cleanResult.error;
         if (err instanceof MarkdownLintError) {
           const message = `Markdown lint issues prevented this note from being stored. Fix the specific lint errors listed below in your content and retry the remember call — the note was NOT stored.\n\n${err.message}`;
           return {
@@ -144,6 +144,7 @@ export function registerRememberTool(server: McpServer, ctx: ServerContext): voi
         }
         throw err;
       }
+      cleanedContent = cleanResult.value;
       const policy = project ? await ctx.configStore.getProjectPolicy(project.id) : undefined;
       const policyScope = policy?.defaultScope;
       const projectVaultExists = cwd ? Boolean(await ctx.vaultManager.getProjectVaultIfExists(cwd)) : true;
@@ -204,13 +205,14 @@ export function registerRememberTool(server: McpServer, ctx: ServerContext): voi
 
       let embeddingStatus: { status: "written" | "skipped"; reason?: string } = { status: "written" };
 
-      try {
+      const embedResult = await attempt("remember:embed", async () => {
         const text = await embedTextForNote(vault.storage, note);
         const vector = await embed(text);
         await vault.storage.writeEmbedding({ id, model: embedModel, embedding: vector, updatedAt: now });
-      } catch (err) {
-        embeddingStatus = { status: "skipped", reason: getErrorMessage(err) };
-        console.error(`[embedding] Skipped for '${id}': ${err}`);
+      });
+      if (!embedResult.ok) {
+        embeddingStatus = { status: "skipped", reason: getErrorMessage(embedResult.error) };
+        console.error(`[embedding] Skipped for '${id}': ${embedResult.error}`);
       }
 
       const projectScope = describeProject(project);

--- a/src/tools/update.ts
+++ b/src/tools/update.ts
@@ -20,7 +20,7 @@ import {
 import { embedTextForNote } from "../helpers/embed.js";
 import { memoryId, isoDateString } from "../brands.js";
 import { cleanMarkdown, MarkdownLintError } from "../markdown.js";
-import { getErrorMessage } from "../error-utils.js";
+import { getErrorMessage, attempt, attemptSync } from "../error-utils.js";
 import { embed, embedModel } from "../embeddings.js";
 import { applySemanticPatches, type SemanticPatch } from "../semantic-patch.js";
 import { hasActualChanges, computeFieldsModified } from "../update-detect-changes.js";
@@ -39,6 +39,14 @@ import {
   NoteIdSchema,
   type PersistenceStatus,
 } from "../structured-content.js";
+
+function preprocessSemanticPatch(val: unknown): unknown {
+  if (typeof val === "string") {
+    const result = attemptSync("update:json-preprocess", () => JSON.parse(val));
+    return result.ok ? result.value : val;
+  }
+  return val;
+}
 
 export function registerUpdateTool(server: McpServer, ctx: ServerContext): void {
   server.registerTool(
@@ -70,12 +78,7 @@ export function registerUpdateTool(server: McpServer, ctx: ServerContext): void 
         id: NoteIdSchema.describe("Exact memory id. Use an id returned by `recall`, `list`, `recent_memories`, or `where_is`."),
         semanticPatch: z
           .preprocess(
-            (val) => {
-              if (typeof val === "string") {
-                try { return JSON.parse(val); } catch { return val; }
-              }
-              return val;
-            },
+            preprocessSemanticPatch,
             z.array(z.object({
             selector: z.object({
               heading: z.string().optional(),
@@ -189,11 +192,11 @@ export function registerUpdateTool(server: McpServer, ctx: ServerContext): void 
       let patchedContent: string | undefined;
       let lintWarnings: string[] | undefined;
       if (semanticPatch && semanticPatch.length > 0) {
-        try {
-          const result = await applySemanticPatches(note.content, semanticPatch as SemanticPatch[]);
-          patchedContent = result.content;
-          lintWarnings = result.lintWarnings;
-        } catch (err) {
+        const patchResult = await attempt("update:semantic-patch", () =>
+          applySemanticPatches(note.content, semanticPatch as SemanticPatch[]),
+        );
+        if (!patchResult.ok) {
+          const err = patchResult.error;
           if (err instanceof MarkdownLintError) {
             const message = `Semantic patch produced content with markdown lint issues. Fix the lint issues in your patch values and retry — do NOT fall back to full content rewrite.\n\n${err.message}`;
             return { content: [{ type: "text", text: message }], isError: true };
@@ -201,12 +204,14 @@ export function registerUpdateTool(server: McpServer, ctx: ServerContext): void 
           const message = getErrorMessage(err);
           return { content: [{ type: "text", text: `Semantic patch failed: ${message}` }], isError: true };
         }
+        patchedContent = patchResult.value.content;
+        lintWarnings = patchResult.value.lintWarnings;
       }
       let cleanedContent: string | undefined;
       if (content !== undefined) {
-        try {
-          cleanedContent = await cleanMarkdown(content);
-        } catch (err) {
+        const cleanResult = await attempt("update:clean-markdown", () => cleanMarkdown(content));
+        if (!cleanResult.ok) {
+          const err = cleanResult.error;
           if (err instanceof MarkdownLintError) {
             const message = `Markdown lint issues prevented the update. Fix the specific lint errors in your content and retry — do NOT fall back to semanticPatch for this.\n\n${err.message}`;
             return {
@@ -217,6 +222,7 @@ export function registerUpdateTool(server: McpServer, ctx: ServerContext): void 
           }
           throw err;
         }
+        cleanedContent = cleanResult.value;
       }
 
       const resolvedTitle = title ?? note.title;
@@ -346,14 +352,16 @@ export function registerUpdateTool(server: McpServer, ctx: ServerContext): void 
       let embeddingStatus: { status: "written" | "skipped"; reason?: string } = { status: "skipped", reason: shouldReembed ? undefined : "metadata-only" };
 
       if (shouldReembed) {
-        try {
+        const embedResult = await attempt("update:re-embed", async () => {
           const text = await embedTextForNote(vault.storage, updated);
           const vector = await embed(text);
           await vault.storage.writeEmbedding({ id: noteId, model: embedModel, embedding: vector, updatedAt: now });
+        });
+        if (embedResult.ok) {
           embeddingStatus = { status: "written" };
-        } catch (err) {
-          embeddingStatus = { status: "skipped", reason: getErrorMessage(err) };
-          console.error(`[embedding] Re-embed failed for '${id}': ${err}`);
+        } else {
+          embeddingStatus = { status: "skipped", reason: getErrorMessage(embedResult.error) };
+          console.error(`[embedding] Re-embed failed for '${id}': ${embedResult.error}`);
         }
       }
 

--- a/src/tools/update.ts
+++ b/src/tools/update.ts
@@ -235,10 +235,11 @@ export function registerUpdateTool(server: McpServer, ctx: ServerContext): void 
       let relatedToChanged = false;
       let resolvedRelatedTo = note.relatedTo;
       if (note.project) {
-        const accessCandidates = getRecentSessionNoteAccesses(note.project)
+        const project = note.project;
+        const accessCandidates = getRecentSessionNoteAccesses(project)
           .map((entry) => {
-            const cachedNote = getSessionCachedNote(note.project!, entry.vaultPath, entry.noteId)
-              ?? getRecentSessionAccessNote(note.project!, entry.vaultPath, entry.noteId);
+            const cachedNote = getSessionCachedNote(project, entry.vaultPath, entry.noteId)
+              ?? getRecentSessionAccessNote(project, entry.vaultPath, entry.noteId);
             return cachedNote
               ? { note: cachedNote, accessedAt: entry.accessedAt, accessKind: entry.accessKind, score: entry.score }
               : null;

--- a/src/vault.ts
+++ b/src/vault.ts
@@ -2,7 +2,7 @@ import fs from "fs/promises";
 import path from "path";
 import { simpleGit } from "simple-git";
 
-import { debugLog, getErrorMessage } from "./error-utils.js";
+import { attempt, debugLog, getErrorMessage } from "./error-utils.js";
 import { Storage, type Note } from "./storage.js";
 import { memoryId } from "./brands.js";
 import { GitOps } from "./git.js";
@@ -258,57 +258,58 @@ function makeVault(
  * namespaces for submodule-specific context while sharing the same git history.
  */
 async function discoverSubmoduleVaultFolders(gitRoot: string): Promise<string[]> {
-  try {
-    const entries = await fs.readdir(gitRoot, { withFileTypes: true });
-    return entries
-      .filter(e => e.isDirectory() && e.name.startsWith(".mnemonic-"))
-      .map(e => e.name)
-      .sort();
-  } catch (err) {
-    debugLog("vault:discover-submodules", `failed: ${getErrorMessage(err)}`);
+  const result = await attempt("vault:discover-submodules", () =>
+    fs.readdir(gitRoot, { withFileTypes: true })
+  );
+  if (!result.ok) {
+    debugLog("vault:discover-submodules", `failed: ${getErrorMessage(result.error)}`);
     return [];
   }
+  return result.value
+    .filter(e => e.isDirectory() && e.name.startsWith(".mnemonic-"))
+    .map(e => e.name)
+    .sort();
 }
 
 async function findGitRoot(cwd: string, visited: Set<string> = new Set()): Promise<string | null> {
-  try {
-    const git = simpleGit(cwd);
-    const root = await git.revparse(["--show-toplevel"]);
-    const trimmedRoot = root.trim();
-    if (!trimmedRoot) return null;
-
-    // Guard against infinite recursion in pathological submodule configurations.
-    if (visited.has(trimmedRoot)) return trimmedRoot;
-    visited.add(trimmedRoot);
-
-    // When inside a git submodule, walk up to the top-level superproject root
-    // so that project vaults are always anchored at the main repository.
-    try {
-      const superproject = await git.revparse(["--show-superproject-working-tree"]);
-      const trimmedSuperproject = superproject.trim();
-      if (trimmedSuperproject) {
-        return findGitRoot(trimmedSuperproject, visited);
-      }
-    } catch {
-      debugLog("vault:find-git-root", "not inside a submodule or flag unsupported, using current root");
-    }
-
-    return trimmedRoot;
-  } catch (err) {
-    debugLog("vault:find-git-root", `failed: ${getErrorMessage(err)}`);
+  const git = simpleGit(cwd);
+  const rootResult = await attempt("vault:find-git-root", () =>
+    git.revparse(["--show-toplevel"])
+  );
+  if (!rootResult.ok) {
+    debugLog("vault:find-git-root", `failed: ${getErrorMessage(rootResult.error)}`);
     return null;
   }
+  const trimmedRoot = rootResult.value.trim();
+  if (!trimmedRoot) return null;
+
+  if (visited.has(trimmedRoot)) return trimmedRoot;
+  visited.add(trimmedRoot);
+
+  const superResult = await attempt("vault:find-git-root:superproject", () =>
+    git.revparse(["--show-superproject-working-tree"])
+  );
+  if (superResult.ok) {
+    const trimmedSuperproject = superResult.value.trim();
+    if (trimmedSuperproject) {
+      return findGitRoot(trimmedSuperproject, visited);
+    }
+  } else {
+    debugLog("vault:find-git-root", "not inside a submodule or flag unsupported, using current root");
+  }
+
+  return trimmedRoot;
 }
 
 export async function ensureGitignore(ignorePath: string): Promise<void> {
   const requiredLines = ["embeddings/", "projections/"];
-  let existing: string;
-  try {
-    existing = await fs.readFile(ignorePath, "utf-8");
-  } catch (err) {
-    debugLog("vault:ensure-gitignore", `no existing gitignore: ${getErrorMessage(err)}`);
-    existing = "";
-  }
+  const existingResult = await attempt("vault:ensure-gitignore", () =>
+    fs.readFile(ignorePath, "utf-8")
+  );
+  const existing = existingResult.ok ? existingResult.value : (() => {
+    debugLog("vault:ensure-gitignore", `no existing gitignore: ${getErrorMessage(existingResult.error)}`);
+    return "";
+  })();
   const missing = requiredLines.filter(line => !existing.includes(line));
   if (missing.length === 0) return;
   const updated = existing.trimEnd() + "\n" + missing.join("\n") + "\n";
@@ -316,10 +317,6 @@ export async function ensureGitignore(ignorePath: string): Promise<void> {
 }
 
 async function pathExists(p: string): Promise<boolean> {
-  try {
-    await fs.access(p);
-    return true;
-  } catch {
-    return false;
-  }
+  const result = await attempt("vault:pathExists", () => fs.access(p));
+  return result.ok;
 }

--- a/tests/cache.unit.test.ts
+++ b/tests/cache.unit.test.ts
@@ -444,7 +444,7 @@ describe("measurement / instrumentation", () => {
     await getOrBuildVaultNoteList("test-project", vault);
 
     const logs = spy.mock.calls.map((args) => args[0] as string);
-    expect(logs.some((l) => l.includes("[cache:fallback]"))).toBe(true);
+    expect(logs.some((l) => l.includes("[cache:build]") && l.includes("fail-soft"))).toBe(true);
     spy.mockRestore();
   });
 

--- a/tests/recall-helpers.unit.test.ts
+++ b/tests/recall-helpers.unit.test.ts
@@ -7,45 +7,45 @@ import {
 import type { NoteLifecycle } from "../src/storage.js";
 
 describe("computeRecallDiversity", () => {
-  it("returns diversity metrics from recall results", () => {
+  it("returns diversity metrics from recall results", async () => {
     const results = [
       { id: "a", tags: ["workflow", "plan"], lifecycle: "temporary" as NoteLifecycle, role: "plan" },
       { id: "b", tags: ["workflow", "decision"], lifecycle: "permanent" as NoteLifecycle, role: "decision" },
       { id: "c", tags: ["bug"], lifecycle: "temporary" as NoteLifecycle, role: "context" },
     ];
-    const diversity = computeRecallDiversity(results);
+    const diversity = await computeRecallDiversity(results);
     expect(diversity).toBeDefined();
     expect(diversity!.themeCount).toBe(4);
     expect(diversity!.roleMix).toEqual({ plan: 1, decision: 1, context: 1 });
     expect(diversity!.lifecycleMix).toEqual({ temporary: 2, permanent: 1 });
   });
 
-  it("counts unique tags across all results", () => {
+  it("counts unique tags across all results", async () => {
     const results = [
       { id: "a", tags: ["x", "y"], lifecycle: "permanent" as NoteLifecycle, role: "summary" },
       { id: "b", tags: ["y", "z"], lifecycle: "permanent" as NoteLifecycle, role: "summary" },
     ];
-    const diversity = computeRecallDiversity(results);
+    const diversity = await computeRecallDiversity(results);
     expect(diversity!.themeCount).toBe(3);
   });
 
-  it("omits role when undefined", () => {
+  it("omits role when undefined", async () => {
     const results = [
       { id: "a", tags: ["test"], lifecycle: "temporary" as NoteLifecycle },
     ];
-    const diversity = computeRecallDiversity(results);
+    const diversity = await computeRecallDiversity(results);
     expect(diversity!.roleMix).toEqual({});
     expect(diversity!.lifecycleMix).toEqual({ temporary: 1 });
   });
 
-  it("returns undefined on computation failure", () => {
+  it("returns undefined on computation failure", async () => {
     const results = null as unknown as Array<{ id: string; tags: string[]; lifecycle: NoteLifecycle; role?: string }>;
-    const diversity = computeRecallDiversity(results);
+    const diversity = await computeRecallDiversity(results);
     expect(diversity).toBeUndefined();
   });
 
-  it("returns empty diversity for empty results", () => {
-    const diversity = computeRecallDiversity([]);
+  it("returns empty diversity for empty results", async () => {
+    const diversity = await computeRecallDiversity([]);
     expect(diversity).toBeDefined();
     expect(diversity!.themeCount).toBe(0);
     expect(diversity!.roleMix).toEqual({});
@@ -54,7 +54,7 @@ describe("computeRecallDiversity", () => {
 });
 
 describe("computeRecallRetrievalCoverage", () => {
-  it("computes coverage fraction for anchors in results", () => {
+  it("computes coverage fraction for anchors in results", async () => {
     const anchorIds = new Set(["a1", "a2", "a3"]);
     const anchorLookup = new Map([
       ["a1", "Anchor One"],
@@ -63,7 +63,7 @@ describe("computeRecallRetrievalCoverage", () => {
     ]);
     const resultIds = ["a1", "other", "a3"];
 
-    const coverage = computeRecallRetrievalCoverage(resultIds, anchorIds, anchorLookup);
+    const coverage = await computeRecallRetrievalCoverage(resultIds, anchorIds, anchorLookup);
     expect(coverage).toBeDefined();
     expect(coverage!.anchorsInResults).toBe(2);
     expect(coverage!.highPriorityAnchorsTotal).toBe(3);
@@ -71,18 +71,18 @@ describe("computeRecallRetrievalCoverage", () => {
     expect(coverage!.missingAnchors).toEqual([{ id: "a2", title: "Anchor Two" }]);
   });
 
-  it("returns fraction 0 when no anchors exist", () => {
+  it("returns fraction 0 when no anchors exist", async () => {
     const anchorIds = new Set<string>();
     const anchorLookup = new Map<string, string>();
     const resultIds = ["x", "y"];
 
-    const coverage = computeRecallRetrievalCoverage(resultIds, anchorIds, anchorLookup);
+    const coverage = await computeRecallRetrievalCoverage(resultIds, anchorIds, anchorLookup);
     expect(coverage!.highPriorityAnchorsTotal).toBe(0);
     expect(coverage!.fraction).toBe(0);
     expect(coverage!.missingAnchors).toEqual([]);
   });
 
-  it("returns fraction 1 when all anchors are in results", () => {
+  it("returns fraction 1 when all anchors are in results", async () => {
     const anchorIds = new Set(["a1", "a2"]);
     const anchorLookup = new Map([
       ["a1", "Anchor One"],
@@ -90,13 +90,13 @@ describe("computeRecallRetrievalCoverage", () => {
     ]);
     const resultIds = ["a1", "a2", "other"];
 
-    const coverage = computeRecallRetrievalCoverage(resultIds, anchorIds, anchorLookup);
+    const coverage = await computeRecallRetrievalCoverage(resultIds, anchorIds, anchorLookup);
     expect(coverage!.anchorsInResults).toBe(2);
     expect(coverage!.fraction).toBe(1);
     expect(coverage!.missingAnchors).toEqual([]);
   });
 
-  it("caps missing anchors at maxMissing", () => {
+  it("caps missing anchors at maxMissing", async () => {
     const anchorIds = new Set(["a1", "a2", "a3", "a4", "a5", "a6", "a7"]);
     const anchorLookup = new Map([
       ["a1", "A1"], ["a2", "A2"], ["a3", "A3"],
@@ -104,21 +104,21 @@ describe("computeRecallRetrievalCoverage", () => {
     ]);
     const resultIds = ["other"];
 
-    const coverage = computeRecallRetrievalCoverage(resultIds, anchorIds, anchorLookup, 3);
+    const coverage = await computeRecallRetrievalCoverage(resultIds, anchorIds, anchorLookup, 3);
     expect(coverage!.missingAnchors.length).toBe(3);
   });
 
-  it("uses unknown title for missing anchor lookup", () => {
+  it("uses unknown title for missing anchor lookup", async () => {
     const anchorIds = new Set(["orphan"]);
     const anchorLookup = new Map<string, string>();
     const resultIds: string[] = [];
 
-    const coverage = computeRecallRetrievalCoverage(resultIds, anchorIds, anchorLookup);
+    const coverage = await computeRecallRetrievalCoverage(resultIds, anchorIds, anchorLookup);
     expect(coverage!.missingAnchors).toEqual([{ id: "orphan", title: "(unknown)" }]);
   });
 
-  it("returns undefined on computation failure", () => {
-    const coverage = computeRecallRetrievalCoverage(null as any, null as any, null as any);
+  it("returns undefined on computation failure", async () => {
+    const coverage = await computeRecallRetrievalCoverage(null as any, null as any, null as any);
     expect(coverage).toBeUndefined();
   });
 });


### PR DESCRIPTION
Introduce a lightweight Result<T, E> type and attempt() wrapper in error-utils.ts that auto-logs failures via debugLog, making fail-soft paths explicit and traceable. Add five ast-grep rules (no-bare-try-catch, no-silent-catch, no-bare-new-error, no-unsafe-json-parse, no-console-log) with file-level allowlists. Wire lint:ast into CI and package scripts so violations block merges.