### PR TITLE
Reject unrecognized CLI commands instead of silently starting MCP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to `mnemonic` will be documented in this file.
 
 The format is loosely based on Keep a Changelog and uses semver-style version headings.
 
+## [0.30.1] - 2026-05-11
+
+### Fixed
+
+- Running an unrecognized CLI command (e.g. `mnemonic sync`) now prints a clear error instead of silently starting the MCP server and hanging. The error lists available CLI commands and explains that tools like `sync` require an MCP client session.
+- `mnemonic --help` now shows available CLI commands, MCP-only tools, and usage examples.
+
+### Changed
+
+- README and homepage: the `import-claude-memory` follow-up step now references the `sync` MCP tool instead of suggesting `mnemonic sync` as a CLI command.
+
 ## [0.30.0] - 2026-05-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -509,7 +509,7 @@ mnemonic import-claude-memory --cwd=/path/to/project
 mnemonic import-claude-memory --claude-home=/custom/.claude
 ```
 
-Imported notes are written to the main vault with `lifecycle: permanent` and `scope: global`. After importing, run `sync` to embed them and push to your remote.
+Imported notes are written to the main vault with `lifecycle: permanent` and `scope: global`. After importing, ask your MCP client to run the `sync` tool to embed them and push to your remote.
 
 ## Prompts
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -2044,8 +2044,7 @@ VAULT_PATH = <span class="str">"/Users/you/mnemonic-vault"</span></pre>
 <span class="cmt"># Specific project path</span>
 <span class="cmd">mnemonic import-claude-memory --cwd=/path/to/project</span>
 
-<span class="cmt"># Then embed and push</span>
-<span class="cmd">mnemonic sync</span></pre>
+<span class="cmt"># Then ask your MCP client to run the sync tool to embed and push</span></pre>
         </div>
       </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@danielmarbach/mnemonic-mcp",
-      "version": "0.30.0",
+      "version": "0.30.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.1",
         "gray-matter": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "description": "A local MCP memory server backed by markdown + JSON files, synced via git",
   "type": "module",
   "repository": {

--- a/rules/no-bare-new-error.yml
+++ b/rules/no-bare-new-error.yml
@@ -11,6 +11,7 @@ files:
   - "src/**/*.ts"
 ignores:
   - "src/brands.ts"
+  - "src/cli/**"
   - "src/__tests__/**"
 note: |
   Bare `new Error(...)` is acceptable in assertion functions (`brands.ts`) and

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -1,0 +1,73 @@
+import { runMigrateCli } from "./migrate.js";
+import { runImportCli } from "./import-claude-memory.js";
+
+export const CLI_COMMANDS = [
+  { name: "migrate", description: "Apply pending schema migrations to vaults" },
+  { name: "import-claude-memory", description: "Import Claude Code auto-memory into the vault" },
+] as const;
+
+export type CliCommand = (typeof CLI_COMMANDS)[number]["name"];
+
+export function isCliCommand(arg: string): arg is CliCommand {
+  return CLI_COMMANDS.some(c => c.name === arg);
+}
+
+export function showHelp(): never {
+  const commandList = CLI_COMMANDS.map(c => `  ${c.name.padEnd(24)}${c.description}`).join("\n");
+  console.log(`mnemonic — local MCP memory server backed by markdown + git
+
+Usage:
+  mnemonic <command> [options]    Run a CLI command
+  mnemonic                        Start the MCP server (for MCP client config)
+
+CLI commands:
+${commandList}
+
+MCP-only tools (not available from the CLI):
+  sync, remember, recall, get, update, forget, list, consolidate, ...
+
+  These tools are available through MCP clients (Claude Code, Cursor, etc.)
+  that start the mnemonic server automatically. They cannot be run as
+  CLI commands — use an MCP client session instead.
+
+Options:
+  --help, -h            Show this message
+
+Examples:
+  mnemonic migrate --dry-run
+  mnemonic import-claude-memory --dry-run
+  mnemonic              # starts the MCP server (used by MCP client config)
+`);
+  process.exit(0);
+}
+
+export function rejectUnknownCommand(command: string): never {
+  console.error(`Unknown command: ${command}`);
+  console.error();
+  console.error(`Available CLI commands: ${CLI_COMMANDS.map(c => c.name).join(", ")}`);
+  console.error();
+  console.error("Tools like sync, remember, recall, etc. are MCP-only and");
+  console.error("require an MCP client session. Run 'mnemonic --help' for details.");
+  process.exit(1);
+}
+
+export async function runCliCommand(command: CliCommand): Promise<void> {
+  switch (command) {
+    case "migrate":
+      await runMigrateCli().catch(err => {
+        console.error("Migration failed:", err);
+        process.exit(1);
+      });
+      process.exit(0);
+    case "import-claude-memory":
+      await runImportCli().catch(err => {
+        console.error("Import failed:", err);
+        process.exit(1);
+      });
+      process.exit(0);
+    default: {
+      const _exhaustive: never = command;
+      throw new Error(`Unhandled CLI command: ${_exhaustive}`);
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,25 +5,28 @@ import { registerAllTools } from "./tools/index.js";
 import { registerPrompts } from "./prompts.js";
 import { createServerContext, readPackageVersion } from "./context.js";
 import { startServer } from "./startup.js";
-import { runMigrateCli } from "./cli/migrate.js";
-import { runImportCli } from "./cli/import-claude-memory.js";
+import { isCliCommand, showHelp, rejectUnknownCommand, runCliCommand } from "./cli/dispatch.js";
 
-// ── CLI commands ────────────────────────────────────────────────────────────────
+// ── CLI dispatch ────────────────────────────────────────────────────────────────
 
-if (process.argv[2] === "migrate") {
-  await runMigrateCli().catch(err => {
-    console.error("Migration failed:", err);
-    process.exit(1);
-  });
-  process.exit(0);
+const cliArg = process.argv[2];
+
+if (cliArg === "--help" || cliArg === "-h") {
+  showHelp();
 }
 
-if (process.argv[2] === "import-claude-memory") {
-  await runImportCli().catch(err => {
-    console.error("Import failed:", err);
-    process.exit(1);
-  });
-  process.exit(0);
+if (cliArg !== undefined && isCliCommand(cliArg)) {
+  await runCliCommand(cliArg);
+}
+
+if (cliArg !== undefined && !cliArg.startsWith("-")) {
+  rejectUnknownCommand(cliArg);
+}
+
+if (cliArg !== undefined && cliArg.startsWith("-")) {
+  console.error(`Unknown option: ${cliArg}`);
+  console.error("Run 'mnemonic --help' for usage.");
+  process.exit(1);
 }
 
 // ── MCP Server ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Running  (or any non-CLI argument) now exits with a clear error listing available CLI commands and explaining that tools like sync, remember, etc. require an MCP client session. Adds  flag showing CLI vs MCP-only tool distinction. Fixes misleading  in README and homepage import-claude-memory docs. Bumps version to 0.30.1.