### PR TITLE
Recall scoring uses RRF with dense rank tie handling

### DIFF
--- a/.mnemonic/notes/apply-three-channel-rrf-graph-rank-and-rank-window-implement-4876709b.md
+++ b/.mnemonic/notes/apply-three-channel-rrf-graph-rank-and-rank-window-implement-4876709b.md
@@ -7,7 +7,7 @@ tags:
   - ranking
 lifecycle: temporary
 createdAt: '2026-05-25T16:05:13.044Z'
-updatedAt: '2026-05-25T16:05:21.293Z'
+updatedAt: '2026-05-25T16:38:15.818Z'
 role: context
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -40,12 +40,14 @@ Implemented the RRF plan in source and tests.
 - Changed retrieval evidence channel from `graph` to `graph-rank` and now emits it whenever `graphRank !== undefined`.
 - Added `RRF_RANK_WINDOW = 100` and applied rank-window truncation through `assignDenseRanks` for semantic, lexical, and graph channels.
 - Changed lexical rank assignment to require lexical evidence so graph-only candidates do not receive fake lexical contribution.
+- Fixed review blocker: all-ranks-missing hybrid fallback now keeps canonical contribution scaled by `CANONICAL_HYBRID_WEIGHT`.
 
 ## Tests updated
 
 - Added unit coverage for graphRank contribution to hybrid scoring.
+- Added unit coverage for weighted canonical fallback when all rank channels are missing.
 - Added semantic rank window truncation and small-set no-op coverage.
-- Updated graph spreading tests to assert score/boosted/semantic promotion are not contaminated.
+- Updated graph spreading tests to assert score, boosted, and semantic promotion are not contaminated.
 - Added graph rank window truncation coverage.
 - Updated canonical promotion test to use explicit graph channel evidence.
 
@@ -57,15 +59,15 @@ Implemented the RRF plan in source and tests.
 
 - Command: `npm test -- tests/recall.unit.test.ts`
 - Result: pass
-- Details: 56/56 recall unit tests passed.
+- Details: 57/57 recall unit tests passed.
 
 - Command: `npm test`
-- Result: pass after rebuild
-- Details: first run failed due stale `build/` artifact importing removed `summarizePreview`; after `npm run build`, full suite passed 1130/1130.
+- Result: pass
+- Details: after removing ignored stale `build/` artifacts and rebuilding from source, full suite passed 1131/1131.
 
 - Command: dogfood recall query `RRF graph rank channel rank window recall ranking improvements`
 - Result: pass
-- Details: returned the active RRF plan, research, and request as top results without obvious ranking regression.
+- Details: returned the active RRF plan, research, request, and apply note as top results without obvious ranking regression.
 
 ## Constraints checked
 
@@ -75,3 +77,8 @@ Implemented the RRF plan in source and tests.
 - Semantic ranks remain based on original semantic retrieval ordering.
 - Graph evidence flows through `graphRank` instead of raw score mutation.
 - Rank window truncates channel contribution, not candidate inclusion.
+- Canonical contribution remains bounded by `CANONICAL_HYBRID_WEIGHT` even when all rank channels are missing.
+
+## Review outcome
+
+Fresh TypeScript review found one blocker: candidates beyond all rank windows could have received unscaled canonical contribution through the all-ranks-missing fallback. Fixed in `src/recall.ts` and covered in `tests/recall.unit.test.ts`.

--- a/.mnemonic/notes/apply-three-channel-rrf-graph-rank-and-rank-window-implement-4876709b.md
+++ b/.mnemonic/notes/apply-three-channel-rrf-graph-rank-and-rank-window-implement-4876709b.md
@@ -7,11 +7,14 @@ tags:
   - ranking
 lifecycle: temporary
 createdAt: '2026-05-25T16:05:13.044Z'
-updatedAt: '2026-05-25T16:05:13.044Z'
+updatedAt: '2026-05-25T16:05:21.293Z'
 role: context
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: plan-three-channel-rrf-with-graph-rank-and-rank-window-size-1c7d15da
+    type: follows
 memoryVersion: 1
 ---
 # Apply: Three-channel RRF graph rank and rank window implementation

--- a/.mnemonic/notes/apply-three-channel-rrf-graph-rank-and-rank-window-implement-4876709b.md
+++ b/.mnemonic/notes/apply-three-channel-rrf-graph-rank-and-rank-window-implement-4876709b.md
@@ -1,0 +1,74 @@
+---
+title: 'Apply: three-channel RRF graph rank and rank window implementation'
+tags:
+  - workflow
+  - apply
+  - rrf
+  - ranking
+lifecycle: temporary
+createdAt: '2026-05-25T16:05:13.044Z'
+updatedAt: '2026-05-25T16:05:13.044Z'
+role: context
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+# Apply: Three-channel RRF graph rank and rank window implementation
+
+Implemented the RRF plan in source and tests.
+
+## Changed files
+
+- `src/recall.ts`
+- `src/tools/recall.ts`
+- `src/structured-content.ts`
+- `tests/recall.unit.test.ts`
+
+## Delivered changes
+
+- Added `graphScore?: number` and `graphRank?: number` to `ScoredRecallCandidate`.
+- Changed graph spreading activation to accumulate independent `graphScore` instead of mutating `score`, `boosted`, or semantic promotion score.
+- Graph-discovered candidates now start with `score = 0`, `boosted = 0`, `semanticScoreForPromotion = 0`, and rank only via `graphRank` unless another channel provides evidence.
+- Assigned graph ranks by dense ranking over `graphScore` after graph spreading.
+- Changed hybrid scoring to three-channel RRF: semantic, lexical, and graph-rank.
+- Reduced `RRF_SCALING_FACTOR` from `3.5` to `3.0` for the third channel.
+- Removed post-graph-spread semantic rank reassignment in `src/tools/recall.ts`.
+- Changed retrieval evidence channel from `graph` to `graph-rank` and now emits it whenever `graphRank !== undefined`.
+- Added `RRF_RANK_WINDOW = 100` and applied rank-window truncation through `assignDenseRanks` for semantic, lexical, and graph channels.
+- Changed lexical rank assignment to require lexical evidence so graph-only candidates do not receive fake lexical contribution.
+
+## Tests updated
+
+- Added unit coverage for graphRank contribution to hybrid scoring.
+- Added semantic rank window truncation and small-set no-op coverage.
+- Updated graph spreading tests to assert score/boosted/semantic promotion are not contaminated.
+- Added graph rank window truncation coverage.
+- Updated canonical promotion test to use explicit graph channel evidence.
+
+## Verification
+
+- Command: `npx tsc --noEmit`
+- Result: pass
+- Details: no TypeScript errors.
+
+- Command: `npm test -- tests/recall.unit.test.ts`
+- Result: pass
+- Details: 56/56 recall unit tests passed.
+
+- Command: `npm test`
+- Result: pass after rebuild
+- Details: first run failed due stale `build/` artifact importing removed `summarizePreview`; after `npm run build`, full suite passed 1130/1130.
+
+- Command: dogfood recall query `RRF graph rank channel rank window recall ranking improvements`
+- Result: pass
+- Details: returned the active RRF plan, research, and request as top results without obvious ranking regression.
+
+## Constraints checked
+
+- No new database, daemon, persisted ranking state, or third-party dependency.
+- Rescue candidate collection unchanged.
+- Canonical explanation promotion still gates on semantic plausibility; graph-discovered candidates use `semanticScoreForPromotion = 0`.
+- Semantic ranks remain based on original semantic retrieval ordering.
+- Graph evidence flows through `graphRank` instead of raw score mutation.
+- Rank window truncates channel contribution, not candidate inclusion.

--- a/.mnemonic/notes/decision-phase-2-recall-scoring-uses-rrf-with-dense-rank-tie-7969c37d.md
+++ b/.mnemonic/notes/decision-phase-2-recall-scoring-uses-rrf-with-dense-rank-tie-7969c37d.md
@@ -8,7 +8,7 @@ tags:
   - workflow
 lifecycle: permanent
 createdAt: '2026-04-25T07:46:10.910Z'
-updatedAt: '2026-05-09T21:10:39.019Z'
+updatedAt: '2026-05-25T14:17:30.658Z'
 role: decision
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -18,6 +18,8 @@ relatedTo:
     type: derives-from
   - id: mnemonic-key-design-decisions-3f2a6273
     type: related-to
+  - id: plan-three-channel-rrf-with-graph-rank-and-rank-window-size-1c7d15da
+    type: derives-from
 memoryVersion: 1
 ---
 # Decision: Phase 2 recall scoring uses RRF with dense rank tie handling

--- a/.mnemonic/notes/plan-three-channel-rrf-with-graph-rank-and-rank-window-size-1c7d15da.md
+++ b/.mnemonic/notes/plan-three-channel-rrf-with-graph-rank-and-rank-window-size-1c7d15da.md
@@ -7,7 +7,7 @@ tags:
   - ranking
 lifecycle: temporary
 createdAt: '2026-05-25T14:07:26.547Z'
-updatedAt: '2026-05-25T16:05:21.293Z'
+updatedAt: '2026-05-25T16:37:55.890Z'
 role: plan
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -34,26 +34,13 @@ Implements gaps 1 and 2 from research `research-rrf-ranking-improvements-article
 - [x] Step 1: Add `graphRank?: number` and `graphScore?: number` to `ScoredRecallCandidate` interface in `src/recall.ts`
 - [x] Step 2: Refactor `applyGraphSpreadingActivation` to NOT modify `candidate.score` or `candidate.boosted`. Instead, store `graphScore` on each candidate (existing + discovered). For existing candidates: set `graphScore += propagatedScore` (accumulate graph evidence). For graph-discovered candidates: set `graphScore = propagatedScore`, `score = 0`, `boosted = 0` (they have no semantic score; graph contribution flows only through `graphRank` RRF channel, not through `boosted`)
 - [x] Step 3: Assign `graphRank` using dense ranking by `graphScore` after spreading completes. Candidates with no graphScore get `graphRank = undefined`
-- [x] Step 4: Update `computeHybridScore` to three-channel RRF: `RRF = 1/(K+semanticRank) + 1/(K+lexicalRank) + 1/(K+graphRank)`. Missing channels contribute 0 (same pattern as current missing-rank handling)
-- [x] Step 5: Remove the post-spreading `semanticRank` reassignment in `src/tools/recall.ts:306-311`. Semantic ranks now reflect the original semantic retrieval order, not graph-boosted scores
-- [x] Step 6: Adjust `RRF_SCALING_FACTOR` from 3.5 to 3.0 so the three-channel max contribution stays close to the old two-channel contribution order of magnitude
+- [x] Step 4: Update `computeHybridScore` to three-channel RRF: `RRF = 1/(K+semanticRank) + 1/(K+lexicalRank) + 1/(K+graphRank)`. Missing channels contribute 0. Canonical contribution remains weighted even when every rank channel is missing
+- [x] Step 5: Remove the post-spreading `semanticRank` reassignment in `src/tools/recall.ts`. Semantic ranks now reflect the original semantic retrieval order, not graph-boosted scores
+- [x] Step 6: Adjust `RRF_SCALING_FACTOR` from `3.5` to `3.0` so the three-channel max contribution stays close to the old two-channel contribution order of magnitude
 - [x] Step 7: Remove all `semanticScoreForPromotion` modifications from graph spreading. Graph-discovered candidates get `semanticScoreForPromotion: 0` (same as rescue candidates). Canonical explanation promotion gates on the original semantic retrieval score, not graph-inflated scores
 - [x] Step 8: Update `RetrievalEvidenceChannel` type in `src/structured-content.ts` by replacing `"graph"` with `"graph-rank"`. Update channel evidence logic in `src/tools/recall.ts` to emit `"graph-rank"` when `graphRank !== undefined`, covering both graph-discovered and graph-boosted existing candidates
 
-**Constraint**: No changes to rescue candidate collection. Rescue candidates continue to contribute via lexical evidence only. Canonical explanation promotion only changed to remove graph-inflated semantic promotion.
-
-**Goal**: Graph spreading activation produces an independent rank channel instead of contaminating semantic scores.
-
-- [ ] Step 1: Add `graphRank?: number` and `graphScore?: number` to `ScoredRecallCandidate` interface in `src/recall.ts`
-- [ ] Step 2: Refactor `applyGraphSpreadingActivation` to NOT modify `candidate.score` or `candidate.boosted`. Instead, store `graphScore` on each candidate (existing + discovered). For existing candidates: set `graphScore += propagatedScore` (accumulate graph evidence). For graph-discovered candidates: set `graphScore = propagatedScore`, `score = 0`, `boosted = 0` (they have no semantic score — graph contribution flows only through `graphRank` RRF channel, not through `boosted`)
-- [ ] Step 3: Assign `graphRank` using dense ranking by `graphScore` after spreading completes. Candidates with no graphScore get `graphRank = undefined`
-- [ ] Step 4: Update `computeHybridScore` to three-channel RRF: `RRF = 1/(K+semanticRank) + 1/(K+lexicalRank) + 1/(K+graphRank)`. Missing channels contribute 0 (same pattern as current missing-rank handling)
-- [ ] Step 5: Remove the post-spreading `semanticRank` reassignment in `src/tools/recall.ts:306-311`. Semantic ranks must reflect the original semantic retrieval order, not graph-boosted scores
-- [ ] Step 6: Adjust `RRF_SCALING_FACTOR`. With three channels, max RRF ≈ 3/60 ≈ 0.050. At current 3.5× → 0.175. Reduce to 3.0× so max RRF contribution ≈ 0.150 (close to old two-channel max of \~0.115). Dogfooding will validate
-- [ ] Step 7: Remove all `semanticScoreForPromotion` modifications from graph spreading — both the `+= propagatedScore` on existing candidates (line 509-510) AND the initial `semanticScoreForPromotion: propagatedScore` on discovered candidates (line 516). Graph-discovered candidates should get `semanticScoreForPromotion: 0` (same as rescue candidates). Canonical explanation promotion gates on the original semantic retrieval score, not graph-inflated scores. Graph contribution already flows through the graphRank RRF channel
-- [ ] Step 8: Update `RetrievalEvidenceChannel` type in `src/structured-content.ts` — replace `"graph"` with `"graph-rank"` in the union type. Update the channel evidence logic in `src/tools/recall.ts` to emit `"graph-rank"` when `graphRank !== undefined`, replacing the current `graphDiscoveredIds.has(id)` check. This covers both graph-discovered AND graph-boosted-existing candidates
-
-**Constraint**: No changes to rescue candidates — they continue to contribute only via `lexicalRank`. No changes to canonical explanation promotion logic beyond `semanticScoreForPromotion` fix.
+**Constraint**: No changes to rescue candidate collection. Rescue candidates continue to contribute via lexical evidence only. Canonical explanation promotion only changed to remove graph-inflated semantic promotion and to preserve canonical weighting in all-ranks-missing fallback.
 
 ### Gap 2: Rank window size
 
@@ -63,47 +50,34 @@ Implements gaps 1 and 2 from research `research-rrf-ranking-improvements-article
 - [x] Step 10: When assigning `semanticRank`, `lexicalRank`, and `graphRank`, only candidates within the top `RRF_RANK_WINDOW` positions get a rank. Candidates beyond the window get `rank = undefined` for that channel (contributing 0, same as missing channel). This is truncation, not exclusion; candidates still appear via other channels
 - [x] Step 11: Apply window consistently in `assignDenseRanks`: it produces 1-based ranks for positions within the window and sets rank to `undefined` for positions beyond `RRF_RANK_WINDOW`
 
-**Constraint**: For vaults with < 100 candidates, the window has zero effect. Unit coverage verifies this small-vault behavior.
-
-**Goal**: Truncate rank lists before RRF fusion to improve top-position discrimination.
-
-- [ ] Step 9: Add `RRF_RANK_WINDOW = 100` constant to `src/recall.ts`
-- [ ] Step 10: When assigning `semanticRank`, `lexicalRank`, and `graphRank` — only candidates within the top `RRF_RANK_WINDOW` positions get a rank. Candidates beyond the window get `rank = undefined` for that channel (contributing 0, same as missing channel). This is truncation, not exclusion — candidates still appear via other channels
-- [ ] Step 11: Apply window consistently: `assignDenseRanks` already produces 1-based ranks. After assignment, set rank to `undefined` for positions > RRF\_RANK\_WINDOW
-
-**Constraint**: For vaults with < 100 candidates, the window has zero effect. No regression risk for small vaults.
+**Constraint**: For vaults with fewer than 100 candidates, the window has zero effect. Unit coverage verifies this small-vault behavior.
 
 ### Verification
 
 - [x] `npx tsc --noEmit` clean
-- [x] `npm test` passed after rebuilding stale `build/` artifacts (`1130/1130`)
+- [x] `npm test -- tests/recall.unit.test.ts` passed (`57/57`)
+- [x] `npm test` passed from a clean rebuild (`1131/1131`)
 - [x] New unit tests in `tests/recall.unit.test.ts`:
   - Three-channel RRF computation with graphRank
+  - Canonical contribution stays weighted when all rank channels are missing
   - Graph-discovered candidate has no semanticRank, gets graphRank
-  - Existing semantic candidate with graph boost keeps original semanticRank
+  - Existing semantic candidate with graph boost keeps original semantic score and boosted score
   - Rank window truncation (candidates beyond window get undefined rank)
-  - Rank window has no effect when candidate count < window
+  - Rank window has no effect when candidate count is below the window
 - [x] Updated existing tests that assumed two-channel RRF or graph score modification
-- [x] Dogfooding: recall query against local vault for `RRF graph rank channel rank window recall ranking improvements` returned the active plan, research, and request as top results without obvious ranking regression
+- [x] Dogfooding: recall query against local vault for `RRF graph rank channel rank window recall ranking improvements` returned the active plan, research, request, and apply note in top results without obvious ranking regression
 
-**Verification note**: First full `npm test` run failed because a stale `build/` artifact imported removed `summarizePreview`; `npm run build` refreshed artifacts and the rerun passed.
+**Verification note**: Early full-suite runs failed because stale ignored files in `build/` imported removed exports. Removing ignored `build/`, rebuilding from source, and rerunning the suite passed.
 
-- [ ] `npx tsc --noEmit` clean
-- [ ] `npm test` — all existing tests updated for three-channel RRF semantics
-- [ ] New unit tests in `tests/recall.unit.test.ts`:
-  - Three-channel RRF computation with graphRank
-  - Graph-discovered candidate has no semanticRank, gets graphRank
-  - Existing semantic candidate with graph boost keeps original semanticRank
-  - Rank window truncation (candidates beyond window get undefined rank)
-  - Rank window has no effect when candidate count < window
-- [ ] Update existing tests that assume two-channel RRF or graph score modification
-- [ ] Dogfooding: recall queries against local vault, verify no ranking regression
+### Review outcome
+
+Fresh TypeScript review found one blocker: when all ranks were missing, `computeHybridScore` returned unscaled canonical contribution. Fixed by applying `CANONICAL_HYBRID_WEIGHT` in the fallback and adding regression coverage.
 
 ### Non-goals
 
-- Weighted RRF (deferred — no measured evidence)
-- Changes to rescue candidate logic
-- Changes to canonical explanation promotion beyond semanticScoreForPromotion fix
+- Weighted RRF (deferred because there is no measured evidence)
+- Changes to rescue candidate collection
+- Changes to canonical explanation promotion beyond semantic promotion and weighted fallback fixes
 - New persistent state or metadata fields
 
 ### Derives-from

--- a/.mnemonic/notes/plan-three-channel-rrf-with-graph-rank-and-rank-window-size-1c7d15da.md
+++ b/.mnemonic/notes/plan-three-channel-rrf-with-graph-rank-and-rank-window-size-1c7d15da.md
@@ -7,7 +7,7 @@ tags:
   - ranking
 lifecycle: temporary
 createdAt: '2026-05-25T14:07:26.547Z'
-updatedAt: '2026-05-25T14:17:46.968Z'
+updatedAt: '2026-05-25T16:04:51.499Z'
 role: plan
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -29,12 +29,25 @@ Implements gaps 1 and 2 from research `research-rrf-ranking-improvements-article
 
 **Goal**: Graph spreading activation produces an independent rank channel instead of contaminating semantic scores.
 
+- [x] Step 1: Add `graphRank?: number` and `graphScore?: number` to `ScoredRecallCandidate` interface in `src/recall.ts`
+- [x] Step 2: Refactor `applyGraphSpreadingActivation` to NOT modify `candidate.score` or `candidate.boosted`. Instead, store `graphScore` on each candidate (existing + discovered). For existing candidates: set `graphScore += propagatedScore` (accumulate graph evidence). For graph-discovered candidates: set `graphScore = propagatedScore`, `score = 0`, `boosted = 0` (they have no semantic score; graph contribution flows only through `graphRank` RRF channel, not through `boosted`)
+- [x] Step 3: Assign `graphRank` using dense ranking by `graphScore` after spreading completes. Candidates with no graphScore get `graphRank = undefined`
+- [x] Step 4: Update `computeHybridScore` to three-channel RRF: `RRF = 1/(K+semanticRank) + 1/(K+lexicalRank) + 1/(K+graphRank)`. Missing channels contribute 0 (same pattern as current missing-rank handling)
+- [x] Step 5: Remove the post-spreading `semanticRank` reassignment in `src/tools/recall.ts:306-311`. Semantic ranks now reflect the original semantic retrieval order, not graph-boosted scores
+- [x] Step 6: Adjust `RRF_SCALING_FACTOR` from 3.5 to 3.0 so the three-channel max contribution stays close to the old two-channel contribution order of magnitude
+- [x] Step 7: Remove all `semanticScoreForPromotion` modifications from graph spreading. Graph-discovered candidates get `semanticScoreForPromotion: 0` (same as rescue candidates). Canonical explanation promotion gates on the original semantic retrieval score, not graph-inflated scores
+- [x] Step 8: Update `RetrievalEvidenceChannel` type in `src/structured-content.ts` by replacing `"graph"` with `"graph-rank"`. Update channel evidence logic in `src/tools/recall.ts` to emit `"graph-rank"` when `graphRank !== undefined`, covering both graph-discovered and graph-boosted existing candidates
+
+**Constraint**: No changes to rescue candidate collection. Rescue candidates continue to contribute via lexical evidence only. Canonical explanation promotion only changed to remove graph-inflated semantic promotion.
+
+**Goal**: Graph spreading activation produces an independent rank channel instead of contaminating semantic scores.
+
 - [ ] Step 1: Add `graphRank?: number` and `graphScore?: number` to `ScoredRecallCandidate` interface in `src/recall.ts`
 - [ ] Step 2: Refactor `applyGraphSpreadingActivation` to NOT modify `candidate.score` or `candidate.boosted`. Instead, store `graphScore` on each candidate (existing + discovered). For existing candidates: set `graphScore += propagatedScore` (accumulate graph evidence). For graph-discovered candidates: set `graphScore = propagatedScore`, `score = 0`, `boosted = 0` (they have no semantic score — graph contribution flows only through `graphRank` RRF channel, not through `boosted`)
 - [ ] Step 3: Assign `graphRank` using dense ranking by `graphScore` after spreading completes. Candidates with no graphScore get `graphRank = undefined`
 - [ ] Step 4: Update `computeHybridScore` to three-channel RRF: `RRF = 1/(K+semanticRank) + 1/(K+lexicalRank) + 1/(K+graphRank)`. Missing channels contribute 0 (same pattern as current missing-rank handling)
 - [ ] Step 5: Remove the post-spreading `semanticRank` reassignment in `src/tools/recall.ts:306-311`. Semantic ranks must reflect the original semantic retrieval order, not graph-boosted scores
-- [ ] Step 6: Adjust `RRF_SCALING_FACTOR`. With three channels, max RRF ≈ 3/60 ≈ 0.050. At current 3.5× → 0.175. Reduce to 3.0× so max RRF contribution ≈ 0.150 (close to old two-channel max of ~0.115). Dogfooding will validate
+- [ ] Step 6: Adjust `RRF_SCALING_FACTOR`. With three channels, max RRF ≈ 3/60 ≈ 0.050. At current 3.5× → 0.175. Reduce to 3.0× so max RRF contribution ≈ 0.150 (close to old two-channel max of \~0.115). Dogfooding will validate
 - [ ] Step 7: Remove all `semanticScoreForPromotion` modifications from graph spreading — both the `+= propagatedScore` on existing candidates (line 509-510) AND the initial `semanticScoreForPromotion: propagatedScore` on discovered candidates (line 516). Graph-discovered candidates should get `semanticScoreForPromotion: 0` (same as rescue candidates). Canonical explanation promotion gates on the original semantic retrieval score, not graph-inflated scores. Graph contribution already flows through the graphRank RRF channel
 - [ ] Step 8: Update `RetrievalEvidenceChannel` type in `src/structured-content.ts` — replace `"graph"` with `"graph-rank"` in the union type. Update the channel evidence logic in `src/tools/recall.ts` to emit `"graph-rank"` when `graphRank !== undefined`, replacing the current `graphDiscoveredIds.has(id)` check. This covers both graph-discovered AND graph-boosted-existing candidates
 
@@ -44,13 +57,34 @@ Implements gaps 1 and 2 from research `research-rrf-ranking-improvements-article
 
 **Goal**: Truncate rank lists before RRF fusion to improve top-position discrimination.
 
+- [x] Step 9: Add `RRF_RANK_WINDOW = 100` constant to `src/recall.ts`
+- [x] Step 10: When assigning `semanticRank`, `lexicalRank`, and `graphRank`, only candidates within the top `RRF_RANK_WINDOW` positions get a rank. Candidates beyond the window get `rank = undefined` for that channel (contributing 0, same as missing channel). This is truncation, not exclusion; candidates still appear via other channels
+- [x] Step 11: Apply window consistently in `assignDenseRanks`: it produces 1-based ranks for positions within the window and sets rank to `undefined` for positions beyond `RRF_RANK_WINDOW`
+
+**Constraint**: For vaults with < 100 candidates, the window has zero effect. Unit coverage verifies this small-vault behavior.
+
+**Goal**: Truncate rank lists before RRF fusion to improve top-position discrimination.
+
 - [ ] Step 9: Add `RRF_RANK_WINDOW = 100` constant to `src/recall.ts`
 - [ ] Step 10: When assigning `semanticRank`, `lexicalRank`, and `graphRank` — only candidates within the top `RRF_RANK_WINDOW` positions get a rank. Candidates beyond the window get `rank = undefined` for that channel (contributing 0, same as missing channel). This is truncation, not exclusion — candidates still appear via other channels
-- [ ] Step 11: Apply window consistently: `assignDenseRanks` already produces 1-based ranks. After assignment, set rank to `undefined` for positions > RRF_RANK_WINDOW
+- [ ] Step 11: Apply window consistently: `assignDenseRanks` already produces 1-based ranks. After assignment, set rank to `undefined` for positions > RRF\_RANK\_WINDOW
 
 **Constraint**: For vaults with < 100 candidates, the window has zero effect. No regression risk for small vaults.
 
 ### Verification
+
+- [x] `npx tsc --noEmit` clean
+- [x] `npm test` passed after rebuilding stale `build/` artifacts (`1130/1130`)
+- [x] New unit tests in `tests/recall.unit.test.ts`:
+  - Three-channel RRF computation with graphRank
+  - Graph-discovered candidate has no semanticRank, gets graphRank
+  - Existing semantic candidate with graph boost keeps original semanticRank
+  - Rank window truncation (candidates beyond window get undefined rank)
+  - Rank window has no effect when candidate count < window
+- [x] Updated existing tests that assumed two-channel RRF or graph score modification
+- [x] Dogfooding: recall query against local vault for `RRF graph rank channel rank window recall ranking improvements` returned the active plan, research, and request as top results without obvious ranking regression
+
+**Verification note**: First full `npm test` run failed because a stale `build/` artifact imported removed `summarizePreview`; `npm run build` refreshed artifacts and the rerun passed.
 
 - [ ] `npx tsc --noEmit` clean
 - [ ] `npm test` — all existing tests updated for three-channel RRF semantics

--- a/.mnemonic/notes/plan-three-channel-rrf-with-graph-rank-and-rank-window-size-1c7d15da.md
+++ b/.mnemonic/notes/plan-three-channel-rrf-with-graph-rank-and-rank-window-size-1c7d15da.md
@@ -7,7 +7,7 @@ tags:
   - ranking
 lifecycle: temporary
 createdAt: '2026-05-25T14:07:26.547Z'
-updatedAt: '2026-05-25T14:17:30.658Z'
+updatedAt: '2026-05-25T14:17:34.050Z'
 role: plan
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -16,6 +16,8 @@ relatedTo:
   - id: research-rrf-ranking-improvements-article-analysis-vs-curren-3b8585ab
     type: derives-from
   - id: decision-phase-2-recall-scoring-uses-rrf-with-dense-rank-tie-7969c37d
+    type: derives-from
+  - id: reference-mnemonic-ranking-signals-inventory-all-scoring-for-27ae79dc
     type: derives-from
 memoryVersion: 1
 ---

--- a/.mnemonic/notes/plan-three-channel-rrf-with-graph-rank-and-rank-window-size-1c7d15da.md
+++ b/.mnemonic/notes/plan-three-channel-rrf-with-graph-rank-and-rank-window-size-1c7d15da.md
@@ -7,11 +7,14 @@ tags:
   - ranking
 lifecycle: temporary
 createdAt: '2026-05-25T14:07:26.547Z'
-updatedAt: '2026-05-25T14:07:26.547Z'
+updatedAt: '2026-05-25T14:07:30.124Z'
 role: plan
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: research-rrf-ranking-improvements-article-analysis-vs-curren-3b8585ab
+    type: derives-from
 memoryVersion: 1
 ---
 ## Plan: Three-channel RRF with graph rank and rank window size

--- a/.mnemonic/notes/plan-three-channel-rrf-with-graph-rank-and-rank-window-size-1c7d15da.md
+++ b/.mnemonic/notes/plan-three-channel-rrf-with-graph-rank-and-rank-window-size-1c7d15da.md
@@ -7,7 +7,7 @@ tags:
   - ranking
 lifecycle: temporary
 createdAt: '2026-05-25T14:07:26.547Z'
-updatedAt: '2026-05-25T16:04:51.499Z'
+updatedAt: '2026-05-25T16:05:21.293Z'
 role: plan
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -19,6 +19,8 @@ relatedTo:
     type: derives-from
   - id: reference-mnemonic-ranking-signals-inventory-all-scoring-for-27ae79dc
     type: derives-from
+  - id: apply-three-channel-rrf-graph-rank-and-rank-window-implement-4876709b
+    type: follows
 memoryVersion: 1
 ---
 ## Plan: Three-channel RRF with graph rank and rank window size

--- a/.mnemonic/notes/plan-three-channel-rrf-with-graph-rank-and-rank-window-size-1c7d15da.md
+++ b/.mnemonic/notes/plan-three-channel-rrf-with-graph-rank-and-rank-window-size-1c7d15da.md
@@ -7,7 +7,7 @@ tags:
   - ranking
 lifecycle: temporary
 createdAt: '2026-05-25T14:07:26.547Z'
-updatedAt: '2026-05-25T14:07:30.124Z'
+updatedAt: '2026-05-25T14:15:30.062Z'
 role: plan
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -25,14 +25,27 @@ Implements gaps 1 and 2 from research `research-rrf-ranking-improvements-article
 
 **Goal**: Graph spreading activation produces an independent rank channel instead of contaminating semantic scores.
 
-- [ ] Step 1: Add `graphRank?: number` and `graphScore?: number` to `ScoredRecallCandidate` interface in `src/recall.ts`
-- [ ] Step 2: Refactor `applyGraphSpreadingActivation` to NOT modify `candidate.score` or `candidate.boosted`. Instead, store `graphScore` on each candidate (existing + discovered). Graph-discovered candidates keep `semanticRank = undefined`; existing candidates keep their original `semanticRank`
-- [ ] Step 3: Assign `graphRank` using dense ranking by `graphScore` after spreading completes. Candidates with no graphScore get `graphRank = undefined`
-- [ ] Step 4: Update `computeHybridScore` to three-channel RRF: `RRF = 1/(K+semanticRank) + 1/(K+lexicalRank) + 1/(K+graphRank)`. Missing channels contribute 0 (same pattern as current missing-rank handling)
-- [ ] Step 5: Remove the post-spreading `semanticRank` reassignment in `src/tools/recall.ts:306-311`. Semantic ranks must reflect the original semantic retrieval order, not graph-boosted scores
-- [ ] Step 6: Adjust `RRF_SCALING_FACTOR`. With three channels, max RRF ≈ 3/60 ≈ 0.050. At current 3.5× → 0.175. Reduce to 3.0× so max RRF contribution ≈ 0.150 (close to old two-channel max of ~0.115). Dogfooding will validate
-- [ ] Step 7: Remove `semanticScoreForPromotion += propagatedScore` from graph spreading. Canonical explanation promotion should gate on the original semantic retrieval score, not graph-inflated scores. Graph contribution already flows through the graphRank RRF channel
-- [ ] Step 8: Update `RetrievalEvidence` channels in `src/tools/recall.ts` to include `"graph-rank"` when `graphRank !== undefined` instead of the current `"graph"` channel (which was based on membership in `graphDiscoveredIds`). Both graph-discovered AND graph-boosted-existing candidates now have `graphRank`
+- \[ ] Step 1: Add `graphRank?: number` and `graphScore?: number` to `ScoredRecallCandidate` interface in `src/recall.ts`
+- \[ ] Step 2: Refactor `applyGraphSpreadingActivation` to NOT modify `candidate.score` or `candidate.boosted`. Instead, store `graphScore` on each candidate (existing + discovered). For existing candidates: set `graphScore += propagatedScore` (accumulate graph evidence). For graph-discovered candidates: set `graphScore = propagatedScore`, `score = 0`, `boosted = 0` (they have no semantic score — graph contribution flows only through `graphRank` RRF channel, not through `boosted`)
+- \[ ] Step 3: Assign `graphRank` using dense ranking by `graphScore` after spreading completes. Candidates with no graphScore get `graphRank = undefined`
+- \[ ] Step 4: Update `computeHybridScore` to three-channel RRF: `RRF = 1/(K+semanticRank) + 1/(K+lexicalRank) + 1/(K+graphRank)`. Missing channels contribute 0 (same pattern as current missing-rank handling)
+- \[ ] Step 5: Remove the post-spreading `semanticRank` reassignment in `src/tools/recall.ts:306-311`. Semantic ranks must reflect the original semantic retrieval order, not graph-boosted scores
+- \[ ] Step 6: Adjust `RRF_SCALING_FACTOR`. With three channels, max RRF ≈ 3/60 ≈ 0.050. At current 3.5× → 0.175. Reduce to 3.0× so max RRF contribution ≈ 0.150 (close to old two-channel max of ~0.115). Dogfooding will validate
+- \[ ] Step 7: Remove all `semanticScoreForPromotion` modifications from graph spreading — both the `+= propagatedScore` on existing candidates (line 509-510) AND the initial `semanticScoreForPromotion: propagatedScore` on discovered candidates (line 516). Graph-discovered candidates should get `semanticScoreForPromotion: 0` (same as rescue candidates). Canonical explanation promotion gates on the original semantic retrieval score, not graph-inflated scores. Graph contribution already flows through the graphRank RRF channel
+- \[ ] Step 8: Update `RetrievalEvidenceChannel` type in `src/structured-content.ts` — replace `"graph"` with `"graph-rank"` in the union type. Update the channel evidence logic in `src/tools/recall.ts` to emit `"graph-rank"` when `graphRank !== undefined`, replacing the current `graphDiscoveredIds.has(id)` check. This covers both graph-discovered AND graph-boosted-existing candidates
+
+**Constraint**: No changes to rescue candidates — they continue to contribute only via `lexicalRank`. No changes to canonical explanation promotion logic beyond `semanticScoreForPromotion` fix.
+
+**Goal**: Graph spreading activation produces an independent rank channel instead of contaminating semantic scores.
+
+- \[ ] Step 1: Add `graphRank?: number` and `graphScore?: number` to `ScoredRecallCandidate` interface in `src/recall.ts`
+- \[ ] Step 2: Refactor `applyGraphSpreadingActivation` to NOT modify `candidate.score` or `candidate.boosted`. Instead, store `graphScore` on each candidate (existing + discovered). Graph-discovered candidates keep `semanticRank = undefined`; existing candidates keep their original `semanticRank`
+- \[ ] Step 3: Assign `graphRank` using dense ranking by `graphScore` after spreading completes. Candidates with no graphScore get `graphRank = undefined`
+- \[ ] Step 4: Update `computeHybridScore` to three-channel RRF: `RRF = 1/(K+semanticRank) + 1/(K+lexicalRank) + 1/(K+graphRank)`. Missing channels contribute 0 (same pattern as current missing-rank handling)
+- \[ ] Step 5: Remove the post-spreading `semanticRank` reassignment in `src/tools/recall.ts:306-311`. Semantic ranks must reflect the original semantic retrieval order, not graph-boosted scores
+- \[ ] Step 6: Adjust `RRF_SCALING_FACTOR`. With three channels, max RRF ≈ 3/60 ≈ 0.050. At current 3.5× → 0.175. Reduce to 3.0× so max RRF contribution ≈ 0.150 (close to old two-channel max of ~0.115). Dogfooding will validate
+- \[ ] Step 7: Remove `semanticScoreForPromotion += propagatedScore` from graph spreading. Canonical explanation promotion should gate on the original semantic retrieval score, not graph-inflated scores. Graph contribution already flows through the graphRank RRF channel
+- \[ ] Step 8: Update `RetrievalEvidence` channels in `src/tools/recall.ts` to include `"graph-rank"` when `graphRank !== undefined` instead of the current `"graph"` channel (which was based on membership in `graphDiscoveredIds`). Both graph-discovered AND graph-boosted-existing candidates now have `graphRank`
 
 **Constraint**: No changes to rescue candidates — they continue to contribute only via `lexicalRank`. No changes to canonical explanation promotion logic beyond the `semanticScoreForPromotion` fix.
 
@@ -40,24 +53,24 @@ Implements gaps 1 and 2 from research `research-rrf-ranking-improvements-article
 
 **Goal**: Truncate rank lists before RRF fusion to improve top-position discrimination.
 
-- [ ] Step 9: Add `RRF_RANK_WINDOW = 100` constant to `src/recall.ts`
-- [ ] Step 10: When assigning `semanticRank`, `lexicalRank`, and `graphRank` — only candidates within the top `RRF_RANK_WINDOW` positions get a rank. Candidates beyond the window get `rank = undefined` for that channel (contributing 0, same as missing channel). This is truncation, not exclusion — candidates still appear via other channels
-- [ ] Step 11: Apply window consistently: `assignDenseRanks` already produces 1-based ranks. After assignment, set rank to `undefined` for positions > RRF_RANK_WINDOW
+- \[ ] Step 9: Add `RRF_RANK_WINDOW = 100` constant to `src/recall.ts`
+- \[ ] Step 10: When assigning `semanticRank`, `lexicalRank`, and `graphRank` — only candidates within the top `RRF_RANK_WINDOW` positions get a rank. Candidates beyond the window get `rank = undefined` for that channel (contributing 0, same as missing channel). This is truncation, not exclusion — candidates still appear via other channels
+- \[ ] Step 11: Apply window consistently: `assignDenseRanks` already produces 1-based ranks. After assignment, set rank to `undefined` for positions > RRF\_RANK\_WINDOW
 
 **Constraint**: For vaults with < 100 candidates, the window has zero effect. No regression risk for small vaults.
 
 ### Verification
 
-- [ ] `npx tsc --noEmit` clean
-- [ ] `npm test` — all existing tests updated for three-channel RRF semantics
-- [ ] New unit tests in `tests/recall.unit.test.ts`:
+- \[ ] `npx tsc --noEmit` clean
+- \[ ] `npm test` — all existing tests updated for three-channel RRF semantics
+- \[ ] New unit tests in `tests/recall.unit.test.ts`:
   - Three-channel RRF computation with graphRank
   - Graph-discovered candidate has no semanticRank, gets graphRank
   - Existing semantic candidate with graph boost keeps original semanticRank
   - Rank window truncation (candidates beyond window get undefined rank)
   - Rank window has no effect when candidate count < window
-- [ ] Update existing tests that assume two-channel RRF or graph score modification
-- [ ] Dogfooding: recall queries against local vault, verify no ranking regression
+- \[ ] Update existing tests that assume two-channel RRF or graph score modification
+- \[ ] Dogfooding: recall queries against local vault, verify no ranking regression
 
 ### Non-goals
 

--- a/.mnemonic/notes/plan-three-channel-rrf-with-graph-rank-and-rank-window-size-1c7d15da.md
+++ b/.mnemonic/notes/plan-three-channel-rrf-with-graph-rank-and-rank-window-size-1c7d15da.md
@@ -7,13 +7,15 @@ tags:
   - ranking
 lifecycle: temporary
 createdAt: '2026-05-25T14:07:26.547Z'
-updatedAt: '2026-05-25T14:15:30.062Z'
+updatedAt: '2026-05-25T14:17:30.658Z'
 role: plan
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
   - id: research-rrf-ranking-improvements-article-analysis-vs-curren-3b8585ab
+    type: derives-from
+  - id: decision-phase-2-recall-scoring-uses-rrf-with-dense-rank-tie-7969c37d
     type: derives-from
 memoryVersion: 1
 ---

--- a/.mnemonic/notes/plan-three-channel-rrf-with-graph-rank-and-rank-window-size-1c7d15da.md
+++ b/.mnemonic/notes/plan-three-channel-rrf-with-graph-rank-and-rank-window-size-1c7d15da.md
@@ -7,7 +7,7 @@ tags:
   - ranking
 lifecycle: temporary
 createdAt: '2026-05-25T14:07:26.547Z'
-updatedAt: '2026-05-25T14:17:34.050Z'
+updatedAt: '2026-05-25T14:17:46.968Z'
 role: plan
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -29,52 +29,39 @@ Implements gaps 1 and 2 from research `research-rrf-ranking-improvements-article
 
 **Goal**: Graph spreading activation produces an independent rank channel instead of contaminating semantic scores.
 
-- \[ ] Step 1: Add `graphRank?: number` and `graphScore?: number` to `ScoredRecallCandidate` interface in `src/recall.ts`
-- \[ ] Step 2: Refactor `applyGraphSpreadingActivation` to NOT modify `candidate.score` or `candidate.boosted`. Instead, store `graphScore` on each candidate (existing + discovered). For existing candidates: set `graphScore += propagatedScore` (accumulate graph evidence). For graph-discovered candidates: set `graphScore = propagatedScore`, `score = 0`, `boosted = 0` (they have no semantic score — graph contribution flows only through `graphRank` RRF channel, not through `boosted`)
-- \[ ] Step 3: Assign `graphRank` using dense ranking by `graphScore` after spreading completes. Candidates with no graphScore get `graphRank = undefined`
-- \[ ] Step 4: Update `computeHybridScore` to three-channel RRF: `RRF = 1/(K+semanticRank) + 1/(K+lexicalRank) + 1/(K+graphRank)`. Missing channels contribute 0 (same pattern as current missing-rank handling)
-- \[ ] Step 5: Remove the post-spreading `semanticRank` reassignment in `src/tools/recall.ts:306-311`. Semantic ranks must reflect the original semantic retrieval order, not graph-boosted scores
-- \[ ] Step 6: Adjust `RRF_SCALING_FACTOR`. With three channels, max RRF ≈ 3/60 ≈ 0.050. At current 3.5× → 0.175. Reduce to 3.0× so max RRF contribution ≈ 0.150 (close to old two-channel max of ~0.115). Dogfooding will validate
-- \[ ] Step 7: Remove all `semanticScoreForPromotion` modifications from graph spreading — both the `+= propagatedScore` on existing candidates (line 509-510) AND the initial `semanticScoreForPromotion: propagatedScore` on discovered candidates (line 516). Graph-discovered candidates should get `semanticScoreForPromotion: 0` (same as rescue candidates). Canonical explanation promotion gates on the original semantic retrieval score, not graph-inflated scores. Graph contribution already flows through the graphRank RRF channel
-- \[ ] Step 8: Update `RetrievalEvidenceChannel` type in `src/structured-content.ts` — replace `"graph"` with `"graph-rank"` in the union type. Update the channel evidence logic in `src/tools/recall.ts` to emit `"graph-rank"` when `graphRank !== undefined`, replacing the current `graphDiscoveredIds.has(id)` check. This covers both graph-discovered AND graph-boosted-existing candidates
+- [ ] Step 1: Add `graphRank?: number` and `graphScore?: number` to `ScoredRecallCandidate` interface in `src/recall.ts`
+- [ ] Step 2: Refactor `applyGraphSpreadingActivation` to NOT modify `candidate.score` or `candidate.boosted`. Instead, store `graphScore` on each candidate (existing + discovered). For existing candidates: set `graphScore += propagatedScore` (accumulate graph evidence). For graph-discovered candidates: set `graphScore = propagatedScore`, `score = 0`, `boosted = 0` (they have no semantic score — graph contribution flows only through `graphRank` RRF channel, not through `boosted`)
+- [ ] Step 3: Assign `graphRank` using dense ranking by `graphScore` after spreading completes. Candidates with no graphScore get `graphRank = undefined`
+- [ ] Step 4: Update `computeHybridScore` to three-channel RRF: `RRF = 1/(K+semanticRank) + 1/(K+lexicalRank) + 1/(K+graphRank)`. Missing channels contribute 0 (same pattern as current missing-rank handling)
+- [ ] Step 5: Remove the post-spreading `semanticRank` reassignment in `src/tools/recall.ts:306-311`. Semantic ranks must reflect the original semantic retrieval order, not graph-boosted scores
+- [ ] Step 6: Adjust `RRF_SCALING_FACTOR`. With three channels, max RRF ≈ 3/60 ≈ 0.050. At current 3.5× → 0.175. Reduce to 3.0× so max RRF contribution ≈ 0.150 (close to old two-channel max of ~0.115). Dogfooding will validate
+- [ ] Step 7: Remove all `semanticScoreForPromotion` modifications from graph spreading — both the `+= propagatedScore` on existing candidates (line 509-510) AND the initial `semanticScoreForPromotion: propagatedScore` on discovered candidates (line 516). Graph-discovered candidates should get `semanticScoreForPromotion: 0` (same as rescue candidates). Canonical explanation promotion gates on the original semantic retrieval score, not graph-inflated scores. Graph contribution already flows through the graphRank RRF channel
+- [ ] Step 8: Update `RetrievalEvidenceChannel` type in `src/structured-content.ts` — replace `"graph"` with `"graph-rank"` in the union type. Update the channel evidence logic in `src/tools/recall.ts` to emit `"graph-rank"` when `graphRank !== undefined`, replacing the current `graphDiscoveredIds.has(id)` check. This covers both graph-discovered AND graph-boosted-existing candidates
 
 **Constraint**: No changes to rescue candidates — they continue to contribute only via `lexicalRank`. No changes to canonical explanation promotion logic beyond `semanticScoreForPromotion` fix.
-
-**Goal**: Graph spreading activation produces an independent rank channel instead of contaminating semantic scores.
-
-- \[ ] Step 1: Add `graphRank?: number` and `graphScore?: number` to `ScoredRecallCandidate` interface in `src/recall.ts`
-- \[ ] Step 2: Refactor `applyGraphSpreadingActivation` to NOT modify `candidate.score` or `candidate.boosted`. Instead, store `graphScore` on each candidate (existing + discovered). Graph-discovered candidates keep `semanticRank = undefined`; existing candidates keep their original `semanticRank`
-- \[ ] Step 3: Assign `graphRank` using dense ranking by `graphScore` after spreading completes. Candidates with no graphScore get `graphRank = undefined`
-- \[ ] Step 4: Update `computeHybridScore` to three-channel RRF: `RRF = 1/(K+semanticRank) + 1/(K+lexicalRank) + 1/(K+graphRank)`. Missing channels contribute 0 (same pattern as current missing-rank handling)
-- \[ ] Step 5: Remove the post-spreading `semanticRank` reassignment in `src/tools/recall.ts:306-311`. Semantic ranks must reflect the original semantic retrieval order, not graph-boosted scores
-- \[ ] Step 6: Adjust `RRF_SCALING_FACTOR`. With three channels, max RRF ≈ 3/60 ≈ 0.050. At current 3.5× → 0.175. Reduce to 3.0× so max RRF contribution ≈ 0.150 (close to old two-channel max of ~0.115). Dogfooding will validate
-- \[ ] Step 7: Remove `semanticScoreForPromotion += propagatedScore` from graph spreading. Canonical explanation promotion should gate on the original semantic retrieval score, not graph-inflated scores. Graph contribution already flows through the graphRank RRF channel
-- \[ ] Step 8: Update `RetrievalEvidence` channels in `src/tools/recall.ts` to include `"graph-rank"` when `graphRank !== undefined` instead of the current `"graph"` channel (which was based on membership in `graphDiscoveredIds`). Both graph-discovered AND graph-boosted-existing candidates now have `graphRank`
-
-**Constraint**: No changes to rescue candidates — they continue to contribute only via `lexicalRank`. No changes to canonical explanation promotion logic beyond the `semanticScoreForPromotion` fix.
 
 ### Gap 2: Rank window size
 
 **Goal**: Truncate rank lists before RRF fusion to improve top-position discrimination.
 
-- \[ ] Step 9: Add `RRF_RANK_WINDOW = 100` constant to `src/recall.ts`
-- \[ ] Step 10: When assigning `semanticRank`, `lexicalRank`, and `graphRank` — only candidates within the top `RRF_RANK_WINDOW` positions get a rank. Candidates beyond the window get `rank = undefined` for that channel (contributing 0, same as missing channel). This is truncation, not exclusion — candidates still appear via other channels
-- \[ ] Step 11: Apply window consistently: `assignDenseRanks` already produces 1-based ranks. After assignment, set rank to `undefined` for positions > RRF\_RANK\_WINDOW
+- [ ] Step 9: Add `RRF_RANK_WINDOW = 100` constant to `src/recall.ts`
+- [ ] Step 10: When assigning `semanticRank`, `lexicalRank`, and `graphRank` — only candidates within the top `RRF_RANK_WINDOW` positions get a rank. Candidates beyond the window get `rank = undefined` for that channel (contributing 0, same as missing channel). This is truncation, not exclusion — candidates still appear via other channels
+- [ ] Step 11: Apply window consistently: `assignDenseRanks` already produces 1-based ranks. After assignment, set rank to `undefined` for positions > RRF_RANK_WINDOW
 
 **Constraint**: For vaults with < 100 candidates, the window has zero effect. No regression risk for small vaults.
 
 ### Verification
 
-- \[ ] `npx tsc --noEmit` clean
-- \[ ] `npm test` — all existing tests updated for three-channel RRF semantics
-- \[ ] New unit tests in `tests/recall.unit.test.ts`:
+- [ ] `npx tsc --noEmit` clean
+- [ ] `npm test` — all existing tests updated for three-channel RRF semantics
+- [ ] New unit tests in `tests/recall.unit.test.ts`:
   - Three-channel RRF computation with graphRank
   - Graph-discovered candidate has no semanticRank, gets graphRank
   - Existing semantic candidate with graph boost keeps original semanticRank
   - Rank window truncation (candidates beyond window get undefined rank)
   - Rank window has no effect when candidate count < window
-- \[ ] Update existing tests that assume two-channel RRF or graph score modification
-- \[ ] Dogfooding: recall queries against local vault, verify no ranking regression
+- [ ] Update existing tests that assume two-channel RRF or graph score modification
+- [ ] Dogfooding: recall queries against local vault, verify no ranking regression
 
 ### Non-goals
 
@@ -87,3 +74,5 @@ Implements gaps 1 and 2 from research `research-rrf-ranking-improvements-article
 
 - research-rrf-ranking-improvements-article-analysis-vs-curren-3b8585ab
 - request-rrf-ranking-improvements-from-bigdata-boutique-artic-1765a16b
+- decision-phase-2-recall-scoring-uses-rrf-with-dense-rank-tie-7969c37d (prior RRF decision this extends)
+- reference-mnemonic-ranking-signals-inventory-all-scoring-for-27ae79dc (scoring formulas reference)

--- a/.mnemonic/notes/plan-three-channel-rrf-with-graph-rank-and-rank-window-size-1c7d15da.md
+++ b/.mnemonic/notes/plan-three-channel-rrf-with-graph-rank-and-rank-window-size-1c7d15da.md
@@ -1,0 +1,69 @@
+---
+title: 'Plan: Three-channel RRF with graph rank and rank window size'
+tags:
+  - workflow
+  - plan
+  - rrf
+  - ranking
+lifecycle: temporary
+createdAt: '2026-05-25T14:07:26.547Z'
+updatedAt: '2026-05-25T14:07:26.547Z'
+role: plan
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+## Plan: Three-channel RRF with graph rank and rank window size
+
+Implements gaps 1 and 2 from research `research-rrf-ranking-improvements-article-analysis-vs-curren-3b8585ab`.
+
+### Gap 1: Graph spreading as third RRF channel
+
+**Goal**: Graph spreading activation produces an independent rank channel instead of contaminating semantic scores.
+
+- [ ] Step 1: Add `graphRank?: number` and `graphScore?: number` to `ScoredRecallCandidate` interface in `src/recall.ts`
+- [ ] Step 2: Refactor `applyGraphSpreadingActivation` to NOT modify `candidate.score` or `candidate.boosted`. Instead, store `graphScore` on each candidate (existing + discovered). Graph-discovered candidates keep `semanticRank = undefined`; existing candidates keep their original `semanticRank`
+- [ ] Step 3: Assign `graphRank` using dense ranking by `graphScore` after spreading completes. Candidates with no graphScore get `graphRank = undefined`
+- [ ] Step 4: Update `computeHybridScore` to three-channel RRF: `RRF = 1/(K+semanticRank) + 1/(K+lexicalRank) + 1/(K+graphRank)`. Missing channels contribute 0 (same pattern as current missing-rank handling)
+- [ ] Step 5: Remove the post-spreading `semanticRank` reassignment in `src/tools/recall.ts:306-311`. Semantic ranks must reflect the original semantic retrieval order, not graph-boosted scores
+- [ ] Step 6: Adjust `RRF_SCALING_FACTOR`. With three channels, max RRF ≈ 3/60 ≈ 0.050. At current 3.5× → 0.175. Reduce to 3.0× so max RRF contribution ≈ 0.150 (close to old two-channel max of ~0.115). Dogfooding will validate
+- [ ] Step 7: Remove `semanticScoreForPromotion += propagatedScore` from graph spreading. Canonical explanation promotion should gate on the original semantic retrieval score, not graph-inflated scores. Graph contribution already flows through the graphRank RRF channel
+- [ ] Step 8: Update `RetrievalEvidence` channels in `src/tools/recall.ts` to include `"graph-rank"` when `graphRank !== undefined` instead of the current `"graph"` channel (which was based on membership in `graphDiscoveredIds`). Both graph-discovered AND graph-boosted-existing candidates now have `graphRank`
+
+**Constraint**: No changes to rescue candidates — they continue to contribute only via `lexicalRank`. No changes to canonical explanation promotion logic beyond the `semanticScoreForPromotion` fix.
+
+### Gap 2: Rank window size
+
+**Goal**: Truncate rank lists before RRF fusion to improve top-position discrimination.
+
+- [ ] Step 9: Add `RRF_RANK_WINDOW = 100` constant to `src/recall.ts`
+- [ ] Step 10: When assigning `semanticRank`, `lexicalRank`, and `graphRank` — only candidates within the top `RRF_RANK_WINDOW` positions get a rank. Candidates beyond the window get `rank = undefined` for that channel (contributing 0, same as missing channel). This is truncation, not exclusion — candidates still appear via other channels
+- [ ] Step 11: Apply window consistently: `assignDenseRanks` already produces 1-based ranks. After assignment, set rank to `undefined` for positions > RRF_RANK_WINDOW
+
+**Constraint**: For vaults with < 100 candidates, the window has zero effect. No regression risk for small vaults.
+
+### Verification
+
+- [ ] `npx tsc --noEmit` clean
+- [ ] `npm test` — all existing tests updated for three-channel RRF semantics
+- [ ] New unit tests in `tests/recall.unit.test.ts`:
+  - Three-channel RRF computation with graphRank
+  - Graph-discovered candidate has no semanticRank, gets graphRank
+  - Existing semantic candidate with graph boost keeps original semanticRank
+  - Rank window truncation (candidates beyond window get undefined rank)
+  - Rank window has no effect when candidate count < window
+- [ ] Update existing tests that assume two-channel RRF or graph score modification
+- [ ] Dogfooding: recall queries against local vault, verify no ranking regression
+
+### Non-goals
+
+- Weighted RRF (deferred — no measured evidence)
+- Changes to rescue candidate logic
+- Changes to canonical explanation promotion beyond semanticScoreForPromotion fix
+- New persistent state or metadata fields
+
+### Derives-from
+
+- research-rrf-ranking-improvements-article-analysis-vs-curren-3b8585ab
+- request-rrf-ranking-improvements-from-bigdata-boutique-artic-1765a16b

--- a/.mnemonic/notes/reference-mnemonic-ranking-signals-inventory-all-scoring-for-27ae79dc.md
+++ b/.mnemonic/notes/reference-mnemonic-ranking-signals-inventory-all-scoring-for-27ae79dc.md
@@ -10,13 +10,15 @@ tags:
   - design
 lifecycle: permanent
 createdAt: '2026-05-09T15:25:30.750Z'
-updatedAt: '2026-05-09T21:03:51.510Z'
+updatedAt: '2026-05-25T14:17:34.050Z'
 role: reference
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
   - id: enriched-confidence-scoring-with-signal-strength-composite-i-06563116
+    type: derives-from
+  - id: plan-three-channel-rrf-with-graph-rank-and-rank-window-size-1c7d15da
     type: derives-from
 memoryVersion: 1
 ---

--- a/.mnemonic/notes/request-rrf-ranking-improvements-from-bigdata-boutique-artic-1765a16b.md
+++ b/.mnemonic/notes/request-rrf-ranking-improvements-from-bigdata-boutique-artic-1765a16b.md
@@ -1,0 +1,32 @@
+---
+title: 'Request: RRF ranking improvements from BigData Boutique article analysis'
+tags:
+  - workflow
+  - request
+lifecycle: temporary
+createdAt: '2026-05-25T14:05:42.422Z'
+updatedAt: '2026-05-25T14:05:42.422Z'
+role: context
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+## Request: RRF Ranking Improvements from BigData Boutique Article Analysis
+
+Analyze the BigData Boutique RRF article (<https://bigdataboutique.com/blog/reciprocal-rank-fusion-how-it-works-and-when-to-use-it>) against Mnemonic's current recall ranking implementation and identify concrete, implementable improvements.
+
+### Trigger
+
+User asked "what can we apply to improve the ranking?" after recalling existing RRF design decisions.
+
+### Identified improvement candidates
+
+1. Graph spreading activation as third RRF channel (not score contamination)
+2. Rank window size constraint
+3. Weighted RRF for asymmetric retriever confidence
+
+### Derives-from
+
+- decision-phase-2-recall-scoring-uses-rrf-with-dense-rank-tie-7969c37d
+- reference-mnemonic-ranking-signals-inventory-all-scoring-for-27ae79dc

--- a/.mnemonic/notes/request-rrf-ranking-improvements-from-bigdata-boutique-artic-1765a16b.md
+++ b/.mnemonic/notes/request-rrf-ranking-improvements-from-bigdata-boutique-artic-1765a16b.md
@@ -5,11 +5,14 @@ tags:
   - request
 lifecycle: temporary
 createdAt: '2026-05-25T14:05:42.422Z'
-updatedAt: '2026-05-25T14:05:42.422Z'
+updatedAt: '2026-05-25T14:06:19.207Z'
 role: context
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: research-rrf-ranking-improvements-article-analysis-vs-curren-3b8585ab
+    type: derives-from
 memoryVersion: 1
 ---
 ## Request: RRF Ranking Improvements from BigData Boutique Article Analysis

--- a/.mnemonic/notes/research-rrf-ranking-improvements-article-analysis-vs-curren-3b8585ab.md
+++ b/.mnemonic/notes/research-rrf-ranking-improvements-article-analysis-vs-curren-3b8585ab.md
@@ -1,0 +1,124 @@
+---
+title: >-
+  Research: RRF ranking improvements — article analysis vs current
+  implementation
+tags:
+  - workflow
+  - research
+  - rrf
+  - ranking
+lifecycle: temporary
+createdAt: '2026-05-25T14:06:16.108Z'
+updatedAt: '2026-05-25T14:06:16.108Z'
+role: research
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+## Research: RRF Ranking Improvements — Article Analysis vs Current Implementation
+
+Sources: BigData Boutique RRF article (2026-05-18), Cormack-Clarke-Büttcher 2009 SIGIR paper, Mnemonic codebase (`src/recall.ts`, `src/tools/recall.ts`).
+
+### Article key findings
+
+**RRF principle**: Each retriever votes for a document by rank position. `RRF_score(d) = Σ_r 1/(k + rank_r(d))`. Operates on ranks, not scores — robust to mismatched score distributions.
+
+**K=60 justification**: Cormack et al. tuned on TREC data; subsequent benchmarks land k ∈ [40, 80]. Smaller k amplifies top ranks (high-precision workloads), larger k preserves long-tail signal (recall-oriented).
+
+**Multi-retriever fusion**: Formula naturally extends to 3+ retrievers. "Practical examples include BM25 + dense + sparse (e.g., SPLADE), or text + image + metadata retrievers in multimodal search."
+
+**Weighted RRF**: `Σ_r w_r / (k + rank_r(d))` for asymmetric retriever confidence. Article advises: "don't reach for weights until you've measured."
+
+**Rank window size**: 50-100 per retriever before fusion. "A true positive at rank 80 in one list and rank 5 in the other will get half the score it deserves if your window is 50." Documents outside window contribute 0.
+
+**Score normalization comparison**: RRF ~3.86% lower NDCG@10 vs tuned score normalization in OpenSearch benchmarks but faster at every latency percentile and immune to score-distribution drift.
+
+**Single-list documents**: Contribute reciprocal-rank from one list, 0 from the other — penalized relative to documents present in both. "Exactly the behavior you want from a hybrid ranker."
+
+### Current Mnemonic implementation
+
+**Formula** (`src/recall.ts:197-217`):
+
+```text
+RRF = 1/(60 + semanticRank) + 1/(60 + lexicalRank)
+hybridScore = boosted + RRF * 3.5 + canonicalScore * 0.05
+```
+
+Two channels: semantic rank (dense by raw cosine score) and lexical rank (dense by lexicalRankSignal = lexical + coverage×0.3 + phrase×0.5).
+
+**Graph spreading activation** (`src/recall.ts:478-537`):
+
+- Top 5 entry points with score >= 0.5
+- propagatedScore = entry.score × 0.5 × multiplier
+- Modifies `candidate.score` and `candidate.boosted` directly (lines 507-524)
+- Discovered candidates get `semanticScoreForPromotion = propagatedScore`
+- After spreading, `semanticRank` is re-assigned based on modified scores (`src/tools/recall.ts:308-311`)
+
+**Canonical explanation promotion**: Separate additive term (0.05 weight), gated on semanticScoreForPromotion >= 0.5.
+
+**No rank window**: All candidates above minSimilarity enter RRF ranking.
+
+### Gap analysis
+
+#### Gap 1: Graph spreading contaminates semantic rank (CRITICAL)
+
+Current behavior: Graph-propagated scores are added to `candidate.score` and `candidate.boosted`, then `semanticRank` is re-assigned based on these contaminated scores. Graph-discovered candidates (which were never found by semantic search) inherit `semanticRank` based on their propagated score.
+
+**Why this violates RRF design**:
+
+- RRF requires each channel to produce independent rank lists
+- Graph-boosted existing candidates get inflated semantic scores, distorting the semantic rank order
+- Graph-discovered candidates (no genuine semantic similarity) get a `semanticRank` that doesn't reflect actual semantic retrieval — it reflects graph proximity
+- The article's worked example shows RRF rewards "consistency across lists" — but here graph discovery pretends to be semantic consistency
+
+**Concrete problem scenario**:
+
+Candidate A: semantic score 0.55, semanticRank=1. Graph spreads +0.15 → score becomes 0.70, semanticRank stays 1 (fine).
+Candidate B: semantic score 0.54, semanticRank=2. No graph boost. After re-ranking, candidate A's inflated 0.70 vs B's 0.54 creates a wider gap than the original 0.55 vs 0.54 warranted. The lexical channel could have promoted B, but A's inflated score makes lexical rescue less effective.
+
+Candidate C (graph-discovered): propagatedScore = 0.35. After spreading and re-ranking, gets semanticRank based on 0.35 — but this note was never semantically retrieved. It has no genuine semantic rank. It should contribute through a graph channel, not a fake semantic one.
+
+**Proposed fix**: Add `graphRank?: number` to `ScoredRecallCandidate`. Graph candidates get no `semanticRank` (they weren't semantically retrieved) and instead get `graphRank` assigned by spreading activation score. The formula becomes three-channel RRF:
+
+```text
+RRF = 1/(K + semanticRank) + 1/(K + lexicalRank) + 1/(K + graphRank)
+```
+
+Candidates present in all three channels (semantic + lexical + graph) naturally rise. Graph-only candidates contribute through their graph term only — exactly as rescue candidates currently contribute through their lexical term only.
+
+**Impact on existing candidates**: Currently, graph-spreading boosts existing candidates' `score` and `boosted`, which inflates their RRF position. With the fix, existing semantic candidates keep their pure `semanticRank` (no contamination), and the graph contribution comes through `1/(K + graphRank)` instead. This is more principled and gives RRF its intended semantics.
+
+**Impact on RRF_SCALING_FACTOR**: With three channels, max RRF ≈ 3/60 ≈ 0.050. At 3.5× → 0.175. May need slight reduction to 3.0 to keep max RRF contribution ≈ 0.150 (similar to old two-channel behavior). Requires dogfooding calibration.
+
+#### Gap 2: No rank window size (MEDIUM)
+
+Current: All candidates above minSimilarity (0.3) enter RRF. No upper bound.
+
+**Why this matters**: The article emphasizes rank window size (50-100) because "documents outside the window contribute 0, so a true positive that lives at rank 80 in one list and rank 5 in the other will get half the score it deserves if your window is 50." Without a window, the RRF curve is flattened too gently for long-tail candidates, reducing discrimination in the interesting top 10-20 positions.
+
+**Mnemonic-specific consideration**: Mnemonic vaults are typically 50-300 notes, not the millions in search engine scenarios. A window of 100 would capture nearly all candidates. The benefit is marginal for small vaults. However, for vaults approaching 500+ notes (seen in dogfooding), a rank window prevents noisy low-signal candidates from diluting the RRF sum.
+
+**Proposed fix**: Cap eligible candidates per rank channel. When candidate count > RANK_WINDOW (e.g., 100), only candidates with rank <= RANK_WINDOW contribute from that channel. Simple truncation, not filtering — candidates below the window still appear in other channels.
+
+**Implementation cost**: Low. Add a constant and truncate the sorted arrays before `assignDenseRanks`.
+
+**Risk**: For small vaults (< 100 notes), the window has zero effect. No regression risk. For large vaults, removes noise from tail candidates.
+
+#### Gap 3: Weighted RRF (LOW, deferred)
+
+The article describes `Σ_r w_r / (k + rank_r(d))` for asymmetric retriever confidence. Requires measured evidence that one channel systematically outperforms. No such evidence exists for Mnemonic. Deferring until evaluation data exists.
+
+### Design constraints preserved
+
+- No database, daemon, or new committed artifacts
+- Fail-soft to semantic-first behavior
+- Additive, bounded, reversible
+- Language-independent
+- One file per note
+
+### Derives-from
+
+- request-rrf-ranking-improvements-from-bigdata-boutique-artic-1765a16b
+- decision-phase-2-recall-scoring-uses-rrf-with-dense-rank-tie-7969c37d
+- reference-mnemonic-ranking-signals-inventory-all-scoring-for-27ae79dc

--- a/.mnemonic/notes/research-rrf-ranking-improvements-article-analysis-vs-curren-3b8585ab.md
+++ b/.mnemonic/notes/research-rrf-ranking-improvements-article-analysis-vs-curren-3b8585ab.md
@@ -9,13 +9,15 @@ tags:
   - ranking
 lifecycle: temporary
 createdAt: '2026-05-25T14:06:16.108Z'
-updatedAt: '2026-05-25T14:06:19.207Z'
+updatedAt: '2026-05-25T14:07:30.124Z'
 role: research
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
   - id: request-rrf-ranking-improvements-from-bigdata-boutique-artic-1765a16b
+    type: derives-from
+  - id: plan-three-channel-rrf-with-graph-rank-and-rank-window-size-1c7d15da
     type: derives-from
 memoryVersion: 1
 ---

--- a/.mnemonic/notes/research-rrf-ranking-improvements-article-analysis-vs-curren-3b8585ab.md
+++ b/.mnemonic/notes/research-rrf-ranking-improvements-article-analysis-vs-curren-3b8585ab.md
@@ -9,11 +9,14 @@ tags:
   - ranking
 lifecycle: temporary
 createdAt: '2026-05-25T14:06:16.108Z'
-updatedAt: '2026-05-25T14:06:16.108Z'
+updatedAt: '2026-05-25T14:06:19.207Z'
 role: research
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: request-rrf-ranking-improvements-from-bigdata-boutique-artic-1765a16b
+    type: derives-from
 memoryVersion: 1
 ---
 ## Research: RRF Ranking Improvements — Article Analysis vs Current Implementation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `mnemonic` will be documented in this file.
 
 The format is loosely based on Keep a Changelog and uses semver-style version headings.
 
+## [Unreleased]
+
+### Changed
+
+- `recall` ranking now treats graph spreading activation as an independent RRF channel (`graph-rank`) instead of mutating semantic scores, applies a 100-result rank window per channel, and keeps canonical explanation scoring bounded when rank channels are missing.
+
 ## [0.33.1] - 2026-05-25
 
 ### Fixed

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -8,12 +8,13 @@ import type { Confidence } from "./structured-content.js";
 import type { RelationshipType } from "./storage.js";
 
 const RRF_K = 60;
+const RRF_RANK_WINDOW = 100;
 const CANONICAL_HYBRID_WEIGHT = 0.05;
 
-// RRF scaling factor: with K=60 and two channels, max RRF ≈ 2/60 ≈ 0.033.
-// Multiplied by 3.5 ≈ 0.115, matching the old additive lexical weight's order-of-magnitude
+// RRF scaling factor: with K=60 and three channels, max RRF ≈ 3/60 ≈ 0.050.
+// Multiplied by 3.0 ≈ 0.150, matching the old additive lexical weight's order-of-magnitude
 // while remaining calibration-free.
-const RRF_SCALING_FACTOR = 3.5;
+const RRF_SCALING_FACTOR = 3.0;
 
 const RECALL_ALWAYS_LOAD_BOOST = 0.01;
 const RECALL_SUMMARY_BOOST = 0.012;
@@ -52,6 +53,10 @@ export interface ScoredRecallCandidate {
   semanticRank?: number;
   /** Rank from the lexical reranking step (1-based). */
   lexicalRank?: number;
+  /** Graph spreading activation score. Undefined when no graph evidence exists. */
+  graphScore?: number;
+  /** Rank from the graph spreading activation channel (1-based). */
+  graphRank?: number;
   boosted: number;
   vault: Vault;
   isCurrentProject: boolean;
@@ -188,17 +193,16 @@ export function isWithinTemporalFilterWindow(
  * Formula:
  *   boosted + RRF + canonicalExplanationScore * CANONICAL_HYBRID_WEIGHT
  *
- * where RRF = 1/(K + semanticRank) + 1/(K + lexicalRank)
+ * where RRF = 1/(K + semanticRank) + 1/(K + lexicalRank) + 1/(K + graphRank)
  *
- * When semanticRank is missing but lexicalRank is available (rescue candidates)
- * only the lexical channel contributes. When both are missing the function
- * falls back to pure boosted (pre-RRF scoring stage).
+ * Missing channels contribute 0. When all ranks are missing, the function keeps
+ * only the boosted score plus the bounded canonical explanation contribution.
  */
 export function computeHybridScore(candidate: ScoredRecallCandidate): number {
   const canonical = candidate.canonicalExplanationScore ?? 0;
 
-  if (candidate.semanticRank === undefined && candidate.lexicalRank === undefined) {
-    return candidate.boosted + canonical;
+  if (candidate.semanticRank === undefined && candidate.lexicalRank === undefined && candidate.graphRank === undefined) {
+    return candidate.boosted + canonical * CANONICAL_HYBRID_WEIGHT;
   }
 
   const semanticContribution = candidate.semanticRank !== undefined
@@ -207,12 +211,15 @@ export function computeHybridScore(candidate: ScoredRecallCandidate): number {
   const lexicalContribution = candidate.lexicalRank !== undefined
     ? 1 / (RRF_K + candidate.lexicalRank)
     : 0;
+  const graphContribution = candidate.graphRank !== undefined
+    ? 1 / (RRF_K + candidate.graphRank)
+    : 0;
 
   // Scale RRF so its maximum influence is comparable to the old additive
-  // lexical weight (~0.12). With K = 60 and two channels the max RRF is
-  // roughly 2/60 ≈ 0.033. Multiplied by 3.5 this hits ~0.115, matching the
+  // lexical weight. With K = 60 and three channels the max RRF is roughly
+  // 3/60 ≈ 0.050. Multiplied by 3.0 this hits ~0.150, matching the
   // old order-of-magnitude while remaining calibration-free.
-  const rrf = semanticContribution + lexicalContribution;
+  const rrf = semanticContribution + lexicalContribution + graphContribution;
 
   return candidate.boosted + rrf * RRF_SCALING_FACTOR + canonical * CANONICAL_HYBRID_WEIGHT;
 }
@@ -226,12 +233,21 @@ function computeLexicalRankSignal(candidate: ScoredRecallCandidate): number {
 
 const RANK_EPSILON = 1e-9;
 
-export function assignDenseRanks<T>(items: T[], scoreOf: (item: T) => number, setRank: (item: T, rank: number) => void): void {
+export function assignDenseRanks<T>(
+  items: T[],
+  scoreOf: (item: T) => number,
+  setRank: (item: T, rank: number | undefined) => void,
+  rankWindow = RRF_RANK_WINDOW
+): void {
   let currentRank = 0;
   let previousScore: number | undefined;
   for (let i = 0; i < items.length; i++) {
     const item = items[i];
     if (item === undefined) continue;
+    if (i >= rankWindow) {
+      setRank(item, undefined);
+      continue;
+    }
     const score = scoreOf(item);
     if (previousScore === undefined || Math.abs(score - previousScore) > RANK_EPSILON) {
       currentRank = i + 1;
@@ -286,8 +302,9 @@ export function applyCanonicalExplanationPromotion(candidates: ScoredRecallCandi
     candidate.canonicalExplanationScore = computeCanonicalExplanationScore(candidate);
   }
 
-  // Assign lexicalRank based on lexicalScore (undefined scores rank last).
-  const sortedByLexical = [...candidates]
+  // Assign lexicalRank only to candidates with lexical evidence.
+  const sortedByLexical = candidates
+    .filter((candidate) => computeLexicalRankSignal(candidate) > 0)
     .sort((a, b) => computeLexicalRankSignal(b) - computeLexicalRankSignal(a) || b.score - a.score);
   assignDenseRanks(sortedByLexical, computeLexicalRankSignal, (candidate, rank) => {
     candidate.lexicalRank = rank;
@@ -504,36 +521,33 @@ export function applyGraphSpreadingActivation(
 
       const existingCandidate = candidateMap.get(rel.id);
       if (existingCandidate) {
-        existingCandidate.score += propagatedScore;
-        existingCandidate.boosted += propagatedScore;
-        if (existingCandidate.semanticScoreForPromotion !== undefined) {
-          existingCandidate.semanticScoreForPromotion += propagatedScore;
-        }
+        existingCandidate.graphScore = (existingCandidate.graphScore ?? 0) + propagatedScore;
       } else if (!discovered.has(rel.id)) {
         discovered.set(rel.id, {
           id: rel.id,
-          score: propagatedScore,
-          semanticScoreForPromotion: propagatedScore,
-          boosted: propagatedScore,
+          score: 0,
+          semanticScoreForPromotion: 0,
+          graphScore: propagatedScore,
+          boosted: 0,
           vault: entry.vault,
           isCurrentProject: entry.isCurrentProject,
         });
       } else {
         const existing = discovered.get(rel.id)!;
-        existing.score += propagatedScore;
-        existing.boosted += propagatedScore;
-        if (existing.semanticScoreForPromotion !== undefined) {
-          existing.semanticScoreForPromotion += propagatedScore;
-        }
+        existing.graphScore = (existing.graphScore ?? 0) + propagatedScore;
       }
     }
   }
 
-  if (discovered.size === 0) {
-    return candidates;
-  }
+  const withDiscovered = discovered.size === 0 ? candidates : [...candidates, ...discovered.values()];
+  const sortedByGraph = withDiscovered
+    .filter((candidate) => candidate.graphScore !== undefined)
+    .sort((a, b) => (b.graphScore ?? 0) - (a.graphScore ?? 0) || b.score - a.score);
+  assignDenseRanks(sortedByGraph, (candidate) => candidate.graphScore ?? 0, (candidate, rank) => {
+    candidate.graphRank = rank;
+  });
 
-  return [...candidates, ...discovered.values()];
+  return withDiscovered;
 }
 
 export function resolveDiscoveredVaults(

--- a/src/structured-content.ts
+++ b/src/structured-content.ts
@@ -162,7 +162,7 @@ export interface RecallRetrievalCoverage {
   missingAnchors: Array<{ id: string; title: string }>;
 }
 
-export type RetrievalEvidenceChannel = "semantic" | "lexical" | "graph" | "temporal-boost" | "canonical" | "rescue";
+export type RetrievalEvidenceChannel = "semantic" | "lexical" | "graph-rank" | "temporal-boost" | "canonical" | "rescue";
 export type RetrievalEvidenceRankBand = "top3" | "top10" | "lower";
 export type RetrievalEvidenceFreshness = "today" | "thisWeek" | "thisMonth" | "older";
 
@@ -830,7 +830,7 @@ export const RecallResultSchema = z.object({
     historySummary: z.string().optional(),
     relationships: RelationshipPreviewSchema.optional(),
     retrievalEvidence: z.object({
-      channels: z.array(z.enum(["semantic", "lexical", "graph", "temporal-boost", "canonical", "rescue"])),
+      channels: z.array(z.enum(["semantic", "lexical", "graph-rank", "temporal-boost", "canonical", "rescue"])),
       rankBand: z.enum(["top3", "top10", "lower"]),
       projectRelevant: z.boolean(),
       freshness: z.enum(["today", "thisWeek", "thisMonth", "older"]),

--- a/src/tools/recall.ts
+++ b/src/tools/recall.ts
@@ -28,7 +28,6 @@ import {
   resolveDiscoveredVaults,
   applyCanonicalExplanationPromotion,
   applyGraphSpreadingActivation,
-  assignDenseRanks,
   type ScoredRecallCandidate,
 } from "../recall.js";
 import { shouldTriggerLexicalRescue } from "../lexical.js";
@@ -280,7 +279,6 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
         undefined
       );
       const reranked = applyLexicalReranking(scored, query, getProjectionText);
-      const semanticCandidateIds = new Set(reranked.map((candidate) => candidate.id));
 
       // Apply graph spreading activation: traverse related notes and boost their scores
       const preSpreadIds = new Set(reranked.map((c) => c.id));
@@ -288,7 +286,6 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
         return noteRelationships.get(id);
       };
       const withGraphSpread = applyGraphSpreadingActivation(reranked, getNoteRelationships);
-      const graphDiscoveredIds = new Set(withGraphSpread.filter((candidate) => !semanticCandidateIds.has(candidate.id)).map((candidate) => candidate.id));
 
       // Resolve correct vault for graph-discovered candidates that inherited their
       // entry point's vault instead of their own.
@@ -301,13 +298,6 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
           }
         }
         return undefined;
-      });
-
-      // Re-assign semanticRank after graph spreading since scores are now modified
-      // and graph-discovered candidates have no semanticRank.
-      const sortedByScore = [...withGraphSpread].sort((a, b) => b.score - a.score || b.boosted - a.boosted);
-      assignDenseRanks(sortedByScore, (candidate) => candidate.score, (candidate, rank) => {
-        candidate.semanticRank = rank;
       });
 
       let promoted = applyCanonicalExplanationPromotion(withGraphSpread);
@@ -394,7 +384,7 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
       // Top 1 by default, top 3 if result count is small
       const recallRelationshipLimit = top.length <= 3 ? 3 : 1;
 
-      for (const [index, { id, score, vault, boosted, semanticRank, lexicalRank, canonicalExplanationScore, metadata, isCurrentProject }] of top.entries()) {
+      for (const [index, { id, score, vault, boosted, semanticRank, lexicalRank, graphRank, canonicalExplanationScore, metadata, isCurrentProject }] of top.entries()) {
         const note = await readCachedNote(vault, id);
         if (note) {
           const centrality = note.relatedTo?.length ?? 0;
@@ -470,7 +460,7 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
               channels: [
                 semanticRank !== undefined ? "semantic" : undefined,
                 lexicalRank !== undefined ? "lexical" : undefined,
-                graphDiscoveredIds.has(id) ? "graph" : undefined,
+                graphRank !== undefined ? "graph-rank" : undefined,
                 rescueCandidateIds.has(id) ? "rescue" : undefined,
                 canonicalExplanationScore !== undefined && canonicalExplanationScore > 0 ? "canonical" : undefined,
                 temporalQueryHint ? "temporal-boost" : undefined,

--- a/tests/recall.unit.test.ts
+++ b/tests/recall.unit.test.ts
@@ -212,6 +212,21 @@ describe("computeHybridScore", () => {
     expect(hybrid).toBeGreaterThan(0.8);
   });
 
+  it("adds graph rank as a third RRF channel", () => {
+    const twoChannel: ScoredRecallCandidate = {
+      id: "a",
+      score: 0.7,
+      boosted: 0.8,
+      vault,
+      isCurrentProject: true,
+      semanticRank: 1,
+      lexicalRank: 1,
+    };
+    const threeChannel: ScoredRecallCandidate = { ...twoChannel, graphRank: 1 };
+
+    expect(computeHybridScore(threeChannel)).toBeGreaterThan(computeHybridScore(twoChannel));
+  });
+
   it("lexical score cannot overcome large semantic gap", () => {
     const lowSemantic: ScoredRecallCandidate = { id: "a", score: 0.3, boosted: 0.3, vault, isCurrentProject: false, lexicalScore: 1.0 };
     const highSemantic: ScoredRecallCandidate = { id: "b", score: 0.8, boosted: 0.8, vault, isCurrentProject: false, lexicalScore: 0 };
@@ -233,6 +248,19 @@ describe("computeHybridScore", () => {
     const withCanonical = computeHybridScore(candidate);
     const withoutCanonical = computeHybridScore({ ...candidate, canonicalExplanationScore: 0 });
     expect(withCanonical).toBeGreaterThan(withoutCanonical);
+  });
+
+  it("keeps canonical contribution weighted when all rank channels are missing", () => {
+    const candidate: ScoredRecallCandidate = {
+      id: "tail-canonical",
+      score: 0.4,
+      boosted: 0.4,
+      vault,
+      isCurrentProject: true,
+      canonicalExplanationScore: 0.1,
+    };
+
+    expect(computeHybridScore(candidate)).toBeCloseTo(0.405, 5);
   });
 });
 
@@ -297,6 +325,35 @@ describe("applyLexicalReranking", () => {
     const reranked = applyLexicalReranking(candidates, "test", () => undefined);
 
     expect(reranked[0].lexicalScore).toBeUndefined();
+  });
+
+  it("does not assign ranks past the RRF rank window", () => {
+    const candidates: ScoredRecallCandidate[] = Array.from({ length: 101 }, (_, i) => ({
+      id: `candidate-${i}`,
+      score: 1 - i * 0.001,
+      boosted: 1 - i * 0.001,
+      vault,
+      isCurrentProject: true,
+    }));
+
+    applyLexicalReranking(candidates, "test", (id) => `projection ${id}`);
+
+    expect(candidates[99].semanticRank).toBe(100);
+    expect(candidates[100].semanticRank).toBeUndefined();
+  });
+
+  it("keeps rank window inactive for smaller candidate sets", () => {
+    const candidates: ScoredRecallCandidate[] = Array.from({ length: 3 }, (_, i) => ({
+      id: `candidate-${i}`,
+      score: 1 - i * 0.1,
+      boosted: 1 - i * 0.1,
+      vault,
+      isCurrentProject: true,
+    }));
+
+    applyLexicalReranking(candidates, "test", (id) => `projection ${id}`);
+
+    expect(candidates.map((candidate) => candidate.semanticRank)).toEqual([1, 2, 3]);
   });
 
   it("preserves all candidates after reranking", () => {
@@ -620,6 +677,7 @@ describe("canonical explanation promotion", () => {
         id: "canonical-structural",
         score: 0.56,
         semanticRank: 1,
+        graphRank: 1,
         semanticScoreForPromotion: 0.56,
         boosted: 0.56,
         vault,
@@ -727,10 +785,14 @@ describe("applyGraphSpreadingActivation", () => {
     expect(result).toHaveLength(2);
     const discovered = result.find((c) => c.id === "related-note");
     expect(discovered).toBeDefined();
-    expect(discovered!.score).toBeCloseTo(0.6 * 0.5 * 0.8, 5);
+    expect(discovered!.score).toBe(0);
+    expect(discovered!.boosted).toBe(0);
+    expect(discovered!.semanticRank).toBeUndefined();
+    expect(discovered!.graphScore).toBeCloseTo(0.6 * 0.5 * 0.8, 5);
+    expect(discovered!.graphRank).toBe(1);
   });
 
-  it("boosts an existing candidate instead of skipping it", () => {
+  it("adds graph evidence to an existing candidate without changing semantic scores", () => {
     const candidates: ScoredRecallCandidate[] = [
       { id: "entry", score: 0.6, boosted: 0.6, vault, isCurrentProject: true },
       { id: "already-there", score: 0.5, boosted: 0.5, vault, isCurrentProject: true },
@@ -747,8 +809,10 @@ describe("applyGraphSpreadingActivation", () => {
 
     expect(result).toHaveLength(2);
     const boosted = result.find((c) => c.id === "already-there")!;
-    expect(boosted.score).toBeCloseTo(0.5 + 0.6 * 0.5 * 0.8, 5);
-    expect(boosted.boosted).toBeCloseTo(0.5 + 0.6 * 0.5 * 0.8, 5);
+    expect(boosted.score).toBeCloseTo(0.5, 5);
+    expect(boosted.boosted).toBeCloseTo(0.5, 5);
+    expect(boosted.graphScore).toBeCloseTo(0.6 * 0.5 * 0.8, 5);
+    expect(boosted.graphRank).toBe(1);
   });
 
   it("accumulates propagated scores onto an existing candidate from multiple entry points", () => {
@@ -772,9 +836,10 @@ describe("applyGraphSpreadingActivation", () => {
 
     const shared = result.find((c) => c.id === "shared")!;
     const expectedBoost = 0.6 * 0.5 * 0.8 + 0.55 * 0.5 * 1.0;
-    expect(shared.score).toBeCloseTo(0.5 + expectedBoost, 5);
-    expect(shared.boosted).toBeCloseTo(0.5 + expectedBoost, 5);
-    expect(shared.semanticScoreForPromotion).toBeCloseTo(0.5 + expectedBoost, 5);
+    expect(shared.score).toBeCloseTo(0.5, 5);
+    expect(shared.boosted).toBeCloseTo(0.5, 5);
+    expect(shared.semanticScoreForPromotion).toBeCloseTo(0.5, 5);
+    expect(shared.graphScore).toBeCloseTo(expectedBoost, 5);
   });
 
   it("applies explains/derives-from multiplier of 1.0", () => {
@@ -792,7 +857,7 @@ describe("applyGraphSpreadingActivation", () => {
     const result = applyGraphSpreadingActivation(candidates, getNoteRelationships);
 
     const discovered = result.find((c) => c.id === "explains-note");
-    expect(discovered!.score).toBeCloseTo(0.7 * 0.5 * 1.0, 5);
+    expect(discovered!.graphScore).toBeCloseTo(0.7 * 0.5 * 1.0, 5);
   });
 
   it("only uses top 5 entry points", () => {
@@ -872,7 +937,7 @@ describe("applyGraphSpreadingActivation", () => {
 
     const discovered = result.find((c) => c.id === "shared");
     const expectedScore = (0.6 * 0.5 * 0.8) + (0.55 * 0.5 * 0.8);
-    expect(discovered!.score).toBeCloseTo(expectedScore, 5);
+    expect(discovered!.graphScore).toBeCloseTo(expectedScore, 5);
   });
 
   it("returns original candidates unchanged when no relationships exist", () => {
@@ -895,7 +960,7 @@ describe("applyGraphSpreadingActivation", () => {
     expect(result).toHaveLength(0);
   });
 
-  it("sets semanticScoreForPromotion on discovered candidates", () => {
+  it("does not treat graph-discovered candidates as semantically promoted", () => {
     const candidates: ScoredRecallCandidate[] = [
       { id: "entry", score: 0.7, boosted: 0.7, vault, isCurrentProject: true },
     ];
@@ -910,7 +975,25 @@ describe("applyGraphSpreadingActivation", () => {
     const result = applyGraphSpreadingActivation(candidates, getNoteRelationships);
 
     const discovered = result.find((c) => c.id === "discovered");
-    expect(discovered!.semanticScoreForPromotion).toBeCloseTo(0.7 * 0.5 * 1.0, 5);
+    expect(discovered!.semanticScoreForPromotion).toBe(0);
+    expect(discovered!.graphRank).toBe(1);
+  });
+
+  it("does not assign graph ranks past the RRF rank window", () => {
+    const candidates: ScoredRecallCandidate[] = [
+      { id: "entry", score: 0.7, boosted: 0.7, vault, isCurrentProject: true },
+    ];
+
+    const result = applyGraphSpreadingActivation(candidates, (id) => {
+      if (id !== "entry") return undefined;
+      return Array.from({ length: 101 }, (_, i) => ({ id: `related-${i}`, type: "related-to" as const }));
+    });
+
+    const ranked = result
+      .filter((candidate) => candidate.id.startsWith("related-"))
+      .sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true }));
+    expect(ranked[99].graphRank).toBe(1);
+    expect(ranked[100].graphRank).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

This PR implements a significant update to the recall scoring mechanism by replacing the additive hybrid lexical weighting with Reciprocal Rank Fusion (RRF) across both semantic and lexical channels. The decision to maintain the RRF constant at K = 60 allows for improved handling of dense rank ties, enhancing the accuracy of recall ranking. Additionally, the hybrid scoring formula has been refined to incorporate a scaled contribution from RRF, integrating it with the existing semantic backbone for better overall performance.



- **Decision: Phase 2 recall scoring uses RRF with dense rank tie handling**
- **Reference: Mnemonic ranking signals inventory — all scoring formulas across codebase**

## Changes

### Decision: Phase 2 recall scoring uses RRF with dense rank tie handling

**Tags:** recall, rrf, phase2, decision, workflow

Phase 2 replaces additive hybrid lexical weighting with Reciprocal Rank Fusion (RRF) across semantic and lexical channels in recall ranking.

### Reference: Mnemonic ranking signals inventory — all scoring formulas across codebase

**Tags:** reference, ranking, scoring, signals, design

Comprehensive inventory of every scoring formula and signal across the codebase. Captured during semvec research (May 2026) for future ranking work.

## Workflow Artifacts

**Research:**

- Research: RRF ranking improvements — article analysis vs current implementation — Sources: BigData Boutique RRF article (2026-05-18), Cormack-Clarke-Büttcher 2009 SIGIR paper, Mnemonic codebase (`src/recall.ts`, `src/tools/recall.ts`).

**Plan:**

- Plan: Three-channel RRF with graph rank and rank window size — Implements gaps 1 and 2 from research `research-rrf-ranking-improvements-article-analysis-vs-curren-3b8585ab`.

**Context:**

- Apply: three-channel RRF graph rank and rank window implementation — Implemented the RRF plan in source and tests.
- Request: RRF ranking improvements from BigData Boutique article analysis — Analyze the BigData Boutique RRF article (<https://bigdataboutique.com/blog/reciprocal-rank-fusion-how-it-works-and-when-to-use-it>) against Mnemonic's current recall ranking implementation and identify concrete, implementable improvements.

## Notes / References

_Detailed notes in `.mnemonic/notes/`:_

- `.mnemonic/notes/decision-phase-2-recall-scoring-uses-rrf-with-dense-rank-tie-7969c37d.md` — Decision: Phase 2 recall scoring uses RRF with dense rank tie handling
- `.mnemonic/notes/reference-mnemonic-ranking-signals-inventory-all-scoring-for-27ae79dc.md` — Reference: Mnemonic ranking signals inventory — all scoring formulas across codebase
- `.mnemonic/notes/apply-three-channel-rrf-graph-rank-and-rank-window-implement-4876709b.md` — Apply: three-channel RRF graph rank and rank window implementation _(context)_
- `.mnemonic/notes/plan-three-channel-rrf-with-graph-rank-and-rank-window-size-1c7d15da.md` — Plan: Three-channel RRF with graph rank and rank window size _(plan)_
- `.mnemonic/notes/request-rrf-ranking-improvements-from-bigdata-boutique-artic-1765a16b.md` — Request: RRF ranking improvements from BigData Boutique article analysis _(context)_
- `.mnemonic/notes/research-rrf-ranking-improvements-article-analysis-vs-curren-3b8585ab.md` — Research: RRF ranking improvements — article analysis vs current implementation _(research)_

---

_Generated from 6 design decision note(s) in `.mnemonic/notes/`. Run `/update-pr` to regenerate._