### PR TITLE
Improve semantic patch section replacement

### DIFF
--- a/.mnemonic/notes/semantic-patch-section-replacement-footgun-and-mitigation-id-b8b38337.md
+++ b/.mnemonic/notes/semantic-patch-section-replacement-footgun-and-mitigation-id-b8b38337.md
@@ -1,0 +1,36 @@
+---
+title: Semantic patch section replacement footgun and mitigation ideas
+tags:
+  - semantic-patch
+  - workflow
+  - tooling
+  - bug-risk
+lifecycle: temporary
+createdAt: '2026-05-25T16:28:34.246Z'
+updatedAt: '2026-05-25T16:28:34.246Z'
+role: context
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+# Semantic patch section replacement footgun and mitigation ideas
+
+Repeated duplicate-section issues come from a mismatch between user intent and `semanticPatch` semantics. Heading selectors operate on the heading node, not the whole Markdown section. Operations such as `replace` and `insertAfter` therefore do not remove the existing section body, which can leave duplicated checklist sections.
+
+## Root cause
+
+`src/semantic-patch.ts` selectors resolve to one top-level Markdown AST node. A heading selector returns only the heading node. `replace` splices that one node; `insertAfter` inserts nodes after that heading. Neither operation understands "the section under this heading" or removes sibling nodes until the next heading.
+
+## Product-level fixes to consider
+
+1. Add a real section-level operation, for example `{ selector: { section: "Verification" }, operation: { op: "replaceSection", value: "..." } }`. It should replace the heading and all following nodes until the next heading of the same or higher depth.
+2. Guard heading `replace`: if selector is `{ heading: ... }` and the replacement value includes the same heading, reject with an error explaining that heading `replace` only replaces the heading node and suggesting `replaceSection`.
+3. Add post-patch duplicate detection for repeated headings, repeated checklist bodies, or `[x]` items followed by equivalent `[ ]` originals. Fail the update before committing when detected.
+4. Rename or alias node-level operations to expose the model: `replaceNode`, `insertNodeAfter`, `insertNodeBefore`. Keep current names only as deprecated or guarded aliases.
+5. Add semantic patch dry-run diagnostics that state whether the patch will leave the existing section body intact.
+6. Operational workaround until section-aware patching exists: use full-content rewrite for multi-section workflow checklist updates instead of heading-level semantic patches.
+
+## Preferred fix
+
+Implement `replaceSection` plus a duplicate-section guard. That addresses the root API footgun and catches future misuse by humans or agents.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 
 ## [0.33.1] - 2026-05-25
 
+### Added
+
+- `update` `semanticPatch` now supports `{ selector: { section: "..." }, operation: { op: "replaceSection", value: "..." } }` for replacing an entire Markdown section, including nested content up to the next same-or-higher-level heading.
+
 ### Fixed
 
 - Semantic patch no longer escapes GFM task list checkboxes (`- [ ]` / `- [x]`) as `\[ ]` / `\[x]` during round-trip serialization.
+- Heading-level `semanticPatch` `replace` now rejects replacements that look like whole-section replacements, preventing duplicated section bodies and directing callers to `replaceSection`.
 
 ## [0.33.0] - 2026-05-25
 

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -71,12 +71,12 @@ export function registerPrompts(server: McpServer): void {
               "### semanticPatch format\n\n" +
               "When using `update` with `semanticPatch`:\n" +
               "- Each patch is an object with two keys: `selector` and `operation` (not flat `{op, value}` at top level).\n" +
-              "- `selector` has exactly one key: `heading`, `headingStartsWith`, `nthChild`, or `lastChild`.\n" +
+              "- `selector` has exactly one key: `heading`, `headingStartsWith`, `section`, `nthChild`, or `lastChild`.\n" +
               "- `operation` has an `op` key plus `value` (except `remove` which has no value).\n" +
               "- The parameter must be a JSON array, NOT a string.\n" +
               "- Use `get` first to read exact heading text, then use those headings (without `##` prefix) as selector values.\n" +
               "- Common mistake: writing `{ \"op\": \"appendChild\", \"value\": \"...\" }` at the top level instead of nesting inside `operation`. Correct shape: `{ \"selector\": { \"heading\": \"Findings\" }, \"operation\": { \"op\": \"insertAfter\", \"value\": \"text\" } }`\n" +
-              "- `appendChild`, `prependChild`, and `replaceChildren` do NOT work with `heading` selectors. To add content under a heading, use `insertAfter`. To replace a heading, use `replace`.",
+              "- `appendChild`, `prependChild`, and `replaceChildren` do NOT work with `heading` selectors. To add content under a heading, use `insertAfter`. To replace a full section including its body, use `{ \"selector\": { \"section\": \"Findings\" }, \"operation\": { \"op\": \"replaceSection\", \"value\": \"## Findings\\n\\nNew body.\" } }`.",
           },
         },
       ],

--- a/src/semantic-patch.ts
+++ b/src/semantic-patch.ts
@@ -6,6 +6,7 @@ import { SemanticPatchError } from "./domain-errors.js";
 export type SemanticSelector =
   | { heading: string }
   | { headingStartsWith: string }
+  | { section: string }
   | { nthChild: number }
   | { lastChild: true };
 
@@ -13,6 +14,7 @@ export type SemanticOperation =
   | { op: "appendChild"; value: string }
   | { op: "prependChild"; value: string }
   | { op: "replace"; value: string }
+  | { op: "replaceSection"; value: string }
   | { op: "replaceChildren"; value: string }
   | { op: "insertAfter"; value: string }
   | { op: "insertBefore"; value: string }
@@ -34,23 +36,55 @@ function isHeadingNode(node: Content): node is Heading {
   return node.type === "heading";
 }
 
+function findHeadingIndex(tree: Root, predicate: (heading: Heading) => boolean): number | undefined {
+  for (let i = 0; i < tree.children.length; i++) {
+    const child = tree.children[i];
+    if (child && isHeadingNode(child) && predicate(child)) {
+      return i;
+    }
+  }
+  return undefined;
+}
+
+function sectionEndIndex(tree: Root, headingIndex: number): number {
+  const heading = tree.children[headingIndex];
+  if (!heading || !isHeadingNode(heading)) {
+    return headingIndex + 1;
+  }
+
+  for (let i = headingIndex + 1; i < tree.children.length; i++) {
+    const child = tree.children[i];
+    if (child && isHeadingNode(child) && child.depth <= heading.depth) {
+      return i;
+    }
+  }
+  return tree.children.length;
+}
+
 function resolveSelector(tree: Root, selector: SemanticSelector): { parent: Root; index: number; target: Content } | undefined {
   if ("heading" in selector) {
-    for (let i = 0; i < tree.children.length; i++) {
-      const child = tree.children[i];
-      if (child && isHeadingNode(child) && getHeadingText(child) === selector.heading) {
-        return { parent: tree, index: i, target: child };
-      }
+    const index = findHeadingIndex(tree, (heading) => getHeadingText(heading) === selector.heading);
+    if (index !== undefined) {
+      const target = tree.children[index];
+      if (target) return { parent: tree, index, target };
     }
     return undefined;
   }
 
   if ("headingStartsWith" in selector) {
-    for (let i = 0; i < tree.children.length; i++) {
-      const child = tree.children[i];
-      if (child && isHeadingNode(child) && getHeadingText(child).startsWith(selector.headingStartsWith)) {
-        return { parent: tree, index: i, target: child };
-      }
+    const index = findHeadingIndex(tree, (heading) => getHeadingText(heading).startsWith(selector.headingStartsWith));
+    if (index !== undefined) {
+      const target = tree.children[index];
+      if (target) return { parent: tree, index, target };
+    }
+    return undefined;
+  }
+
+  if ("section" in selector) {
+    const index = findHeadingIndex(tree, (heading) => getHeadingText(heading) === selector.section);
+    if (index !== undefined) {
+      const target = tree.children[index];
+      if (target) return { parent: tree, index, target };
     }
     return undefined;
   }
@@ -92,6 +126,22 @@ function parseValueNodes(value: string): Content[] {
   return fragment.children;
 }
 
+function throwIfHeadingReplaceLooksLikeSectionReplace(target: Content, selector: SemanticSelector, op: SemanticOperation): void {
+  if (op.op !== "replace" || !("heading" in selector || "headingStartsWith" in selector) || !isHeadingNode(target)) {
+    return;
+  }
+
+  const newNodes = parseValueNodes(op.value);
+  if (!newNodes.some((node) => isHeadingNode(node) && getHeadingText(node) === getHeadingText(target))) {
+    return;
+  }
+
+  throw new SemanticPatchError(
+    "Heading `replace` only replaces the heading node and leaves the existing section body intact. " +
+    "Use `{ selector: { section: \"...\" }, operation: { op: \"replaceSection\", value: \"...\" } }` to replace a whole section."
+  );
+}
+
 function collectAvailableHeadings(tree: Root): string[] {
   const headings: string[] = [];
   for (const child of tree.children) {
@@ -124,6 +174,7 @@ export async function applySemanticPatches(body: string, patches: SemanticPatch[
 
     const { parent, index, target } = resolved;
     const op = patch.operation;
+    throwIfHeadingReplaceLooksLikeSectionReplace(target, patch.selector, op);
 
     switch (op.op) {
       case "appendChild": {
@@ -147,6 +198,14 @@ export async function applySemanticPatches(body: string, patches: SemanticPatch[
       case "replace": {
         const newNodes = parseValueNodes(op.value);
         parent.children.splice(index, 1, ...newNodes);
+        break;
+      }
+      case "replaceSection": {
+        if (!isHeadingNode(target) || !("section" in patch.selector)) {
+          throw new SemanticPatchError("replaceSection requires a section selector");
+        }
+        const newNodes = parseValueNodes(op.value);
+        parent.children.splice(index, sectionEndIndex(parent, index) - index, ...newNodes);
         break;
       }
       case "replaceChildren": {

--- a/src/tools/update.ts
+++ b/src/tools/update.ts
@@ -84,19 +84,21 @@ export function registerUpdateTool(server: McpServer, ctx: ServerContext): void 
             selector: z.object({
               heading: z.string().optional(),
               headingStartsWith: z.string().optional(),
+              section: z.string().optional(),
               nthChild: z.number().int().optional(),
               lastChild: z.literal(true).optional(),
             }).refine(
               (sel) => {
-                const keys = [sel.heading, sel.headingStartsWith, sel.nthChild, sel.lastChild].filter((v) => v !== undefined);
+                const keys = [sel.heading, sel.headingStartsWith, sel.section, sel.nthChild, sel.lastChild].filter((v) => v !== undefined);
                 return keys.length === 1;
               },
-              { message: "Selector must have exactly one of: heading, headingStartsWith, nthChild, lastChild" }
+              { message: "Selector must have exactly one of: heading, headingStartsWith, section, nthChild, lastChild" }
             ),
             operation: z.discriminatedUnion("op", [
               z.object({ op: z.literal("appendChild"), value: z.string() }),
               z.object({ op: z.literal("prependChild"), value: z.string() }),
               z.object({ op: z.literal("replace"), value: z.string() }),
+              z.object({ op: z.literal("replaceSection"), value: z.string() }),
               z.object({ op: z.literal("replaceChildren"), value: z.string() }),
               z.object({ op: z.literal("insertAfter"), value: z.string() }),
               z.object({ op: z.literal("insertBefore"), value: z.string() }),
@@ -107,15 +109,15 @@ export function registerUpdateTool(server: McpServer, ctx: ServerContext): void 
           .describe(
             "Targeted edits to note sections. Array of {selector, operation} objects. Mutually exclusive with content. " +
             "If this fails, fix the issue in your patch values and retry — do NOT fall back to full content rewrite.\n\n" +
-            "selector: exactly one of { heading: \"exact heading text\" } | { headingStartsWith: \"prefix\" } | { lastChild: true } | { nthChild: 0-based-index }\n" +
-            "operation: { op: \"appendChild\", value: \"content\" } | { op: \"prependChild\", value: \"content\" } | { op: \"replace\", value: \"new content\" } | { op: \"replaceChildren\", value: \"new children\" } | { op: \"insertAfter\", value: \"content\" } | { op: \"insertBefore\", value: \"content\" } | { op: \"remove\" }\n\n" +
+            "selector: exactly one of { heading: \"exact heading text\" } | { headingStartsWith: \"prefix\" } | { section: \"exact heading text\" } | { lastChild: true } | { nthChild: 0-based-index }\n" +
+            "operation: { op: \"appendChild\", value: \"content\" } | { op: \"prependChild\", value: \"content\" } | { op: \"replace\", value: \"new content\" } | { op: \"replaceSection\", value: \"new section\" } | { op: \"replaceChildren\", value: \"new children\" } | { op: \"insertAfter\", value: \"content\" } | { op: \"insertBefore\", value: \"content\" } | { op: \"remove\" }\n\n" +
             "Example — add a paragraph under ## Findings, replace body under ## Recommendation, remove ## Old Section:\n" +
             "[\n" +
             "  { \"selector\": { \"heading\": \"Findings\" }, \"operation\": { \"op\": \"insertAfter\", \"value\": \"A new paragraph.\" } },\n" +
-            "  { \"selector\": { \"heading\": \"Recommendation\" }, \"operation\": { \"op\": \"replace\", \"value\": \"## Recommendation\\n\\nUpdated recommendation.\" } },\n" +
+            "  { \"selector\": { \"section\": \"Recommendation\" }, \"operation\": { \"op\": \"replaceSection\", \"value\": \"## Recommendation\\n\\nUpdated recommendation.\" } },\n" +
             "  { \"selector\": { \"heading\": \"Old Section\" }, \"operation\": { \"op\": \"remove\" } }\n" +
             "]\n\n" +
-            "IMPORTANT: `appendChild`, `prependChild`, and `replaceChildren` do NOT work with `heading` selectors (headings only contain inline text, not block content). To add or replace content under a heading, use `insertAfter`. To replace a heading entirely, use `replace`."
+            "IMPORTANT: `appendChild`, `prependChild`, and `replaceChildren` do NOT work with `heading` selectors (headings only contain inline text, not block content). To add content under a heading, use `insertAfter`. To replace a full section including its body, use `section` + `replaceSection`."
           ),
         content: z.string().max(100000, "Content must be at most 100,000 characters").optional().describe("Full note body replacement. Use only for complete rewrites or when the note is small. Mutually exclusive with semanticPatch. Content must pass markdown lint. Auto-fixable issues are fixed automatically. Common unfixable issues: fenced code blocks need a language tag (e.g. use ```text not bare ```), and broken links are rejected. If lint fails, fix the specific issues and retry — do NOT fall back to semanticPatch for this."),
         title: z.string().max(500, "Title must be at most 500 characters").optional().describe("Specific, retrieval-friendly title. Prefer the concrete topic or decision, not a vague label."),

--- a/tests/semantic-patch.unit.test.ts
+++ b/tests/semantic-patch.unit.test.ts
@@ -320,6 +320,30 @@ describe("semantic-patch", () => {
     expect(result.lintWarnings).toEqual([]);
   });
 
+  it("replaces an entire section with replaceSection", async () => {
+    const note = "# Note\n\n## A\n\nOld A.\n\n### Child\n\nNested old.\n\n## B\n\nKeep B.\n";
+    const patches: SemanticPatch[] = [
+      { selector: { section: "A" }, operation: { op: "replaceSection", value: "## A\n\nNew A." } },
+    ];
+    const result = await applySemanticPatches(note, patches);
+    expect(result.content).toBe("# Note\n\n## A\n\nNew A.\n\n## B\n\nKeep B.");
+    expect(result.lintWarnings).toEqual([]);
+  });
+
+  it("rejects replaceSection without a section selector", async () => {
+    const patches: SemanticPatch[] = [
+      { selector: { heading: "Details" }, operation: { op: "replaceSection", value: "## Details\n\nNew." } },
+    ];
+    await expect(applySemanticPatches(sampleNote, patches)).rejects.toThrow("replaceSection requires a section selector");
+  });
+
+  it("rejects heading replace that looks like a section replacement", async () => {
+    const patches: SemanticPatch[] = [
+      { selector: { heading: "Details" }, operation: { op: "replace", value: "## Details\n\nNew details." } },
+    ];
+    await expect(applySemanticPatches(sampleNote, patches)).rejects.toThrow("Heading `replace` only replaces the heading node");
+  });
+
   it("fails on ambiguous headingStartsWith match (returns first match)", async () => {
     const note = "# Alpha\n\n## Alphabeta\n\nA.\n";
     const patches: SemanticPatch[] = [


### PR DESCRIPTION
## Summary

Repeated duplicate-section issues come from a mismatch between user intent and `semanticPatch` semantics.

## Workflow Artifacts

**Context:**

- Semantic patch section replacement footgun and mitigation ideas — Repeated duplicate-section issues come from a mismatch between user intent and `semanticPatch` semantics.

## Notes / References

_Detailed notes in `.mnemonic/notes/`:_

- `.mnemonic/notes/semantic-patch-section-replacement-footgun-and-mitigation-id-b8b38337.md` — Semantic patch section replacement footgun and mitigation ideas _(context)_

---

_Generated from 1 design decision note(s) in `.mnemonic/notes/`. Run `/update-pr` to regenerate._