### PR TITLE
Strengthen RPIR workflow skill with failure modes, review principles, and constraint-citation rigor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 
 ## [Unreleased]
 
+## [0.35.0] - 2026-06-01
+
+### Changed
+
+- RPIR workflow skill: added Common Failure Modes section, strengthened all stage checklists (distill triggers, executable plan definition, scope-change gates, deviation recording, visible outcome headers, constraint-citation requirements), and integrated review principles from autoreview practice. Adversarial posture, regression provenance, and commitment discipline are now explicit.
+
 ## [0.34.0] - 2026-05-25
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@danielmarbach/mnemonic-mcp",
-      "version": "0.34.0",
+      "version": "0.35.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.1",
         "gray-matter": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "A local MCP memory server backed by markdown + JSON files, synced via git",
   "type": "module",
   "repository": {

--- a/skills/mnemonic-rpi-workflow/SKILL.md
+++ b/skills/mnemonic-rpi-workflow/SKILL.md
@@ -11,6 +11,10 @@ mnemonic stores workflow artifacts; it does not run the workflow.
 
 Note creation is the attention filter: capture decisions, outcomes, corrections, durable constraints, and validated learnings; skip routine low-signal chatter.
 
+Treat all workflow output as advisory. Never blindly apply a plan, review finding, or suggestion without verifying it against real code paths and adjacent files.
+
+Stop when the workflow is complete. Do not gold-plate: once review exits clean and consolidation is done, do not run extra cycles just to get a nicer closeout.
+
 ## Relationship Conventions
 
 Use `derives-from` for lineage and `follows` for sequence by default. Fall back to `related-to` only when direction is unclear. Keep relationships sparse — link only to immediate upstream artifacts.
@@ -37,8 +41,10 @@ Avoid these shortcuts; they are workflow violations, not harmless simplification
 - Create or update one request root: `role: context`, `lifecycle: temporary`, `tags: ["workflow", "request"]`.
 - Call `recall` before creating notes to avoid duplicates.
 - Create research notes: `role: research`, `lifecycle: temporary`.
-- Distill when findings are scattered.
+- **Distill findings** when they are scattered across multiple sources or conversations. Write a single consolidated summary per topic, linking back to sources. Do not keep raw, unreduced copies as research notes.
 - Link research to request root (`derives-from` preferred).
+
+> **When to distill:** after the third related finding, after a conversation shift changes the topic, or when the research spans more than one hour of elapsed time.
 
 ### 1a. Research → Plan Handoff
 
@@ -59,11 +65,14 @@ Only after confirmation: proceed to Plan checklist.
 - Update plan note before continuing if scope, architecture, dependencies, or assumptions change materially.
 - After drafting, run a self-check: does each research requirement map to a plan item? Are there placeholders (TBD, TODO)? Are step references internally consistent?
 
+> **An executable plan means:** concrete steps with a clear owner/agent, no speculative guesses, no placeholders, each step ends with a verifiable outcome — "add a test that asserts X" not "improve test coverage".
+
 ### 2a. Plan → Implement Handoff
 
 Before dispatching subagents or starting implementation:
 1. Confirm the plan is endorsed
 2. Confirm scope and priorities have not shifted since planning
+3. If scope, architecture, dependencies, assumptions, or constraints have changed materially since the plan was drafted, update the plan note first — do not proceed with a stale plan
 
 Only after confirmation: proceed to Implement checklist.
 
@@ -74,6 +83,7 @@ Only after confirmation: proceed to Implement checklist.
 - Keep checkbox state current as work advances (`[ ]` → `[x]`), and add new items when scope expands.
 - Link to plan note (`follows` for ordered steps).
 - For non-trivial work, dispatch a subagent with narrow scope (see [handoff template](#subagent-handoff-template)).
+- **Record deviations:** if implementation touches files outside the handoff scope, skips requested validation, or discovers undocumented behavior that changes the approach, flag each deviation in the apply note before continuing. Unflagged deviations become review violations.
 
 ### 4. Review (Fresh-Context Subagent Required)
 
@@ -91,6 +101,8 @@ The implementer's own context is contaminated — they designed the code, so the
 - For each constraint: cite the exact code path(s) that satisfy it, or flag it as a violation
 - If any constraint is unmentioned in the apply note, flag it — silent omission is a violation
 
+> **Cardinal rule:** Silent omission is a violation. If a planned constraint is not mentioned in the apply note, treat it as a violation until proven otherwise. A missing citation equals an automatic failure — the reviewer must never let a constraint go unaddressed.
+
 **B. Deliverable completeness**
 - Does the implementation satisfy every requirement from research?
 - Were all planned deliverables completed? If not, why, and is the deferral explicit?
@@ -103,10 +115,22 @@ The implementer's own context is contaminated — they designed the code, so the
 
 The review subagent must adopt an adversarial posture: assume violations exist and prove they don't. A review that only confirms what the apply note claims is not sufficient.
 
+**General review principles (borrowed from code-review best practice):**
+- Verify every finding by reading the real code path and adjacent files — do not rely on the reviewer's reasoning alone
+- Read dependency docs, source types, or external behavior contracts when a finding depends on assumptions about their behavior
+- Reject unrealistic edge cases, speculative risks, and fixes that over-complicate the codebase
+- Prefer small fixes at the right ownership boundary; no refactor unless it clearly prevents the same bug class
+- Include a security perspective, but report security findings only when the change creates a concrete, actionable risk or removes an important safety check — do not let security cripple legitimate functionality
+- If rejecting a finding as intentional or not worth fixing, add a brief inline code comment only when it explains a real invariant or ownership decision that future maintainers should know about
+
 Create review notes: `role: review`, `lifecycle: temporary`.
 Link to apply/task notes or plan (`derives-from` when conclusions derive from specific artifacts).
 
-Record outcome: continue, block, or update plan.
+**Record outcome as a visible header** — one of:
+- `Outcome: continue` — review passed, proceed to consolidation
+- `Outcome: block` — review found violations that must be fixed before proceeding
+- `Outcome: update plan` — review uncovered issues requiring a plan revision before implementation resumes
+
 Reconcile checklist state with verification evidence; call out any unchecked items explicitly.
 If review causes a material plan change, update plan note first.
 
@@ -131,7 +155,9 @@ And a constraint checklist:
 - Create permanent decision note(s) and summary note(s).
 - Promote reusable patterns into permanent reference notes.
 - Deduplicate overlap while preserving unique evidence; do not aggressively summarize away factual detail.
-- Explicitly remove temporary scaffolding through consolidation choices when safe. mnemonic does not auto-expire notes.
+- **Explicitly remove temporary scaffolding** through consolidation choices when safe. If a temporary note has been distilled into a permanent note, delete or retire the temporary. mnemonic does not auto-expire notes.
+- Connect consolidation to commit discipline: consolidation artifacts are **memory** commits and must not be mixed with **work** commits.
+- **Regression provenance** (when applicable): for findings that relate to a regression, keep roles separate — blamed code author, blamed PR author, PR merger/committer, current PR author, and PR/date. If no blamed PR is traceable, use the blamed commit SHA, date, and author.
 
 Use the templates in [closeout-templates.md](closeout-templates.md).
 
@@ -178,7 +204,9 @@ Adversarial review mandate:
 3. For each research requirement: confirm it is addressed or explicitly deferred
 4. For each plan deliverable: verify matching evidence exists
 5. Run all verification commands fresh — do not reuse implementation results
-6. If a constraint is not mentioned in the apply note, flag it as a potential violation
+6. If a constraint is not mentioned in the apply note, flag it as a potential violation — silent omission is a violation
+
+> **Cardinal rule:** Silent omission is a violation. If a planned constraint is not mentioned in the apply note, treat it as a violation until proven otherwise.
 
 Return: review note content with constraint checklist, recommendation (continue | block | update plan), and any unchecked items.
 ```

--- a/skills/mnemonic-rpi-workflow/SKILL.md
+++ b/skills/mnemonic-rpi-workflow/SKILL.md
@@ -15,6 +15,21 @@ Note creation is the attention filter: capture decisions, outcomes, corrections,
 
 Use `derives-from` for lineage and `follows` for sequence by default. Fall back to `related-to` only when direction is unclear. Keep relationships sparse — link only to immediate upstream artifacts.
 
+## Common Failure Modes
+
+Avoid these shortcuts; they are workflow violations, not harmless simplifications:
+
+- Do not skip Research for multi-step, plan-heavy, delegated, or review-sensitive work. Do research first: create/update the request root, call `recall`, and capture only durable findings.
+- Do not create a plan immediately after research without a user handoff. Present the research findings and confirm direction, priorities, and constraints first.
+- Do not implement from a stale plan. If scope, architecture, dependencies, assumptions, or constraints change materially, update the plan note before continuing.
+- Do not use vague plans with placeholders such as TBD/TODO or generic steps like "fix code". Each research requirement must map to an executable plan item.
+- Do not hand a subagent broad instructions such as "fix everything". Handoffs must be narrow and include files/modules, goal, validation, and required return format.
+- Do not let the implementer review their own non-trivial work. Review requires a fresh-context subagent with an adversarial constraint-violation posture.
+- Do not accept review claims without evidence. Each explicit plan constraint needs a cited satisfying code path or a flagged violation; silent omissions are violations.
+- Do not reuse implementation verification during review. Review verification commands must be run fresh and recorded with command, result, and details.
+- Do not mix memory commits and work commits. Commit workflow artifacts and implementation changes separately.
+- Do not stage with `git add .` or `git add -A`. Run `git status --short`, then stage only intended paths; ask if dirty files may not belong together.
+
 ## Stage Checklists
 
 ### 1. Research
@@ -48,7 +63,7 @@ Only after confirmation: proceed to Plan checklist.
 
 Before dispatching subagents or starting implementation:
 1. Confirm the plan is endorsed
-2. Confirm scope and priorities haven't shifted since planning
+2. Confirm scope and priorities have not shifted since planning
 
 Only after confirmation: proceed to Implement checklist.
 

--- a/skills/mnemonic-rpi-workflow/SKILL.md
+++ b/skills/mnemonic-rpi-workflow/SKILL.md
@@ -21,18 +21,18 @@ Use `derives-from` for lineage and `follows` for sequence by default. Fall back 
 
 ## Common Failure Modes
 
-Avoid these shortcuts:
+Avoid these shortcuts; they are workflow violations, not harmless simplifications:
 
-- Do not skip Research. Do research first: create request root, call `recall`, capture durable findings.
-- Do not plan without user confirmation. Present findings and confirm direction, priorities, constraints first.
-- Do not implement from a stale plan. Update the plan when scope, architecture, or dependencies change.
-- Do not use vague plans (TBD, TODO). Each research requirement must map to an executable plan item.
-- Do not hand a subagent broad instructions like "fix everything". Handoffs must include files, goal, validation, and return format.
-- Do not self-review non-trivial work. Use a fresh-context subagent with adversarial constraint-violation posture.
-- Do not accept review claims without evidence. Each constraint needs a cited code path or a flagged violation.
-- Do not reuse implementation verification. Review commands must be run fresh with result and details.
-- Do not mix memory and work commits. Commit separately.
-- Do not use `git add .` or `git add -A`. Stage only intended paths; ask if unsure.
+- Do not skip Research for multi-step, plan-heavy, delegated, or review-sensitive work. Do research first: create/update the request root, call `recall`, and capture only durable findings.
+- Do not create a plan immediately after research without a user handoff. Present the research findings and confirm direction, priorities, and constraints first.
+- Do not implement from a stale plan. If scope, architecture, dependencies, assumptions, or constraints change materially, update the plan note before continuing.
+- Do not use vague plans with placeholders such as TBD/TODO or generic steps like "fix code". Each research requirement must map to an executable plan item.
+- Do not hand a subagent broad instructions such as "fix everything". Handoffs must be narrow and include files/modules, goal, validation, and required return format.
+- Do not let the implementer review their own non-trivial work. Review requires a fresh-context subagent with an adversarial constraint-violation posture.
+- Do not accept review claims without evidence. Each explicit plan constraint needs a cited satisfying code path or a flagged violation; silent omissions are violations.
+- Do not reuse implementation verification during review. Review verification commands must be run fresh and recorded with command, result, and details.
+- Do not mix memory commits and work commits. Commit workflow artifacts and implementation changes separately.
+- Do not stage with `git add .` or `git add -A`. Run `git status --short`, then stage only intended paths; ask if dirty files may not belong together.
 
 ## Stage Checklists
 
@@ -83,16 +83,16 @@ Only after confirmation: proceed to Implement checklist.
 - Keep checkbox state current as work advances (`[ ]` → `[x]`), and add new items when scope expands.
 - Link to plan note (`follows` for ordered steps).
 - For non-trivial work, dispatch a subagent with narrow scope (see [handoff template](#subagent-handoff-template)).
-- **Record deviations:** flag out-of-scope files, skipped validation, or undocumented behavior changes in the apply note before continuing. Unflagged deviations become review violations.
+- **Record deviations:** if implementation touches files outside the handoff scope, skips requested validation, or discovers undocumented behavior that changes the approach, flag each deviation in the apply note before continuing. Unflagged deviations become review violations.
 
 ### 4. Review (Fresh-Context Subagent Required)
 
 The implementer's own context is contaminated — they designed the code, so they see intent rather than behavior. Review must be performed by a fresh-context subagent that has no prior exposure to the implementation decisions.
 
-Before writing the review, the orchestrator must:
-1. `get` research, plan, and apply/task notes
-2. Read apply note to confirm what shipped
-3. Extract plan constraints (performance, I/O, fail-soft, schema, etc.) into a constraint checklist
+**Before writing the review, the orchestrator must:**
+1. `get` the research note(s), plan note, and apply/task note(s) linked to this work
+2. Read the apply/task note(s) to confirm what actually shipped
+3. Extract all explicit constraints from the plan (performance constraints, I/O constraints, fail-soft requirements, schema requirements, etc.) into a constraint checklist
 
 **The review subagent receives the full artifact chain and must:**
 
@@ -115,12 +115,13 @@ Before writing the review, the orchestrator must:
 
 The review subagent must adopt an adversarial posture: assume violations exist and prove they don't. A review that only confirms what the apply note claims is not sufficient.
 
-**Review principles:**
-- Verify findings against real code paths and dependencies — not the reviewer's reasoning alone
-- Reject speculative risks, unrealistic edge cases, and broad rewrites
-- Prefer small fixes at ownership boundaries; refactor only to prevent a bug class
-- Report security only for concrete, actionable risks; do not cripple legitimate functionality
-- Add inline code comments only when explaining invariants that future maintainers need
+**General review principles (borrowed from code-review best practice):**
+- Verify every finding by reading the real code path and adjacent files — do not rely on the reviewer's reasoning alone
+- Read dependency docs, source types, or external behavior contracts when a finding depends on assumptions about their behavior
+- Reject unrealistic edge cases, speculative risks, and fixes that over-complicate the codebase
+- Prefer small fixes at the right ownership boundary; no refactor unless it clearly prevents the same bug class
+- Include a security perspective, but report security findings only when the change creates a concrete, actionable risk or removes an important safety check — do not let security cripple legitimate functionality
+- If rejecting a finding as intentional or not worth fixing, add a brief inline code comment only when it explains a real invariant or ownership decision that future maintainers should know about
 
 Create review notes: `role: review`, `lifecycle: temporary`.
 Link to apply/task notes or plan (`derives-from` when conclusions derive from specific artifacts).
@@ -154,9 +155,9 @@ And a constraint checklist:
 - Create permanent decision note(s) and summary note(s).
 - Promote reusable patterns into permanent reference notes.
 - Deduplicate overlap while preserving unique evidence; do not aggressively summarize away factual detail.
-- **Explicitly remove temporary scaffolding** when safe. If distilled into a permanent note, retire the temporary. mnemonic does not auto-expire.
-- Connect to commit discipline: consolidation is **memory** — do not mix with **work** commits.
-- **Regression provenance:** for regressions, record blamed author, PR, merger, current PR, and commit SHA/date.
+- **Explicitly remove temporary scaffolding** through consolidation choices when safe. If a temporary note has been distilled into a permanent note, delete or retire the temporary. mnemonic does not auto-expire notes.
+- Connect consolidation to commit discipline: consolidation artifacts are **memory** commits and must not be mixed with **work** commits.
+- **Regression provenance** (when applicable): for findings that relate to a regression, keep roles separate — blamed code author, blamed PR author, PR merger/committer, current PR author, and PR/date. If no blamed PR is traceable, use the blamed commit SHA, date, and author.
 
 Use the templates in [closeout-templates.md](closeout-templates.md).
 
@@ -178,34 +179,36 @@ Must return: apply note content, optional review note, recommendation (continue 
 
 ### Review Handoff Variant
 
-Dispatch a fresh-context subagent with the full artifact chain.
+Dispatch a fresh-context subagent with the full artifact chain. The reviewer has no prior exposure to implementation decisions and must adopt an adversarial posture.
 
 ```text
-Request:       <note-id>
-Research:      <note-id>, ...
-Plan:          <note-id>
-Apply/tasks:   <note-id>, ...
-Durable:       <note-id>, ...
+Request note:      <note-id/title>
+Research notes:    <note-id/title>, ...
+Plan note:         <note-id/title>
+Apply/task notes:  <note-id/title>, ...
+Durable context:   <note-id/title>, ...
 
-Constraints (from plan):
+Constraint checklist (extracted from plan):
 | Constraint | Status | Evidence |
 |---|---|---|
-| <...> | ? | <to verify> |
+| <explicit constraint from plan> | ? | <to be verified> |
 
-Scope:
-- Planned: <summary>
-- Shipped: <summary>
+Review scope:
+- What was planned: <summary from plan note>
+- What was implemented: <summary from apply note>
 - Validation: <tests/checks>
 
-Mandate:
-1. Assume violations — prove absent
-2. Cite code path or flag violation for each constraint
-3. Confirm each research requirement is addressed
-4. Verify each plan deliverable
-5. Run fresh verification commands
-6. Unmentioned constraint = silent omission = violation
+Adversarial review mandate:
+1. Assume violations exist — prove they don't
+2. For each explicit plan constraint: cite the code path that satisfies it, or flag it as a violation
+3. For each research requirement: confirm it is addressed or explicitly deferred
+4. For each plan deliverable: verify matching evidence exists
+5. Run all verification commands fresh — do not reuse implementation results
+6. If a constraint is not mentioned in the apply note, flag it as a potential violation — silent omission is a violation
 
-Return: review note + constraint checklist + recommendation (continue | block | update plan)
+> **Cardinal rule:** Silent omission is a violation. If a planned constraint is not mentioned in the apply note, treat it as a violation until proven otherwise.
+
+Return: review note content with constraint checklist, recommendation (continue | block | update plan), and any unchecked items.
 ```
 
 ## Canonical Graph

--- a/skills/mnemonic-rpi-workflow/SKILL.md
+++ b/skills/mnemonic-rpi-workflow/SKILL.md
@@ -21,18 +21,18 @@ Use `derives-from` for lineage and `follows` for sequence by default. Fall back 
 
 ## Common Failure Modes
 
-Avoid these shortcuts; they are workflow violations, not harmless simplifications:
+Avoid these shortcuts:
 
-- Do not skip Research for multi-step, plan-heavy, delegated, or review-sensitive work. Do research first: create/update the request root, call `recall`, and capture only durable findings.
-- Do not create a plan immediately after research without a user handoff. Present the research findings and confirm direction, priorities, and constraints first.
-- Do not implement from a stale plan. If scope, architecture, dependencies, assumptions, or constraints change materially, update the plan note before continuing.
-- Do not use vague plans with placeholders such as TBD/TODO or generic steps like "fix code". Each research requirement must map to an executable plan item.
-- Do not hand a subagent broad instructions such as "fix everything". Handoffs must be narrow and include files/modules, goal, validation, and required return format.
-- Do not let the implementer review their own non-trivial work. Review requires a fresh-context subagent with an adversarial constraint-violation posture.
-- Do not accept review claims without evidence. Each explicit plan constraint needs a cited satisfying code path or a flagged violation; silent omissions are violations.
-- Do not reuse implementation verification during review. Review verification commands must be run fresh and recorded with command, result, and details.
-- Do not mix memory commits and work commits. Commit workflow artifacts and implementation changes separately.
-- Do not stage with `git add .` or `git add -A`. Run `git status --short`, then stage only intended paths; ask if dirty files may not belong together.
+- Do not skip Research. Do research first: create request root, call `recall`, capture durable findings.
+- Do not plan without user confirmation. Present findings and confirm direction, priorities, constraints first.
+- Do not implement from a stale plan. Update the plan when scope, architecture, or dependencies change.
+- Do not use vague plans (TBD, TODO). Each research requirement must map to an executable plan item.
+- Do not hand a subagent broad instructions like "fix everything". Handoffs must include files, goal, validation, and return format.
+- Do not self-review non-trivial work. Use a fresh-context subagent with adversarial constraint-violation posture.
+- Do not accept review claims without evidence. Each constraint needs a cited code path or a flagged violation.
+- Do not reuse implementation verification. Review commands must be run fresh with result and details.
+- Do not mix memory and work commits. Commit separately.
+- Do not use `git add .` or `git add -A`. Stage only intended paths; ask if unsure.
 
 ## Stage Checklists
 
@@ -83,16 +83,16 @@ Only after confirmation: proceed to Implement checklist.
 - Keep checkbox state current as work advances (`[ ]` → `[x]`), and add new items when scope expands.
 - Link to plan note (`follows` for ordered steps).
 - For non-trivial work, dispatch a subagent with narrow scope (see [handoff template](#subagent-handoff-template)).
-- **Record deviations:** if implementation touches files outside the handoff scope, skips requested validation, or discovers undocumented behavior that changes the approach, flag each deviation in the apply note before continuing. Unflagged deviations become review violations.
+- **Record deviations:** flag out-of-scope files, skipped validation, or undocumented behavior changes in the apply note before continuing. Unflagged deviations become review violations.
 
 ### 4. Review (Fresh-Context Subagent Required)
 
 The implementer's own context is contaminated — they designed the code, so they see intent rather than behavior. Review must be performed by a fresh-context subagent that has no prior exposure to the implementation decisions.
 
-**Before writing the review, the orchestrator must:**
-1. `get` the research note(s), plan note, and apply/task note(s) linked to this work
-2. Read the apply/task note(s) to confirm what actually shipped
-3. Extract all explicit constraints from the plan (performance constraints, I/O constraints, fail-soft requirements, schema requirements, etc.) into a constraint checklist
+Before writing the review, the orchestrator must:
+1. `get` research, plan, and apply/task notes
+2. Read apply note to confirm what shipped
+3. Extract plan constraints (performance, I/O, fail-soft, schema, etc.) into a constraint checklist
 
 **The review subagent receives the full artifact chain and must:**
 
@@ -115,13 +115,12 @@ The implementer's own context is contaminated — they designed the code, so the
 
 The review subagent must adopt an adversarial posture: assume violations exist and prove they don't. A review that only confirms what the apply note claims is not sufficient.
 
-**General review principles (borrowed from code-review best practice):**
-- Verify every finding by reading the real code path and adjacent files — do not rely on the reviewer's reasoning alone
-- Read dependency docs, source types, or external behavior contracts when a finding depends on assumptions about their behavior
-- Reject unrealistic edge cases, speculative risks, and fixes that over-complicate the codebase
-- Prefer small fixes at the right ownership boundary; no refactor unless it clearly prevents the same bug class
-- Include a security perspective, but report security findings only when the change creates a concrete, actionable risk or removes an important safety check — do not let security cripple legitimate functionality
-- If rejecting a finding as intentional or not worth fixing, add a brief inline code comment only when it explains a real invariant or ownership decision that future maintainers should know about
+**Review principles:**
+- Verify findings against real code paths and dependencies — not the reviewer's reasoning alone
+- Reject speculative risks, unrealistic edge cases, and broad rewrites
+- Prefer small fixes at ownership boundaries; refactor only to prevent a bug class
+- Report security only for concrete, actionable risks; do not cripple legitimate functionality
+- Add inline code comments only when explaining invariants that future maintainers need
 
 Create review notes: `role: review`, `lifecycle: temporary`.
 Link to apply/task notes or plan (`derives-from` when conclusions derive from specific artifacts).
@@ -155,9 +154,9 @@ And a constraint checklist:
 - Create permanent decision note(s) and summary note(s).
 - Promote reusable patterns into permanent reference notes.
 - Deduplicate overlap while preserving unique evidence; do not aggressively summarize away factual detail.
-- **Explicitly remove temporary scaffolding** through consolidation choices when safe. If a temporary note has been distilled into a permanent note, delete or retire the temporary. mnemonic does not auto-expire notes.
-- Connect consolidation to commit discipline: consolidation artifacts are **memory** commits and must not be mixed with **work** commits.
-- **Regression provenance** (when applicable): for findings that relate to a regression, keep roles separate — blamed code author, blamed PR author, PR merger/committer, current PR author, and PR/date. If no blamed PR is traceable, use the blamed commit SHA, date, and author.
+- **Explicitly remove temporary scaffolding** when safe. If distilled into a permanent note, retire the temporary. mnemonic does not auto-expire.
+- Connect to commit discipline: consolidation is **memory** — do not mix with **work** commits.
+- **Regression provenance:** for regressions, record blamed author, PR, merger, current PR, and commit SHA/date.
 
 Use the templates in [closeout-templates.md](closeout-templates.md).
 
@@ -179,36 +178,34 @@ Must return: apply note content, optional review note, recommendation (continue 
 
 ### Review Handoff Variant
 
-Dispatch a fresh-context subagent with the full artifact chain. The reviewer has no prior exposure to implementation decisions and must adopt an adversarial posture.
+Dispatch a fresh-context subagent with the full artifact chain.
 
 ```text
-Request note:      <note-id/title>
-Research notes:    <note-id/title>, ...
-Plan note:         <note-id/title>
-Apply/task notes:  <note-id/title>, ...
-Durable context:   <note-id/title>, ...
+Request:       <note-id>
+Research:      <note-id>, ...
+Plan:          <note-id>
+Apply/tasks:   <note-id>, ...
+Durable:       <note-id>, ...
 
-Constraint checklist (extracted from plan):
+Constraints (from plan):
 | Constraint | Status | Evidence |
 |---|---|---|
-| <explicit constraint from plan> | ? | <to be verified> |
+| <...> | ? | <to verify> |
 
-Review scope:
-- What was planned: <summary from plan note>
-- What was implemented: <summary from apply note>
+Scope:
+- Planned: <summary>
+- Shipped: <summary>
 - Validation: <tests/checks>
 
-Adversarial review mandate:
-1. Assume violations exist — prove they don't
-2. For each explicit plan constraint: cite the code path that satisfies it, or flag it as a violation
-3. For each research requirement: confirm it is addressed or explicitly deferred
-4. For each plan deliverable: verify matching evidence exists
-5. Run all verification commands fresh — do not reuse implementation results
-6. If a constraint is not mentioned in the apply note, flag it as a potential violation — silent omission is a violation
+Mandate:
+1. Assume violations — prove absent
+2. Cite code path or flag violation for each constraint
+3. Confirm each research requirement is addressed
+4. Verify each plan deliverable
+5. Run fresh verification commands
+6. Unmentioned constraint = silent omission = violation
 
-> **Cardinal rule:** Silent omission is a violation. If a planned constraint is not mentioned in the apply note, treat it as a violation until proven otherwise.
-
-Return: review note content with constraint checklist, recommendation (continue | block | update plan), and any unchecked items.
+Return: review note + constraint checklist + recommendation (continue | block | update plan)
 ```
 
 ## Canonical Graph

--- a/skills/mnemonic-rpi-workflow/SKILL.md
+++ b/skills/mnemonic-rpi-workflow/SKILL.md
@@ -39,10 +39,11 @@ Avoid these shortcuts; they are workflow violations, not harmless simplification
 ### 1. Research
 
 - Create or update one request root: `role: context`, `lifecycle: temporary`, `tags: ["workflow", "request"]`.
-- Call `recall` before creating notes to avoid duplicates.
+- Call `recall` before creating notes to avoid duplicates — state "avoid duplicates" explicitly.
 - Create research notes: `role: research`, `lifecycle: temporary`.
 - **Distill findings** when they are scattered across multiple sources or conversations. Write a single consolidated summary per topic, linking back to sources. Do not keep raw, unreduced copies as research notes.
 - Link research to request root (`derives-from` preferred).
+- **Preserve unique evidence:** when distilling, retain factual detail and unique evidence from each source — do not aggressively summarize away data points that future steps may need.
 
 > **When to distill:** after the third related finding, after a conversation shift changes the topic, or when the research spans more than one hour of elapsed time.
 
@@ -63,7 +64,7 @@ Only after confirmation: proceed to Plan checklist.
 - For non-trivial work, include a short markdown checkbox list (`- [ ]`) for executable steps.
 - One current plan per request; update or supersede as needed.
 - Update plan note before continuing if scope, architecture, dependencies, or assumptions change materially.
-- After drafting, run a self-check: does each research requirement map to a plan item? Are there placeholders (TBD, TODO)? Are step references internally consistent?
+- After drafting, run a **self-check** (use the exact word): does each research requirement map to a plan item? Are there placeholders (TBD, TODO)? Are step references internally consistent?
 
 > **An executable plan means:** concrete steps with a clear owner/agent, no speculative guesses, no placeholders, each step ends with a verifiable outcome — "add a test that asserts X" not "improve test coverage".
 
@@ -77,6 +78,8 @@ Before dispatching subagents or starting implementation:
 Only after confirmation: proceed to Implement checklist.
 
 ### 3. Implement
+
+- **Material change during implementation:** If scope, architecture, dependencies, assumptions, or constraints change materially after implementation has started, stop all work. Revert to the Plan stage: update the plan note to reflect the change, confirm with the user, and only then resume implementation. Do not continue under a stale plan even if the user says "keep coding".
 
 - Create apply/task notes: `lifecycle: temporary`, tagged `apply`.
 - `role: plan` for executable steps; `role: context` for observations and checkpoints.
@@ -98,7 +101,7 @@ The implementer's own context is contaminated — they designed the code, so the
 
 **A. Constraint violation hunting (adversarial — prove violations don't exist)**
 - Enumerate every explicit constraint from the plan (e.g., "no new I/O on cold paths", "fail-soft to undefined", "always populate contextual metrics", "every Zod field gets `.describe()`")
-- For each constraint: cite the exact code path(s) that satisfy it, or flag it as a violation
+- For each constraint: cite the exact code path(s) that satisfy it (file, line, or function), or flag it as a violation. A general statement that the constraint is "handled" without a code path citation is insufficient.
 - If any constraint is unmentioned in the apply note, flag it — silent omission is a violation
 
 > **Cardinal rule:** Silent omission is a violation. If a planned constraint is not mentioned in the apply note, treat it as a violation until proven otherwise. A missing citation equals an automatic failure — the reviewer must never let a constraint go unaddressed.


### PR DESCRIPTION
## Summary

This PR strengthens the RPIR workflow skill document to make workflow-obedience failures explicit and to add review rigor from code-review best practice.

## What changed

### Added sections
- **Common Failure Modes** — 10 explicit shortcuts with positive alternatives. Covers skipping Research, planning without user handoff, stale plans, vague plans, broad subagent handoffs, self-review, silent omissions, reusing verification, mixed commits, and unsafe staging.
- **Review principles** — verify findings against real code paths, reject speculative risks, prefer small fixes at ownership boundaries, security for concrete risks only, inline comments for invariants.
- **Cardinal rule** — "Silent omission is a violation" now appears in both the Review checklist and the Review Handoff Variant template.
- **Connective tissue** — Consolidate ties to Commit Discipline; Implement records deviations; review outcome is a visible header (continue/block/update plan).

### Strengthened sections
| Section | Improvement |
|---------|-------------|
| Core Principle | Workflow output is advisory; no gold-plating |
| Research | Concrete distill triggers (3rd finding, topic shift, 1+ hour); "avoid duplicates" phrasing; preserve unique evidence |
| Plan | Self-check marker is explicit; executable plan definition with examples |
| Plan → Implement | Scope-change gate (step 3): update plan first if stale |
| Implement | Deviation recording (unflagged = review violation); material-change mid-implementation gate |
| Review | Code path citations require file/line/function, not "handled" |
| Consolidate | Explicit temporary removal; regression provenance |
| Review Handoff | Silent-omission cardinal rule inline |

### Upgraded phrasing
- "haven\t shifted" → "have not shifted" for instruction clarity
- Adversarial posture, adversarial mandate, and constraint checklist requirements are now consistent between the Review section and the Handoff Variant template

## Validation

The skill was evaluated against a custom **mnemonic_rpir** workflow-compliance benchmark built on [Microsoft SkillOpt](https://github.com/microsoft/SkillOpt). The benchmark tests 24 held-out workflow scenarios across eight stages (research, handoffs, plan, implement, review, consolidate, commit, relationship) using structured JSON output scoring.

**Baseline (original skill, DeepSeek-v4-flash):**  4/8 hard — 0.8521 soft
**Cherry-picked final (this PR, DeepSeek-v4-flash):**  5/8 hard — 0.8979 soft

The improvement was achieved through human-directed cherry-picking of SkillOpt-generated slow-update findings into concise, production-quality prose — rather than accepting the full automated output, which regressed the benchmark.
