### PR TITLE
Migrate mnemonic to MCP 2026-07-28 spec and TypeScript SDK v2

### DIFF
--- a/.mnemonic/notes/mnemonic-project-overview-and-purpose-763b7a51.md
+++ b/.mnemonic/notes/mnemonic-project-overview-and-purpose-763b7a51.md
@@ -7,7 +7,7 @@ tags:
   - typescript
 lifecycle: permanent
 createdAt: '2026-03-07T17:58:49.005Z'
-updatedAt: '2026-05-09T21:16:14.012Z'
+updatedAt: '2026-08-01T10:55:12.757Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
@@ -29,12 +29,14 @@ A personal MCP memory server backed by plain markdown + JSON files, synced via g
 
 **Embedding transport:** `src/embeddings.ts` uses Ollama's `/api/embed` endpoint with truncation enabled so longer notes still embed safely with the v2 model.
 
-**Stack:** TypeScript, Node.js, `@modelcontextprotocol/sdk`, `simple-git`, `gray-matter`, `zod`, Ollama (external HTTP).
+**Stack:** TypeScript, Node.js, `@modelcontextprotocol/server` v2 (MCP 2026-07-28 spec), `simple-git`, `gray-matter`, `zod`, Ollama (external HTTP).
 
 **Vault location:** `~/mnemonic-vault` by default (env: `VAULT_PATH`). One `.md` file per note, embeddings in `embeddings/` (gitignored — local only).
 
 **Repository layout:** runtime code lives in `src/`, compiled output goes to `build/`.
 
 **Entry point:** `build/index.js` (compiled from `src/index.ts`). Run via `node build/index.js`.
+
+**MCP transport:** `serveStdio()` from `@modelcontextprotocol/server/stdio` — era-negotiating stdio transport supporting both legacy and 2026-era clients.
 
 **Inspired by:** petabridge/memorizer but without Postgres/pgvector.

--- a/.mnemonic/notes/mnemonic-source-file-layout-4d11294d.md
+++ b/.mnemonic/notes/mnemonic-source-file-layout-4d11294d.md
@@ -7,7 +7,7 @@ tags:
   - structure
 lifecycle: permanent
 createdAt: '2026-03-07T17:58:59.865Z'
-updatedAt: '2026-05-09T21:06:02.096Z'
+updatedAt: '2026-08-01T10:55:12.739Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
@@ -21,7 +21,8 @@ memoryVersion: 1
 ---
 All runtime TypeScript source files live under `src/` to keep the repository layout obvious and predictable.
 
-- `src/index.ts` — MCP server entry point, all tool registrations, config, startup
+- `src/index.ts` — MCP server entry point, tool registration, `McpServer` construction with cache hints, startup via `serveStdio()`
+- `src/startup.ts` — Server startup via `serveStdio()` from `@modelcontextprotocol/server/stdio`, pending migration warnings
 - `src/storage.ts` — read/write notes (markdown + YAML frontmatter) and embeddings (JSON); defines `Note`, `Relationship`, `RelationshipType`, `EmbeddingRecord`
 - `src/embeddings.ts` — Ollama HTTP client, cosine similarity, `embedModel` constant
 - `src/git.ts` — git operations via `simple-git`; `GitOps` class, `SyncResult` type
@@ -34,3 +35,5 @@ Build output goes to `build/`. `tsconfig.json` uses `rootDir: src` and targets E
 **Important:** `simpleGit()` must be called in `GitOps.init()`, not the constructor — the vault directory does not exist until `Storage.init()` runs first.
 
 **Organization rule:** keep the repo simple and mostly flat; add feature folders only when the codebase actually pushes for them.
+
+**SDK:** `@modelcontextprotocol/server` v2 (MCP 2026-07-28). No more `_registeredTools` override — v2 defaults to JSON Schema 2020-12.

--- a/.mnemonic/notes/plan-migrate-mnemonic-to-mcp-2026-07-28-spec-and-typescript--072d79cd.md
+++ b/.mnemonic/notes/plan-migrate-mnemonic-to-mcp-2026-07-28-spec-and-typescript--072d79cd.md
@@ -7,7 +7,7 @@ tags:
   - mcp-2026-07-28
 lifecycle: temporary
 createdAt: '2026-08-01T10:44:02.956Z'
-updatedAt: '2026-08-01T10:44:02.956Z'
+updatedAt: '2026-08-01T10:44:10.184Z'
 role: plan
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -17,6 +17,8 @@ relatedTo:
     type: related-to
   - id: mnemonic-project-overview-and-purpose-763b7a51
     type: related-to
+  - id: research-mcp-2026-07-28-spec-changes-and-typescript-sdk-v2-m-57bad211
+    type: derives-from
 memoryVersion: 1
 ---
 # Plan: MCP 2026-07-28 + TypeScript SDK v2 Migration

--- a/.mnemonic/notes/plan-migrate-mnemonic-to-mcp-2026-07-28-spec-and-typescript--072d79cd.md
+++ b/.mnemonic/notes/plan-migrate-mnemonic-to-mcp-2026-07-28-spec-and-typescript--072d79cd.md
@@ -1,0 +1,93 @@
+---
+title: 'Plan: Migrate mnemonic to MCP 2026-07-28 spec and TypeScript SDK v2'
+tags:
+  - rpir
+  - workflow
+  - plan
+  - mcp-2026-07-28
+lifecycle: temporary
+createdAt: '2026-08-01T10:44:02.956Z'
+updatedAt: '2026-08-01T10:44:02.956Z'
+role: plan
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+relatedTo:
+  - id: mnemonic-mcp-tools-inventory-47499799
+    type: related-to
+  - id: mnemonic-project-overview-and-purpose-763b7a51
+    type: related-to
+memoryVersion: 1
+---
+# Plan: MCP 2026-07-28 + TypeScript SDK v2 Migration
+
+Single PR, 5 stages executed sequentially.
+
+## Stage 1: Dependency Swap
+
+- Remove `@modelcontextprotocol/sdk` v1.30.0
+- Add `@modelcontextprotocol/server` v2.0.0
+- Update all import paths across `src/` and `tests/`
+
+## Stage 2: Core API Migration
+
+- **`src/index.ts`**: Remove the `tools/list` override (~54 lines: `ListToolsRequestSchema`, `toJsonSchemaCompat`, `normalizeObjectSchema`, `internalServer.setRequestHandler`, `_registeredTools` access). Drop `capabilities` from `McpServer` constructor.
+- **`src/startup.ts`**: Replace `StdioServerTransport` + `server.connect()` with `serveStdio(() => buildServer())` from `@modelcontextprotocol/server/stdio`.
+- **`src/tools/*.ts`** (29 files): Wrap `inputSchema` from bare shapes to `z.object({...})`. Rename `extra` → `ctx` in handlers. Ensure `CallToolResult` carries `content`.
+- **`src/prompts.ts`**: Wrap `argsSchema` in `z.object({...})`.
+- **`src/context.ts`** + **`src/server-context.ts`**: Update types for v2 SDK.
+
+## Stage 3: Test Infrastructure + Dogfooding
+
+- **`tests/helpers/mcp.ts`**: Update `callLocalMcpMethod()` and `createPersistentMcpSession()` — v2 `serveStdio()` serves legacy clients so `initialize` handshake still works, but verify response shapes.
+- **`tests/helpers/mcp-schema-client.ts`**: Verify `tools/list` response compatibility with v2 format.
+- **`scripts/dogfood-document-source.mjs`**: Verify `ensureSession()` still works with v2 server (legacy shim).
+- **`scripts/run-dogfood-packs.mjs`**: Same.
+- Run `npm test` + `npm run dogfood:isolated`. Both must pass.
+
+## Stage 4: Protocol Improvements
+
+- Add `cacheHints` to `McpServer` options for `tools/list` caching (1h TTL).
+- Verify all `outputSchema` fields respect structured output contract (`.describe()`, tool description `Returns`, text output parity).
+
+## Stage 5: Documentation + Memory Sync
+
+- **`ARCHITECTURE.md`**: Update MCP server entry point section, remove mention of `tools/list` override, document `serveStdio()`, update source layout table.
+- **`README.md`**: Note MCP 2026-07-28 compliance, updated dependency.
+- **`AGENT.md`**: Verify tool table accuracy.
+- **`CHANGELOG.md`**: Curated migration entry.
+- **`docs/index.html`**: Mention spec version support.
+- Update permanent design notes:
+  - `mnemonic-project-overview-and-purpose-763b7a51` — update SDK reference
+  - `mnemonic-source-file-layout-4d11294d` — reflect new `src/index.ts` structure
+  - `mnemonic-mcp-tools-inventory-47499799` — refresh if needed
+
+## Schema Version Hack
+
+- The `tools/list` override (commits e6321f6 + 717ea3f) is the "hack" — originally patch-package, then runtime override.
+- V2 SDK defaults to JSON Schema 2020-12 → **entire override removed** in Stage 2.
+
+## Subagent Delegation
+
+- `inputSchema` wrapping across 29 tool files delegated to subagents (model: `deepseek/deepseek-v4-flash`).
+- Core migration (Stages 1-2) kept in main context.
+
+## Structured Content Contract Check (Stage 4)
+
+- Verify no `outputSchema` drift from v2 SDK conversion.
+- Ensure all Zod output schema fields have `.describe()`.
+- Verify text output parity for all structured content fields.
+
+## Dogfooding
+
+- `verify:release` chain = `build → test → dogfood:isolated` — all three must pass.
+- Dogfood scripts (`dogfood-document-source.mjs`, `run-dogfood-packs.mjs`) use raw JSON-RPC with `initialize` handshake — v2 `serveStdio()` legacy shim serves them transparently, but response shape verification needed.
+
+## Design Constraints (all stages)
+
+- File-first, git-backed — no I/O changes
+- Fail-soft to undefined
+- No new I/O on cold paths
+- Structured output: `.describe()` + tool description `Returns` + text output parity
+- Changelog curated, not commit log
+- Docs sync: ARCHITECTURE.md, README.md, AGENT.md, docs/index.html

--- a/.mnemonic/notes/plan-migrate-mnemonic-to-mcp-2026-07-28-spec-and-typescript--072d79cd.md
+++ b/.mnemonic/notes/plan-migrate-mnemonic-to-mcp-2026-07-28-spec-and-typescript--072d79cd.md
@@ -7,7 +7,7 @@ tags:
   - mcp-2026-07-28
 lifecycle: temporary
 createdAt: '2026-08-01T10:44:02.956Z'
-updatedAt: '2026-08-01T10:44:10.184Z'
+updatedAt: '2026-08-01T11:00:39.514Z'
 role: plan
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -19,6 +19,8 @@ relatedTo:
     type: related-to
   - id: research-mcp-2026-07-28-spec-changes-and-typescript-sdk-v2-m-57bad211
     type: derives-from
+  - id: review-mcp-2026-07-28-typescript-sdk-v2-migration-f9c93e37
+    type: follows
 memoryVersion: 1
 ---
 # Plan: MCP 2026-07-28 + TypeScript SDK v2 Migration

--- a/.mnemonic/notes/request-migrate-mnemonic-to-mcp-2026-07-28-specification-and-fda9bab6.md
+++ b/.mnemonic/notes/request-migrate-mnemonic-to-mcp-2026-07-28-specification-and-fda9bab6.md
@@ -8,13 +8,15 @@ tags:
   - request
 lifecycle: temporary
 createdAt: '2026-08-01T10:39:47.907Z'
-updatedAt: '2026-08-01T10:39:54.858Z'
+updatedAt: '2026-08-01T10:44:10.183Z'
 role: context
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
   - id: research-mcp-2026-07-28-spec-changes-and-typescript-sdk-v2-m-57bad211
+    type: related-to
+  - id: plan-migrate-mnemonic-to-mcp-2026-07-28-spec-and-typescript--072d79cd
     type: related-to
 memoryVersion: 1
 ---

--- a/.mnemonic/notes/request-migrate-mnemonic-to-mcp-2026-07-28-specification-and-fda9bab6.md
+++ b/.mnemonic/notes/request-migrate-mnemonic-to-mcp-2026-07-28-specification-and-fda9bab6.md
@@ -1,0 +1,57 @@
+---
+title: >-
+  Request: Migrate mnemonic to MCP 2026-07-28 specification and TypeScript SDK
+  v2
+tags:
+  - rpir
+  - workflow
+  - request
+lifecycle: temporary
+createdAt: '2026-08-01T10:39:47.907Z'
+updatedAt: '2026-08-01T10:39:47.907Z'
+role: context
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+# Request: Migrate to MCP 2026-07-28 + TypeScript SDK v2
+
+## What
+
+Migrate mnemonic from `@modelcontextprotocol/sdk` v1.x to `@modelcontextprotocol/server` v2.0.0, adopting the MCP 2026-07-28 protocol revision.
+
+## Why
+
+- MCP 2026-07-28 is the largest spec revision ever, making MCP stateless
+- TypeScript SDK v2 is the stable release line going forward
+- JSON Schema 2020-12 now the default — mnemonic's hacky `tools/list` override can be removed
+- Cache hints for tool lists can reduce token waste for clients
+- Cleaner architecture: no more SDK-internal access (`_registeredTools`)
+
+## Scope
+
+- Replace `@modelcontextprotocol/sdk` with `@modelcontextprotocol/server`
+- Migrate stdio transport: `server.connect(StdioServerTransport)` → `serveStdio()`
+- Wrap all `inputSchema` from bare shapes to `z.object({...})` (Standard Schema)
+- Remove `tools/list` JSON Schema 2020-12 override (~50 lines)
+- Update test helpers (no more `initialize` handshake)
+- Add cache hints for tools/list
+- Update ARCHITECTURE.md, README.md, AGENT.md, CHANGELOG.md, docs/index.html
+
+## Design Constraints (from mnemonic memory)
+
+- File-first, git-backed — no database, no daemon
+- Fail-soft to undefined
+- Structured output contract (Zod .describe(), tool descriptions, text output)
+- No new I/O on cold/fallback paths
+- Changelog and docs sync across all surfaces
+- RPIR workflow discipline
+
+## References
+
+- <https://blog.modelcontextprotocol.io/posts/2026-07-28/>
+- <https://devblogs.microsoft.com/dotnet/announcing-v20-of-the-official-mcp-csharp-sdk/>
+- <https://aws.amazon.com/blogs/machine-learning/how-agentcore-gateway-supports-the-mcp-2026-07-28-spec/>
+- <https://ts.sdk.modelcontextprotocol.io/v2/migration/support-2026-07-28>
+- SDK currently at v1.30.0 (via Renovate lockfile bump)

--- a/.mnemonic/notes/request-migrate-mnemonic-to-mcp-2026-07-28-specification-and-fda9bab6.md
+++ b/.mnemonic/notes/request-migrate-mnemonic-to-mcp-2026-07-28-specification-and-fda9bab6.md
@@ -8,11 +8,14 @@ tags:
   - request
 lifecycle: temporary
 createdAt: '2026-08-01T10:39:47.907Z'
-updatedAt: '2026-08-01T10:39:47.907Z'
+updatedAt: '2026-08-01T10:39:54.858Z'
 role: context
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: research-mcp-2026-07-28-spec-changes-and-typescript-sdk-v2-m-57bad211
+    type: related-to
 memoryVersion: 1
 ---
 # Request: Migrate to MCP 2026-07-28 + TypeScript SDK v2

--- a/.mnemonic/notes/research-mcp-2026-07-28-spec-changes-and-typescript-sdk-v2-m-57bad211.md
+++ b/.mnemonic/notes/research-mcp-2026-07-28-spec-changes-and-typescript-sdk-v2-m-57bad211.md
@@ -7,11 +7,14 @@ tags:
   - mcp-2026-07-28
 lifecycle: temporary
 createdAt: '2026-08-01T10:39:47.900Z'
-updatedAt: '2026-08-01T10:39:47.900Z'
+updatedAt: '2026-08-01T10:39:54.858Z'
 role: research
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: request-migrate-mnemonic-to-mcp-2026-07-28-specification-and-fda9bab6
+    type: related-to
 memoryVersion: 1
 ---
 # Research: MCP 2026-07-28 + TypeScript SDK v2 Migration

--- a/.mnemonic/notes/research-mcp-2026-07-28-spec-changes-and-typescript-sdk-v2-m-57bad211.md
+++ b/.mnemonic/notes/research-mcp-2026-07-28-spec-changes-and-typescript-sdk-v2-m-57bad211.md
@@ -7,7 +7,7 @@ tags:
   - mcp-2026-07-28
 lifecycle: temporary
 createdAt: '2026-08-01T10:39:47.900Z'
-updatedAt: '2026-08-01T10:39:54.858Z'
+updatedAt: '2026-08-01T10:44:10.184Z'
 role: research
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -15,6 +15,8 @@ projectName: mnemonic
 relatedTo:
   - id: request-migrate-mnemonic-to-mcp-2026-07-28-specification-and-fda9bab6
     type: related-to
+  - id: plan-migrate-mnemonic-to-mcp-2026-07-28-spec-and-typescript--072d79cd
+    type: derives-from
 memoryVersion: 1
 ---
 # Research: MCP 2026-07-28 + TypeScript SDK v2 Migration

--- a/.mnemonic/notes/research-mcp-2026-07-28-spec-changes-and-typescript-sdk-v2-m-57bad211.md
+++ b/.mnemonic/notes/research-mcp-2026-07-28-spec-changes-and-typescript-sdk-v2-m-57bad211.md
@@ -1,0 +1,114 @@
+---
+title: 'Research: MCP 2026-07-28 spec changes and TypeScript SDK v2 migration impact'
+tags:
+  - rpir
+  - workflow
+  - research
+  - mcp-2026-07-28
+lifecycle: temporary
+createdAt: '2026-08-01T10:39:47.900Z'
+updatedAt: '2026-08-01T10:39:47.900Z'
+role: research
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+# Research: MCP 2026-07-28 + TypeScript SDK v2 Migration
+
+## Spec Changes
+
+### Core: Stateless Protocol
+
+- `initialize`/`initialized` handshake **retired** (SEP-2575, SEP-2567)
+- `Mcp-Session-Id` header removed
+- Each request self-describing: carries protocol version, client identity, capabilities in `_meta`
+- New `server/discover` RPC for capability discovery (optional, not required)
+- Horizontal scaling: any request can land on any instance behind plain round-robin LB
+
+### Multi Round-Trip Requests (MRTR)
+
+- Replaces server-initiated `elicitation/create`, `sampling/createMessage`, `roots/list`
+- Server returns `resultType: "input_required"` with embedded requests
+- Client retries original call with `inputResponses` attached
+- `requestState` — opaque string for server state across rounds
+
+### Header-Based Routing
+
+- `Mcp-Method` and `Mcp-Name` headers on Streamable HTTP
+- Gateways/WAFs/rate limiters route on headers, not JSON body
+
+### Cacheable List Results
+
+- `tools/list`, `prompts/list`, `resources/list`, `resources/read` carry `ttlMs` and `cacheScope`
+- Clients can cache tool catalogs
+
+### Other
+
+- Authorization: RFC 9207 `iss` validation, DCR deprecated in favor of CIMD
+- Tasks move to `io.modelcontextprotocol/tasks` extension
+- Sampling, Roots, Logging deprecated (SEP-2577)
+- JSON Schema 2020-12 now default
+
+## TypeScript SDK v2 Changes
+
+### Package Split
+
+- v1: `@modelcontextprotocol/sdk` (monolithic, subpath imports)
+- v2: `@modelcontextprotocol/server` + `@modelcontextprotocol/client`
+- Optional middleware: `@modelcontextprotocol/express`, `/fastify`, `/hono`, `/node`
+
+### Server API Changes
+
+| v1 | v2 |
+| --- | --- |
+| `server.connect(new StdioServerTransport())` | `serveStdio(() => buildServer())` from `@modelcontextprotocol/server/stdio` |
+| `inputSchema: { url: z.url() }` (bare shapes) | `inputSchema: z.object({ url: z.url() })` (Standard Schema) |
+| `extra` handler param | `ctx` handler param |
+| `McpServer(name, ver, { capabilities })` | `McpServer({ name, version })` — no capabilities arg |
+| JSON Schema draft-07 by default | JSON Schema 2020-12 by default |
+| `toJsonSchemaCompat` / `normalizeObjectSchema` | SDK handles conversion internally |
+
+### Stdio: serveStdio()
+
+- Hand-constructed `McpServer` + `StdioServerTransport` speaks 2025-era only
+- For 2026-07-28: `serveStdio(() => buildServer())` selects era per connection
+- Per-request identity via `ctx.mcpReq.envelope`, NOT `getClientCapabilities()`
+
+### Requirements
+
+- Node ≥ 22.19 (mnemonic: v25.2.1 ✅)
+- Zod ≥ 4.2.0 (mnemonic: v4.3.6 ✅)
+- TypeScript ≥ 6 (mnemonic: TS6 ✅)
+
+## Impact on Mnemonic
+
+### Direct Benefits
+
+1. **Remove `tools/list` override** — the `_registeredTools` + `internalServer.setRequestHandler` hack goes away (~50 lines)
+2. **Cache hints** — add `ttlMs`/`cacheScope` to tool list responses (28 tools, agents re-request frequently)
+3. **Cleaner entrypoint** — no SDK-internal hackery
+4. **Future-proof** — v2 is the stable release line
+
+### Files to Change
+
+- `src/index.ts` — major: imports, McpServer constructor, remove tools/list override
+- `src/startup.ts` — `serveStdio()` instead of `StdioServerTransport` + `server.connect()`
+- `src/context.ts` / `src/server-context.ts` — type updates
+- `src/tools/*.ts` (29 files) — `inputSchema` wrapping, `extra`→`ctx`
+- `src/prompts.ts` — `argsSchema` wrapping
+- `tests/helpers/mcp.ts` — initialize handshake changes
+- `tests/helpers/mcp-schema-client.ts` — tools/list response shape
+- `package.json` — dependency swap
+
+### Backward Compatibility
+
+- v2 SDK handles legacy clients transparently (auto-negotiates era)
+- v2 server still accepts v1 clients via legacy shim
+- No flag day needed
+
+## External Confirmation
+
+- C# SDK v2 confirms backward-compatible-by-design pattern
+- AWS AgentCore confirms "designed to be the last revision that breaks compatibility"
+- Migration is opt-in — nothing breaks on July 28

--- a/.mnemonic/notes/review-mcp-2026-07-28-typescript-sdk-v2-migration-f9c93e37.md
+++ b/.mnemonic/notes/review-mcp-2026-07-28-typescript-sdk-v2-migration-f9c93e37.md
@@ -1,0 +1,78 @@
+---
+title: 'Review: MCP 2026-07-28 + TypeScript SDK v2 migration'
+tags:
+  - rpir
+  - workflow
+  - review
+  - mcp-2026-07-28
+lifecycle: temporary
+createdAt: '2026-08-01T11:00:32.902Z'
+updatedAt: '2026-08-01T11:00:32.902Z'
+role: review
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+# Review: MCP 2026-07-28 + TypeScript SDK v2 Migration
+
+## Summary
+
+Successfully migrated mnemonic from `@modelcontextprotocol/sdk` v1.30.0 to `@modelcontextprotocol/server` v2.0.0. Net reduction of 974 lines. All 1305 tests + dogfooding pass.
+
+## What Changed
+
+### Removed (~54 lines)
+
+- `tools/list` JSON Schema 2020-12 override (`_registeredTools` + `internalServer.setRequestHandler` hack)
+- `toJsonSchemaCompat`, `normalizeObjectSchema`, `ListToolsRequestSchema` imports
+
+### Changed
+
+- 31 files: import `@modelcontextprotocol/sdk/server/mcp.js` → `@modelcontextprotocol/server`
+- `src/startup.ts`: `server.connect(new StdioServerTransport())` → `serveStdio(() => server)`
+- `src/index.ts`: `McpServer` constructor format, added `cacheHints`
+- `package.json`: removed `@modelcontextprotocol/sdk` v1.x dependency
+
+### Added
+
+- `cacheHints` on `tools/list`: 1-hour TTL, private cache scope
+- CHANGELOG entry
+- ARCHITECTURE.md updates
+
+## What Didn't Need Changing
+
+- `inputSchema` wrapping — already `z.object({...})` from Zod v4 migration
+- `extra` → `ctx` — no tool used the handler context parameter
+- `prompts.ts` — no `argsSchema` to wrap
+- Test helpers — legacy shim in `serveStdio()` handles `initialize` handshake transparently
+- Dogfood scripts — same, legacy shim transparent
+
+## Verification
+
+- `npm test`: 1305/1305 pass, 75 test files ✅
+- `npm run dogfood:isolated`: passes ✅
+- `npx tsc --noEmit`: clean ✅
+- `npm run build:fast`: clean ✅
+- `npm run lint`: clean ✅
+- `npm run format:check`: clean ✅
+- Pre-commit hooks: all passed ✅
+
+## Design Constraints Compliance
+
+- File-first, git-backed — unchanged ✅
+- Fail-soft to undefined — unchanged ✅
+- No new I/O on cold paths — unchanged ✅
+- Structured output contract preserved ✅
+- Changelog curated ✅
+- Docs synced ✅
+
+## Residual Notes
+
+- Two tests (`sync-migrations`, `writable-attachment`) can fail under high parallelism but pass in isolation — pre-existing flakiness, not SDK-related
+- `@modelcontextprotocol/sdk` removed from dependencies; Renovate will no longer attempt v1 updates
+
+## Memory Updates
+
+- `mnemonic-project-overview-and-purpose-763b7a51` — updated SDK reference
+- `mnemonic-source-file-layout-4d11294d` — updated source layout for v2

--- a/.mnemonic/notes/review-mcp-2026-07-28-typescript-sdk-v2-migration-f9c93e37.md
+++ b/.mnemonic/notes/review-mcp-2026-07-28-typescript-sdk-v2-migration-f9c93e37.md
@@ -7,11 +7,14 @@ tags:
   - mcp-2026-07-28
 lifecycle: temporary
 createdAt: '2026-08-01T11:00:32.902Z'
-updatedAt: '2026-08-01T11:00:32.902Z'
+updatedAt: '2026-08-01T11:00:39.514Z'
 role: review
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: plan-migrate-mnemonic-to-mcp-2026-07-28-spec-and-typescript--072d79cd
+    type: follows
 memoryVersion: 1
 ---
 # Review: MCP 2026-07-28 + TypeScript SDK v2 Migration

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,14 +1,14 @@
 # Architecture
 
-`mnemonic` is a file-first MCP memory server. It stores notes as markdown, keeps embeddings as local JSON, routes reads and writes across a main vault and optional project vaults, and uses git as the synchronization and audit layer instead of a database.
+`mnemonic` is an MCP memory server built around files. It stores notes as markdown, keeps embeddings as local JSON, routes reads and writes across a main vault and optional project vaults, and uses git for synchronization and audit instead of a database.
 
 ## System goals
 
 - Keep memory durable, inspectable, and portable by storing source data as normal files.
-- Make project context first-class without losing access to global memory.
-- Let MCP clients spawn the server on demand over stdio instead of depending on an always-on service.
+- Keep project context available without losing access to global memory.
+- Let MCP clients spawn the server on demand over stdio instead of requiring an always-on service.
 - Treat embeddings as derived data that can be rebuilt locally.
-- Keep the architecture simple enough to evolve through notes, tests, and migrations rather than heavyweight infrastructure.
+- Keep the architecture simple enough to evolve through notes, tests, and migrations instead of heavyweight infrastructure.
 
 ## Core concepts
 
@@ -23,7 +23,7 @@
 - Notes live in `notes/<id>.md` with YAML frontmatter and markdown body.
 - Embeddings live in `embeddings/<id>.json` and are gitignored.
 - A note can be global or project-associated, and can hold typed relationships to other notes.
-- Metadata-only note changes such as lifecycle migrations do not require re-embedding; embeddings are refreshed when title/content changes or during sync backfill.
+- Metadata-only note changes such as lifecycle migrations do not require re-embedding. Embeddings are refreshed when title or content changes, or during sync backfill.
 
 ### Project identity
 
@@ -34,7 +34,7 @@
 
 ### MCP-first operations
 
-- `src/index.ts` registers the MCP tools and is the orchestration layer. Uses `@modelcontextprotocol/server` v2 (MCP 2026-07-28 spec).
+- `src/index.ts` registers the MCP tools and coordinates requests. It uses `@modelcontextprotocol/server` v2 (MCP 2026-07-28 spec).
 - The server entry point uses `serveStdio()` from `@modelcontextprotocol/server/stdio` which auto-negotiates protocol era with clients.
 - Most user-visible behavior is exposed through tools like `remember`, `recall`, `update`, `forget`, `sync`, `consolidate`, and migration commands.
 - The local helper `scripts/mcp-local.sh` rebuilds and launches the current server for dogfooding and CI-safe integration tests.
@@ -71,7 +71,7 @@ flowchart LR
 
 ### Write flow
 
-For commands like `remember` and `update`, the server resolves project context, chooses the target vault, writes the note, attempts to refresh embeddings, commits the changed files, and then only auto-pushes when the main-vault `config.json` `mutationPushMode` allows it.
+For commands like `remember` and `update`, the server resolves project context, chooses the target vault, writes the note, refreshes embeddings when possible, commits the changed files, and auto-pushes only when `mutationPushMode` in the main-vault `config.json` allows it.
 
 ```mermaid
 sequenceDiagram
@@ -101,9 +101,9 @@ sequenceDiagram
 
 ### Recall flow
 
-Recall searches embeddings from the project vault first when `cwd` is present, then widens to the main vault. Current-project matches receive a bounded policy prior (+0.005); selection remains score-ordered so project affinity cannot hard-select over strong global retrieval.
+When `cwd` is present, recall searches the project vault first and then widens to the main vault. Current-project matches receive a bounded policy prior (+0.005). Results remain score-ordered, so project affinity cannot displace a strong global match.
 
-The ranking pipeline is bounded and fail-soft: semantic embeddings, an always-on lexical channel over compact projections, and semantic-conditioned graph expansion each produce channel ranks; RRF fuses those ranks, followed by bounded semantic-confidence, project, metadata, temporal, and canonical adjustments. Explicit high-confidence temporal windows still filter candidates before ranking. Lexical candidate generation reuses the existing session projection/token cache and TF-IDF machinery, without introducing a database or synced index.
+The ranking pipeline is bounded and fail-soft. Semantic embeddings, an always-on lexical channel over compact projections, and semantic-conditioned graph expansion each produce channel ranks. RRF fuses those ranks, then applies bounded semantic-confidence, project, metadata, temporal, and canonical adjustments. Explicit high-confidence temporal windows still filter candidates before ranking. Lexical candidate generation reuses the existing session projection/token cache and TF-IDF machinery, without introducing a database or synced index.
 
 ```mermaid
 flowchart TD
@@ -227,8 +227,8 @@ Document-source attachments extend the attachment system to support read-only re
 ### Entity namespaces
 
 Document and chunk identifiers use reserved namespaces that cannot collide with Memory IDs:
-- `doc:<documentId>` — references a document by its stable logical ID
-- `chunk:<chunkId>` — references a chunk by its stable logical ID
+- `doc:<documentId>`: references a document by its stable logical ID
+- `chunk:<chunkId>`: references a chunk by its stable logical ID
 
 The entity resolver in `src/document-entity-ref.ts` classifies references and routes them to the correct handler, preventing document-source entities from being treated as managed memories.
 
@@ -236,7 +236,7 @@ The entity resolver in `src/document-entity-ref.ts` classifies references and ro
 
 - **Markdown extractor** (`src/markdown-extractor.ts`): parses markdown using the existing MDAST stack, validates against `acceptedMediaTypes`, and returns extracted text content.
 - **Markdown chunker** (`src/markdown-chunker.ts`): splits extracted content into chunks with heading ancestry tracking. Produces an introduction chunk for content before the first heading, then one chunk per heading section. Oversized sections are split by paragraph with deterministic bounds.
-- **Extractor registry** (`src/document-extractor.ts`): dispatches source blobs to registered extractors by media type. The registry is extensible for future formats such as PDF.
+- **Extractor registry** (`src/document-extractor.ts`): dispatches source blobs to registered extractors by media type. The registry can support formats such as PDF in the future.
 
 ### Generation-based indexing
 
@@ -258,13 +258,13 @@ Document chunks participate in the recall ranking pipeline alongside memory resu
 
 ### Mutation rejection
 
-All mutation tools (`update`, `forget`, `move_memory`, `relate`, `unrelate`, `consolidate`) route inputs through the entity resolver before vault lookup. Document and chunk references are rejected with an `ImmutableDocumentSourceError`, ensuring document-source entities are never modified through Mnemonic.
+All mutation tools (`update`, `forget`, `move_memory`, `relate`, `unrelate`, `consolidate`) route inputs through the entity resolver before vault lookup. Document and chunk references are rejected with an `ImmutableDocumentSourceError`, so document-source entities cannot be modified through Mnemonic.
 
 ### Configuration
 
 Document-source attachments use a discriminated union in attachment configuration:
-- `kind: "mnemonic-vault"` — legacy writable vault attachments (default for existing configs)
-- `kind: "document-source"` — read-only document retrieval attachments
+- `kind: "mnemonic-vault"`: legacy writable vault attachments (default for existing configs)
+- `kind: "document-source"`: read-only document retrieval attachments
 
 Document-source attachments accept:
 - `root`: normalized repository-relative path (default `.`)
@@ -282,7 +282,7 @@ Every attachment now has a persisted opaque `attachmentId`, separate from reposi
 - CI-safe MCP integration tests use the real local entrypoint with `DISABLE_GIT=true`, a temp `VAULT_PATH`, and a fake `OLLAMA_URL` endpoint.
 - CI failure learnings are artifact-first and promoted manually into memory through MCP rather than auto-written on every failed run.
 
-## Future pressure points
+## Areas to watch
 
 - Recall latency as memory volume grows.
 - More sophisticated clustering or consolidation strategies.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -34,9 +34,11 @@
 
 ### MCP-first operations
 
-- `src/index.ts` registers the MCP tools and is the orchestration layer.
+- `src/index.ts` registers the MCP tools and is the orchestration layer. Uses `@modelcontextprotocol/server` v2 (MCP 2026-07-28 spec).
+- The server entry point uses `serveStdio()` from `@modelcontextprotocol/server/stdio` which auto-negotiates protocol era with clients.
 - Most user-visible behavior is exposed through tools like `remember`, `recall`, `update`, `forget`, `sync`, `consolidate`, and migration commands.
 - The local helper `scripts/mcp-local.sh` rebuilds and launches the current server for dogfooding and CI-safe integration tests.
+- `tools/list` responses carry cache hints (`ttlMs`, `cacheScope`) to reduce redundant tool catalog re-fetches by clients.
 
 ## Runtime topology
 
@@ -149,7 +151,8 @@ flowchart TD
 
 | Path                           | Responsibility                                                                                |
 | ------------------------------ | --------------------------------------------------------------------------------------------- |
-| `src/index.ts`                 | MCP server entry point, tool registration, orchestration, CLI migration command               |
+| `src/index.ts`                 | MCP server entry point, tool registration, orchestration, CLI migration command, cache hints for tools/list |
+| `src/startup.ts`               | Server startup via `serveStdio()` from `@modelcontextprotocol/server/stdio`, migration warnings            |
 | `src/storage.ts`               | Markdown note persistence, embedding JSON persistence, core types                             |
 | `src/vault.ts`                 | Main/project vault lifecycle, search order, vault routing                                     |
 | `src/project.ts`               | Stable project detection from git metadata                                                    |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `mnemonic` will be documented in this file.
 
 The format is loosely based on Keep a Changelog and uses semver-style version headings.
 
+## [Unreleased]
+
+### Changed
+
+- Migrated to `@modelcontextprotocol/server` v2.0.0 (MCP 2026-07-28 spec). The server now uses `serveStdio()` for era-negotiating stdio transport.
+- Removed the `tools/list` JSON Schema 2020-12 override — v2 SDK defaults to 2020-12 natively.
+- `tools/list` responses now carry cache hints (1-hour TTL) to reduce redundant re-fetches.
+
 ## [0.38.0] - 2026-07-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `mnemonic` will be documented in this file.
 
 The format is loosely based on Keep a Changelog and uses semver-style version headings.
 
-## [Unreleased]
+## [0.39.0] - 2026-08-01
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 
 ## [Unreleased]
 
+### Added
+
+- Protected-branch commits now ask for one-time confirmation through the client UI on supported clients (`remember`, `update`, `forget`, `relate`, `unrelate`, `consolidate`, `move_memory`); other clients keep the previous error message.
+- `remember` asks through the client UI where to store a memory (project vs global) when no scope is configured.
+- `remember` can store memories in writable attached vaults, asking which vault to use when several write targets exist.
+
 ### Changed
 
 - Migrated to `@modelcontextprotocol/server` v2.0.0 (MCP 2026-07-28 spec). The server now uses `serveStdio()` for era-negotiating stdio transport.

--- a/README.md
+++ b/README.md
@@ -6,27 +6,27 @@ For the high-level system map, see [`ARCHITECTURE.md`](ARCHITECTURE.md). For rel
 
 ## Why mnemonic
 
-- 🧠 Your MCP client remembers decisions, fixes, and context across sessions — no re-explaining the same project.
-- 📁 Memories are plain markdown with YAML frontmatter: readable, diffable, mergeable, and easy to back up.
-- 🚫 No database or always-on service: just files, git, and a local Node process.
-- 🎯 Project-scoped recall favors the right repo context while keeping stronger global matches accessible.
-- 🔎 Hybrid recall finds conceptual matches plus exact names, identifiers, phrases, error codes, and versions.
-- 🤝 Shared `.mnemonic/` notes travel with the repository, so project knowledge isn't trapped in one person's chat history.
-- 📚 Document-source attachments let you link external repos as read-only knowledge sources — their markdown docs are indexed and searchable through recall alongside your memories.
-- 🔒 Embeddings stay local and gitignored — semantic retrieval without committing generated vector data.
-- 📝 Every `remember`, `update`, and `consolidate` creates a semantic git commit — decision log and plans travel with the code in the same history.
-- 🔓 Designed for removability — though we're quietly confident you won't use that exit. Every note is plain markdown with YAML frontmatter; the knowledge you gather is independent of mnemonic and always yours.
+- Your MCP client can carry decisions, fixes, and context across sessions, so you do not have to re-explain the same project.
+- Memories are plain markdown with YAML frontmatter. They are readable, diffable, mergeable, and easy to back up.
+- No database or always-on service is required. mnemonic uses files, git, and a local Node process.
+- Project-scoped recall favors the right repo context while keeping stronger global matches accessible.
+- Hybrid recall finds conceptual matches as well as exact names, identifiers, phrases, error codes, and versions.
+- Shared `.mnemonic/` notes travel with the repository, so project knowledge is not trapped in one person's chat history.
+- Document-source attachments let you link external repos as read-only knowledge sources. Their markdown docs are indexed and searchable through recall alongside your memories.
+- Embeddings stay local and gitignored. You get semantic retrieval without committing generated vector data.
+- Every `remember`, `update`, and `consolidate` creates a semantic git commit. Your decision log and plans travel with the code in the same history.
+- If you stop using mnemonic, your notes remain plain markdown with YAML frontmatter. The knowledge you gather stays independent and remains yours.
 
 ## Stability
 
 The storage format is stable with migration support for any future changes. Keep an eye on the changelog; `list_migrations` shows pending work per vault after each update.
 
-**Scale:** Designed for simplicity and portability — not large-scale knowledge bases.
+**Scale:** mnemonic favors simplicity and portability over large-scale knowledge bases.
 
-- Hundreds to low thousands of notes: excellent fit.
+- Hundreds to low thousands of notes: a good fit.
 - Several thousand: often fine, depending on note size, machine speed, and embedding throughput.
-- Within a session, notes and embeddings are cached after first access — repeated `recall`, `get`, and `project_memory_summary` calls skip storage reads regardless of vault size.
-- Very large collections: expect pain points around reindex time, recall latency, and git churn.
+- Within a session, notes and embeddings are cached after first access. Repeated `recall`, `get`, and `project_memory_summary` calls skip storage reads regardless of vault size.
+- Very large collections: expect longer reindexing, higher recall latency, and more git churn.
 - Many concurrent writers or massive scale: consider a dedicated database and indexing layer instead.
 
 ## Prerequisites
@@ -43,7 +43,7 @@ ollama pull nomic-embed-text-v2-moe
 ollama pull qwen3-embedding:0.6b
 ```
 
-No code changes required — set `EMBED_MODEL=qwen3-embedding:0.6b` in your environment or MCP config.
+To use it, set `EMBED_MODEL=qwen3-embedding:0.6b` in your environment or MCP config.
 
 Advanced users can use OpenAI-compatible endpoints, native OpenAI, or Gemini instead. Provider settings are environment-only; mnemonic never writes API keys to notes, embedding files, vault config, or git.
 
@@ -293,19 +293,19 @@ Privacy note: Ollama keeps projection text local. OpenAI-compatible cloud proxie
 
 ### config.json
 
-The main vault's `~/mnemonic-vault/config.json` holds machine-local settings that survive across sessions. You can edit it by hand — unknown fields are ignored and invalid values fall back to defaults.
+The main vault's `~/mnemonic-vault/config.json` holds machine-local settings that survive across sessions. You can edit it by hand. Unknown fields are ignored, and invalid values fall back to defaults.
 
 User-tunable fields:
 
 | Field                     | Default       | Description                                                          |
 | ------------------------- | ------------- | -------------------------------------------------------------------- |
-| `reindexEmbedConcurrency` | `4`           | Parallel embedding requests during `sync` (capped 1–16)              |
+| `reindexEmbedConcurrency` | `4`           | Parallel embedding requests during `sync` (capped from 1 to 16)     |
 | `mutationPushMode`        | `"main-only"` | When to auto-push after a write: `"all"`, `"main-only"`, or `"none"` |
 
-`projectMemoryPolicies` and `projectIdentityOverrides` are written automatically by `set_project_memory_policy` and `set_project_identity` — no need to edit them by hand.
+`projectMemoryPolicies` and `projectIdentityOverrides` are written automatically by `set_project_memory_policy` and `set_project_identity`. You do not need to edit them by hand.
 Project memory policies can include protected-branch settings (`protectedBranchBehavior`, `protectedBranchPatterns`) used by mutating tools when they commit to project vaults (`remember`, `update`, `forget`, `move_memory`, and mutating `consolidate` strategies).
 
-Example — raise concurrency on a fast machine and disable auto-push everywhere:
+For example, raise concurrency on a fast machine and disable auto-push everywhere:
 
 ```json
 {
@@ -320,7 +320,7 @@ Example — raise concurrency on a fast machine and disable auto-push everywhere
 
 Two vault types store notes:
 
-**Main vault** — private global memories at `~/mnemonic-vault` (its own git repo):
+**Main vault:** private global memories at `~/mnemonic-vault` (its own git repo):
 
 ```
 ~/mnemonic-vault/
@@ -333,7 +333,7 @@ Two vault types store notes:
     setup-notes-a1b2c3.json
 ```
 
-**Project vault** — project-specific memories committed into the project repo:
+**Project vault:** project-specific memories committed into the project repo:
 
 ```
 <git-root>/
@@ -362,7 +362,7 @@ Use `set_project_memory_policy` to save per-project defaults:
 - protected-branch behavior for project-vault writes (`ask`, `block`, `allow`)
 - protected-branch patterns (glob strings; defaults are `main`, `master`, `release*`)
 
-When write scope policy is `ask`, `remember` returns a clear storage choice instead of guessing — on supported MCP clients it asks project vs global through the client UI. When protected-branch behavior is `ask`, mutating tools that would commit to the project vault ask for one-time confirmation through the client UI (or return the `allowProtectedBranch: true` override option plus instructions to persist `block`/`allow` on clients without support).
+When write scope policy is `ask`, `remember` returns a clear storage choice instead of guessing. On supported MCP clients, it asks you to choose project or global storage through the client UI. When protected-branch behavior is `ask`, mutating tools that would commit to the project vault ask for one-time confirmation through the client UI. Clients without that support return the `allowProtectedBranch: true` override option and instructions for persisting `block` or `allow`.
 
 ### Project identity
 
@@ -370,14 +370,14 @@ Project identity derives from the **git remote URL**, normalized to a stable slu
 
 ### Recall
 
-`recall` with `cwd` searches both vaults. Project notes get a **small tiebreaker boost** — a soft signal, not a hard filter — so global memories remain accessible while project context floats to the top.
+`recall` with `cwd` searches both vaults. Project notes get a **small tiebreaker boost**. It is a soft signal, not a hard filter, so global memories remain accessible while project context floats to the top.
 
 Every result carries structured quality signals to help agents decide what to trust:
 
-- **`signalStrength`** — a composite score (0.00-0.50) from role, graph centrality, lifecycle, and recency. Higher values mean more structural support behind the note.
-- **`confidence`** — high/medium/low tier derived from `signalStrength`, replacing a single coarse heuristic.
-- **`diversity`** — theme count, role mix, and lifecycle mix across selected results.
-- **`retrievalCoverage`** — fraction of high-priority anchors (alwaysLoad and summary notes) represented in results.
+- **`signalStrength`:** a composite score (0.00-0.50) from role, graph centrality, lifecycle, and recency. Higher values mean more structural support behind the note.
+- **`confidence`:** a high, medium, or low tier derived from `signalStrength`, replacing a single coarse heuristic.
+- **`diversity`:** the theme count, role mix, and lifecycle mix across selected results.
+- **`retrievalCoverage`:** the fraction of high-priority anchors (alwaysLoad and summary notes) represented in results.
 
 **Hybrid recall** combines semantic similarity, exact wording, and relationship context on every query. It can now find exact names, identifiers, phrases, error codes, and version strings even when they are not semantically similar, while still favoring conceptually relevant and well-connected notes. The ranking remains bounded and fail-soft, uses compact projections without new infrastructure, and preserves canonical explanation promotion and temporal recency hints.
 
@@ -401,28 +401,28 @@ Recall evidence:
 
 **How it works:**
 
-mnemonic interprets change semantically using structural and statistical signals (size ratios, heading changes, section movements) rather than language-dependent analysis. Raw diffs are intentionally NOT part of default temporal output—you get interpretive summaries that explain what kind of change happened, not patch noise.
+mnemonic interprets change semantically using structural and statistical signals (size ratios, heading changes, and section movements) rather than language-dependent analysis. Raw diffs are intentionally NOT part of default temporal output. You get interpretive summaries that explain what kind of change happened, not patch noise.
 
 Use `verbose: true` together with temporal mode when you want richer change stats such as additions, deletions, files changed, and change classification. Those stats describe the whole commit that touched the note, not a raw diff excerpt, so recall stays bounded and does not return full diffs.
 
 The `scope` parameter on `recall` narrows results:
 
-- `"all"` _(default)_ — project memories boosted, then global
-- `"project"` — only memories for the detected project
-- `"global"` — only memories with no project association
+- `"all"` (default): project memories boosted, then global
+- `"project"`: only memories for the detected project
+- `"global"`: only memories with no project association
 
 ### Note lifecycle
 
 Each note carries a `lifecycle`:
 
-- `"permanent"` _(default)_ — durable knowledge for future sessions
-- `"temporary"` — working-state scaffolding (plans, WIP checkpoints) that can be cleaned up once consolidated
+- `"permanent"` (default): durable knowledge for future sessions
+- `"temporary"`: working-state scaffolding (plans, WIP checkpoints) that can be cleaned up once consolidated
 
 Store what should help future work: decisions, outcomes, corrections, constraints, and lessons learned. Leave routine chatter out. Cleanup stays explicit through lifecycle and consolidation choices; mnemonic does not auto-expire notes.
 
 ### Roles and lifecycle
 
-Roles are optional prioritization hints, not required schema. mnemonic infers a `role` and `importance` from structural signals (heading count, bullet density, inbound references, relationship types) — inference is language-independent and never overwrites explicit frontmatter. Valid roles: `summary`, `decision`, `plan`, `context`, `reference`, `research`, `review`. Valid importance values: `high`, `normal`, `low`.
+Roles are optional prioritization hints, not required schema. mnemonic infers a `role` and `importance` from structural signals (heading count, bullet density, inbound references, and relationship types). Inference is language-independent and never overwrites explicit frontmatter. Valid roles: `summary`, `decision`, `plan`, `context`, `reference`, `research`, `review`. Valid importance values: `high`, `normal`, `low`.
 
 Set `alwaysLoad: true` in a note's frontmatter to mark it as an explicit session anchor; it receives the highest recall and relationship-expansion priority regardless of inferred role.
 
@@ -465,12 +465,12 @@ Embedding records include non-secret compatibility metadata so mnemonic can avoi
 
 **Projections** improve embedding quality by extracting structured representations instead of embedding raw markdown. Each note has a projection stored in `projections/<noteId>.json` (also gitignored) containing:
 
-- `projectionText`: compact embedding input (max 1200 chars) with title, lifecycle, tags, summary, and h1–h3 headings
+- `projectionText`: compact embedding input (max 1200 chars) with title, lifecycle, tags, summary, and h1 through h3 headings
 - `summary`: extracted from the first non-heading paragraph, first bullet list, or first 200 chars of body
-- `headings`: up to 8 deduplicated h1–h3 headings (plain text, in order)
+- `headings`: up to 8 deduplicated h1 through h3 headings (plain text, in order)
 - `updatedAt`: staleness anchor matching the note's updatedAt timestamp
 
-Projections are built lazily on first embed and rebuilt when `note.updatedAt !== projection.updatedAt`. No global rebuild needed — staleness is timestamp-based. If projection generation fails, the system falls back to raw `title + content` so embeds never block.
+Projections are built lazily on first embed and rebuilt when `note.updatedAt !== projection.updatedAt`. No global rebuild is needed because staleness is timestamp-based. If projection generation fails, the system falls back to raw `title + content`, so embeds never block.
 
 ### Migrations
 
@@ -577,9 +577,9 @@ Imported notes are written to the main vault with `lifecycle: permanent` and `sc
 
 `project_memory_summary` categorizes notes by theme. Themes **emerge automatically** from your notes:
 
-- **Tag-based classification** — notes with matching tags (e.g., `["decisions"]`, `["bugs"]`) are grouped immediately
-- **Keyword graduation** — keywords that appear across multiple notes become named themes over time
-- **"other" bucket** — notes that don't match any theme are grouped here; this shrinks as themes emerge
+- **Tag-based classification:** notes with matching tags (for example, `["decisions"]` or `["bugs"]`) are grouped immediately.
+- **Keyword graduation:** keywords that appear across multiple notes become named themes over time.
+- **"other" bucket:** notes that do not match a theme are grouped here. This bucket shrinks as themes emerge.
 
 No predefined schema required. The system adapts to your project's vocabulary.
 
@@ -617,7 +617,7 @@ Multi-repo attachment support lets you link external repositories as **federated
 Key concepts:
 
 - `add_attachment` links a repo by its absolute `localPath` (supports `~` expansion); optional `branch`, `vaultFolder`, `writable`, and `pushBranch` select branch, sub-vault, write access, and push target. Use `kind: "document-source"` to index markdown files as read-only document retrieval sources.
-- **Document-source attachments**: when `kind: "document-source"`, the attachment indexes markdown files from a pinned git revision. Documents are extracted, heading-aware chunked, and made searchable through recall; `get` resolves `doc:` and `chunk:` handles for exact content. Mutation tools reject document-source entities — the source repository is never written to. Configuration accepts `root` (default `.`), `include` (default `["**/*.md"]`), `exclude` (defaults to generated/vendor paths), and `acceptedMediaTypes` (default `["text/markdown"]`); see [Configuring attachments](#configuring-attachments) for worked examples.
+- **Document-source attachments:** when `kind: "document-source"`, the attachment indexes markdown files from a pinned git revision. Documents are extracted, split by heading, and made searchable through recall. `get` resolves `doc:` and `chunk:` handles for exact content. Mutation tools reject document-source entities, so the source repository is never written to. Configuration accepts `root` (default `.`), `include` (default `["**/*.md"]`), `exclude` (defaults to generated/vendor paths), and `acceptedMediaTypes` (default `["text/markdown"]`). See [Configuring attachments](#configuring-attachments) for worked examples.
 - `remove_attachment` removes by `projectSlug`; `list_attachments` shows all attachments with status.
 - `set_attachment_enabled` toggles an attachment on/off without removing config; `set_attachment_branch` changes the branch.
 - Max 5 attachments per project (configurable via `maxAttachmentsPerProject` in project memory policy).
@@ -632,7 +632,7 @@ Key concepts:
 
 Attachments are configured through the `add_attachment` tool, which writes the config and activates the attachment. `cwd` and `localPath` are required; everything else is optional. Fields that do not apply to the chosen `kind` are ignored.
 
-**Document-source** — index an external repository's markdown as read-only, searchable content:
+**Document-source:** index an external repository's markdown as read-only, searchable content:
 
 ```json
 {
@@ -653,9 +653,9 @@ Attachments are configured through the `add_attachment` tool, which writes the c
 | `exclude`            | `["node_modules", ".git", "dist", "build", ".next", ".cache", "coverage"]` | Glob patterns relative to `root` to skip; defaults cover generated/vendor paths |
 | `acceptedMediaTypes` | `["text/markdown"]`                                                 | Canonical lower-case IANA base media types accepted as indexable sources        |
 
-Only tracked Git blobs at the pinned revision are indexed — symlinks, submodules, and untracked working-tree files are skipped. Matching is case-sensitive on Git tree paths: `**` crosses directories, `*` matches within a segment, and a bare name like `node_modules` matches any segment.
+Only tracked Git blobs at the pinned revision are indexed. Symlinks, submodules, and untracked working-tree files are skipped. Matching is case-sensitive on Git tree paths: `**` crosses directories, `*` matches within a segment, and a bare name like `node_modules` matches any segment.
 
-**Mnemonic-vault** — attach another repository's notes as a federated vault, optionally writable:
+**Mnemonic-vault:** attach another repository's notes as a federated vault, optionally writable:
 
 ```json
 {
@@ -708,11 +708,11 @@ After the first sync, call the `sync` MCP tool (with `cwd` for project vaults) w
 
 Easier search is part of it, but three things work together:
 
-- **Semantic search over vector embeddings.** Each note is indexed through your configured embedding provider so `recall` finds the right note even when you don't remember the exact words — searching "JWT expiry bug" can surface a note titled "RS256 migration rationale". `grep` only matches strings you already know.
+- **Semantic search over vector embeddings.** Each note is indexed through your configured embedding provider, so `recall` can find the right note even when you do not remember the exact words. For example, searching "JWT expiry bug" can surface a note titled "RS256 migration rationale". `grep` only matches strings you already know.
 - **A connected knowledge graph.** Notes link to each other with typed relationships (`explains`, `supersedes`, `example-of`). Related context surfaces together automatically; `memory_graph` shows the full web. A folder of markdown files has no edges between them.
-- **Decision history travels with the code.** Every `remember`, `update`, and `consolidate` creates a descriptive git commit, so your decision log and implementation plans evolve alongside the code they describe — attributed and timestamped in `git log`.
+- **Decision history travels with the code.** Every `remember`, `update`, and `consolidate` creates a descriptive git commit. Your decision log and implementation plans evolve alongside the code they describe, with attribution and timestamps in `git log`.
 
-mnemonic is designed to be removable — so give it a try with confidence. We think once you do, you'll stay. But if you ever leave, all the knowledge you've gathered is independent: plain markdown with standard YAML frontmatter, readable in any editor, searchable with `grep`, committable to git. No rescue operation required.
+mnemonic is designed to be removable. If you stop using it, your notes remain plain markdown with standard YAML frontmatter. You can read them in any editor, search them with `grep`, and commit them to git.
 
 **Are mnemonic's embeddings the same as what Claude uses?**
 
@@ -747,11 +747,11 @@ This keeps early ideation reusable as personal/global knowledge while moving con
 
 **How does mnemonic differ from Beads?**
 
-mnemonic and Beads address complementary concerns. mnemonic is a **knowledge graph**: it stores notes, relationships between them, and lets agents retrieve relevant context through semantic search. [Beads](https://github.com/steveyegge/beads) is a **task and dependency tracker**: it models work items and their dependencies so agents can determine what is ready to execute next. Both tools can coexist in the same workflow — mnemonic stores knowledge and reasoning while Beads manages execution.
+mnemonic and Beads address complementary concerns. mnemonic is a **knowledge graph**: it stores notes, relationships between them, and lets agents retrieve relevant context through semantic search. [Beads](https://github.com/steveyegge/beads) is a **task and dependency tracker**: it models work items and their dependencies so agents can determine what is ready to execute next. Both tools can coexist in the same workflow. mnemonic stores knowledge and reasoning while Beads manages execution.
 
 **How does mnemonic differ from Memory Bank MCP?**
 
-mnemonic and Memory Bank MCP both provide persistent memory for agents, but differ in hosting and scope. Memory Bank MCP is a **centralized service** — your memory lives in a remote MCP service and is accessed across projects through that single endpoint. mnemonic is **local-first** — your memories live as plain markdown files on your machine: project-scoped notes in `.mnemonic/` within each repo, and personal notes in a global vault under your home directory. There is no always-on server to configure or depend on; the MCP server spawns on demand per session.
+mnemonic and Memory Bank MCP both provide persistent memory for agents, but differ in hosting and scope. Memory Bank MCP is a **centralized service**. Your memory lives in a remote MCP service and is accessed across projects through that endpoint. mnemonic is **local-first**. Your memories live as plain markdown files on your machine: project-scoped notes in `.mnemonic/` within each repo, and personal notes in a global vault under your home directory. There is no always-on server to configure or depend on. The MCP server spawns on demand per session.
 
 **How does mnemonic differ from Basic Memory?**
 

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ Use `set_project_memory_policy` to save per-project defaults:
 - protected-branch behavior for project-vault writes (`ask`, `block`, `allow`)
 - protected-branch patterns (glob strings; defaults are `main`, `master`, `release*`)
 
-When write scope policy is `ask`, `remember` returns a clear storage choice instead of guessing. When protected-branch behavior is `ask`, mutating tools that would commit to the project vault return a one-time override option (`allowProtectedBranch: true`) plus instructions to persist `block`/`allow`.
+When write scope policy is `ask`, `remember` returns a clear storage choice instead of guessing — on supported MCP clients it asks project vs global through the client UI. When protected-branch behavior is `ask`, mutating tools that would commit to the project vault ask for one-time confirmation through the client UI (or return the `allowProtectedBranch: true` override option plus instructions to persist `block`/`allow` on clients without support).
 
 ### Project identity
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>mnemonic — AI memory that lives in your repo</title>
+  <title>mnemonic: AI memory that lives in your repo</title>
   <meta name="description" content="A local MCP memory server backed by plain markdown, synced via git. Project-scoped hybrid recall finds concepts, exact identifiers, and connected context. No database required." />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -1166,7 +1166,7 @@
 
     <h1>
       Your AI assistant<br />
-      <span class="brand">remembers</span>, project by project.
+      <span class="brand">remembers</span> your projects.
     </h1>
 
     <p class="hero-sub">
@@ -1241,13 +1241,13 @@
   <div class="container">
     <div class="section-label">Why mnemonic</div>
     <h2 class="section-title">Stop re-explaining your codebase.</h2>
-    <p class="section-desc">Your AI assistant forgets everything between sessions. mnemonic fixes that — without a database or a SaaS subscription.</p>
+    <p class="section-desc">Your AI assistant forgets everything between sessions. mnemonic carries that context forward without a database or SaaS subscription.</p>
 
     <div class="features-grid">
       <div class="feature-card fade-up">
         <span class="feature-icon">&#x1F4C4;</span>
         <h3>Plain markdown, always</h3>
-        <p>Every memory is a markdown file with YAML frontmatter — designed for removability from day one. Give it a try; we think you'll like it enough to stay. And if you ever do leave, all the knowledge you've gathered is yours: plain markdown, independent of mnemonic, no strings attached.</p>
+        <p>Every memory is a markdown file with YAML frontmatter. If you stop using mnemonic, you can still read, search, and commit those notes because they remain independent of the tool.</p>
       </div>
       <div class="feature-card fade-up">
         <span class="feature-icon">&#x1F3AF;</span>
@@ -1257,7 +1257,7 @@
       <div class="feature-card fade-up">
         <span class="feature-icon">&#x1F33F;</span>
         <h3>Git is the database</h3>
-        <p>No Postgres to babysit. Every <code style="font-family:JetBrains Mono,monospace;font-size:0.8em;color:var(--primary-lt)">remember</code>, <code style="font-family:JetBrains Mono,monospace;font-size:0.8em;color:var(--primary-lt)">update</code>, and <code style="font-family:JetBrains Mono,monospace;font-size:0.8em;color:var(--primary-lt)">consolidate</code> creates a semantic git commit — your decision log and implementation plans travel with the code in the same history. Pushes are controlled so project-vault writes do not fail on unpublished branches by default. History is inspectable, conflicts are isolated to individual files, and sync works across machines.</p>
+        <p>No Postgres to babysit. Every <code style="font-family:JetBrains Mono,monospace;font-size:0.8em;color:var(--primary-lt)">remember</code>, <code style="font-family:JetBrains Mono,monospace;font-size:0.8em;color:var(--primary-lt)">update</code>, and <code style="font-family:JetBrains Mono,monospace;font-size:0.8em;color:var(--primary-lt)">consolidate</code> creates a semantic git commit. Your decision log and implementation plans travel with the code in the same history. Pushes are controlled so project-vault writes do not fail on unpublished branches by default. History is inspectable, conflicts are isolated to individual files, and sync works across machines.</p>
       </div>
       <div class="feature-card fade-up">
         <span class="feature-icon">&#x1F50D;</span>
@@ -1282,17 +1282,17 @@
       <div class="feature-card fade-up">
         <span class="feature-icon">&#x1F4CC;</span>
         <h3>Notes surface smarter over time</h3>
-        <p>Mark notes <code style="font-family:JetBrains Mono,monospace;font-size:0.8em;color:var(--cyan-lt)">temporary</code> for plans and WIP, <code style="font-family:JetBrains Mono,monospace;font-size:0.8em;color:var(--cyan-lt)">permanent</code> for decisions worth keeping. Capture what future work will need — decisions, outcomes, corrections, and constraints — and leave routine chatter out. Pin any note as a session anchor to always bring it to the top.</p>
+        <p>Mark notes <code style="font-family:JetBrains Mono,monospace;font-size:0.8em;color:var(--cyan-lt)">temporary</code> for plans and WIP, and <code style="font-family:JetBrains Mono,monospace;font-size:0.8em;color:var(--cyan-lt)">permanent</code> for decisions worth keeping. Capture what future work will need: decisions, outcomes, corrections, and constraints. Leave routine chatter out. Pin any note as a session anchor to always bring it to the top.</p>
       </div>
       <div class="feature-card fade-up">
         <span class="feature-icon">&#x1F4DC;</span>
         <h3>Understand how decisions evolved</h3>
-        <p>Opt-in temporal mode adds compact git-backed history to <code style="font-family:JetBrains Mono,monospace;font-size:0.8em;color:var(--primary-lt)">recall</code> results. Each change is described in plain language — "Expanded the note with additional detail", "Connected this note to related work" — and the overall arc is summarised: "The core decision remained stable while rationale expanded." See how a decision formed without wading through raw diffs.</p>
+        <p>Opt-in temporal mode adds compact git-backed history to <code style="font-family:JetBrains Mono,monospace;font-size:0.8em;color:var(--primary-lt)">recall</code> results. Each change is described in plain language, such as "Expanded the note with additional detail" or "Connected this note to related work". The overall arc is summarised too: "The core decision remained stable while rationale expanded." See how a decision formed without wading through raw diffs.</p>
       </div>
       <div class="feature-card fade-up">
         <span class="feature-icon">&#x1F4CA;</span>
         <h3>Agents know what to trust</h3>
-        <p>Every <code style="font-family:JetBrains Mono,monospace;font-size:0.8em;color:var(--primary-lt)">recall</code> result carries structured quality signals: <code style="font-family:JetBrains Mono,monospace;font-size:0.8em;color:var(--cyan-lt)">signalStrength</code> rates each note on role, centrality, and recency; <code style="font-family:JetBrains Mono,monospace;font-size:0.8em;color:var(--cyan-lt)">retrievalCoverage</code> shows how many of your most important notes made it in; <code style="font-family:JetBrains Mono,monospace;font-size:0.8em;color:var(--cyan-lt)">diversity</code> reveals how many perspectives the result set spans. Agents don't just see ranked notes — they see why each note is worth paying attention to.</p>
+        <p>Every <code style="font-family:JetBrains Mono,monospace;font-size:0.8em;color:var(--primary-lt)">recall</code> result carries structured quality signals: <code style="font-family:JetBrains Mono,monospace;font-size:0.8em;color:var(--cyan-lt)">signalStrength</code> rates each note on role, centrality, and recency; <code style="font-family:JetBrains Mono,monospace;font-size:0.8em;color:var(--cyan-lt)">retrievalCoverage</code> shows how many of your most important notes made it in; <code style="font-family:JetBrains Mono,monospace;font-size:0.8em;color:var(--cyan-lt)">diversity</code> reveals how many perspectives the result set spans. Agents see ranked notes and the signals behind each result.
       </div>
       <div class="feature-card fade-up">
         <span class="feature-icon">&#x1F517;</span>
@@ -1417,7 +1417,7 @@
         <div class="vault-card-header">
           <div class="vault-pill main">main vault</div>
         </div>
-        <p>Private global memories stored in <code style="font-family:JetBrains Mono,monospace;font-size:0.8em;color:var(--primary-lt)">~/mnemonic-vault</code> — its own git repo. Cross-project knowledge, user preferences, early brainstorming before a repo exists, and anything you don't want committed to a project repo.</p>
+        <p>Private global memories stored in <code style="font-family:JetBrains Mono,monospace;font-size:0.8em;color:var(--primary-lt)">~/mnemonic-vault</code>, its own git repo. Use it for cross-project knowledge, user preferences, early brainstorming before a repo exists, and anything you do not want committed to a project repo.</p>
         <div class="file-tree">
 <span class="dir">~/mnemonic-vault/</span>
 <span class="file">  .gitignore</span>
@@ -1535,8 +1535,8 @@
   </svg>
   <div class="container">
     <div class="section-label">MCP tools</div>
-    <h2 class="section-title">Everything you need, nothing you don't.</h2>
-    <p class="section-desc">All tools are text-first and optimized for LLM consumption — compact, semantically explicit, no unnecessary structure. On protected branches, write actions pause and ask before committing unless you choose a different policy.</p>
+    <h2 class="section-title">Tools for capture, recall, and maintenance.</h2>
+    <p class="section-desc">All tools are text-first and optimized for LLM consumption. They stay compact and semantically explicit without unnecessary structure. On protected branches, write actions pause and ask before committing unless you choose a different policy.</p>
 
     <div class="tools-categories">
 
@@ -1544,31 +1544,31 @@
       <div>
         <div class="tool-category-header">Capture &amp; Retrieve</div>
         <div class="tool-category-grid">
-          <div class="tool-card" data-tip="Tell the AI what to remember — a decision, a pattern, a gotcha. Stores it in your project or personal vault and links it to the current context.">
+          <div class="tool-card" data-tip="Tell the AI what to remember: a decision, a pattern, or a gotcha. Stores it in your project or personal vault and links it to the current context.">
             <div class="tool-card-name">remember</div>
             <div class="tool-card-purpose">Save something worth keeping</div>
           </div>
-          <div class="tool-card" data-tip="Finds the most relevant notes for any question. Automatically surfaces project-specific memories first, then broader personal context. Each result carries signalStrength, confidence, and diversity metrics so agents can gauge what to trust. Temporal mode shows how a note changed over time, and optional recall evidence gives a short plain-language reason for why each result appeared. Document-source attachments contribute documentChunks alongside memory results.">
+          <div class="tool-card" data-tip="Finds the most relevant notes for any question. It surfaces project-specific memories first, then broader personal context. Each result carries signalStrength, confidence, and diversity metrics so agents can gauge what to trust. Temporal mode shows how a note changed over time, and optional recall evidence gives a short plain-language reason for each result. Document-source attachments contribute documentChunks alongside memory results.">
             <div class="tool-card-name">recall</div>
             <div class="tool-card-purpose">Ask what you've previously learned - or how it evolved</div>
           </div>
-          <div class="tool-card" data-tip="Edit an existing note's content, title, or tags. Keeps your memory base tidy instead of letting outdated notes pile up alongside fresh ones.">
+          <div class="tool-card" data-tip="Edit an existing note's content, title, or tags. Keep your memory base current instead of letting outdated notes pile up alongside fresh ones.">
             <div class="tool-card-name">update</div>
             <div class="tool-card-purpose">Correct or expand a memory</div>
           </div>
-          <div class="tool-card" data-tip="Permanently deletes a note and tidies up any connections to it. Can't be undone — but nothing important is ever truly lost if it was worth remembering.">
+          <div class="tool-card" data-tip="Permanently deletes a note and removes its connections. This cannot be undone, so use it for notes you no longer need.">
             <div class="tool-card-name">forget</div>
             <div class="tool-card-purpose">Remove something no longer useful</div>
           </div>
-          <div class="tool-card" data-tip="Retrieve a note directly by its ID — useful when you already know exactly which note you need, no searching required. Also resolves doc: and chunk: handles for exact document content from indexed document-source attachments.">
+          <div class="tool-card" data-tip="Retrieve a note directly by its ID when you already know which note you need. It also resolves doc: and chunk: handles for exact document content from indexed document-source attachments.">
             <div class="tool-card-name">get</div>
             <div class="tool-card-purpose">Pull up a specific note</div>
           </div>
-          <div class="tool-card" data-tip="Browse what's stored — filter by project, tag, or location. Great for a quick inventory before starting work on something familiar.">
+          <div class="tool-card" data-tip="Browse what's stored. Filter by project, tag, or location to take inventory before starting work.">
             <div class="tool-card-name">list</div>
             <div class="tool-card-purpose">See all memories for a project or tag</div>
           </div>
-          <div class="tool-card" data-tip="Shows the most recently touched notes. Handy at the start of a session to restore context without needing to remember what you were doing.">
+          <div class="tool-card" data-tip="Shows the most recently touched notes. Use it at the start of a session to restore context without remembering what you were doing.">
             <div class="tool-card-name">recent_memories</div>
             <div class="tool-card-purpose">Pick up where you left off</div>
           </div>
@@ -1583,7 +1583,7 @@
       <div>
         <div class="tool-category-header">Knowledge Graph</div>
         <div class="tool-category-grid">
-          <div class="tool-card" data-tip="Mark how two notes relate — one explains another, one is an example of another, or one supersedes another. Builds a navigable web of knowledge over time.">
+          <div class="tool-card" data-tip="Mark how two notes relate: one may explain another, provide an example, or supersede it. The relationships form a navigable knowledge graph.">
             <div class="tool-card-name">relate</div>
             <div class="tool-card-purpose">Connect two memories</div>
           </div>
@@ -1606,15 +1606,15 @@
       <div>
         <div class="tool-category-header">Project Context</div>
         <div class="tool-category-grid">
-          <div class="tool-card" data-tip="Uses the git remote URL to give every project a stable identity — the same across your laptop, a colleague's machine, and CI.">
+          <div class="tool-card" data-tip="Uses the git remote URL to give every project a stable identity across your laptop, a colleague's machine, and CI.">
             <div class="tool-card-name">detect_project</div>
             <div class="tool-card-purpose">Check which project this folder belongs to</div>
           </div>
-          <div class="tool-card" data-tip="Get a quick orientation: themes, anchor notes, maintenance warnings for stale temporaries or superseded cleanup, and explicit guidance on which notes to read first — perfect for starting a session.">
+          <div class="tool-card" data-tip="Get a quick orientation with themes, anchor notes, maintenance warnings, and guidance on which notes to read first.">
             <div class="tool-card-name">project_memory_summary</div>
             <div class="tool-card-purpose">What does mnemonic know about this project?</div>
           </div>
-          <div class="tool-card" data-tip="Tells you whether a note lives in your personal vault or alongside the project's code — and exactly where on disk.">
+          <div class="tool-card" data-tip="Tells you whether a note lives in your personal vault or alongside the project's code, and shows exactly where it is on disk.">
             <div class="tool-card-name">where_is_memory</div>
             <div class="tool-card-purpose">Find where a specific note lives</div>
           </div>
@@ -1622,7 +1622,7 @@
             <div class="tool-card-name">move_memory</div>
             <div class="tool-card-purpose">Move a note from personal to project (or back)</div>
           </div>
-          <div class="tool-card" data-tip="Shows which git remote is used to identify the project, and whether you've overridden it — for example, to point at an upstream fork instead of your copy.">
+          <div class="tool-card" data-tip="Shows which git remote identifies the project and whether you have overridden it, for example to point at an upstream fork instead of your copy.">
             <div class="tool-card-name">get_project_identity</div>
             <div class="tool-card-purpose">See this project's identity</div>
           </div>
@@ -1961,17 +1961,17 @@ VAULT_PATH = <span class="str">"/Users/you/mnemonic-vault"</span></pre>
           <tr>
             <td><code>reindexEmbedConcurrency</code></td>
             <td class="default">4</td>
-            <td>Parallel embedding requests during <code>sync</code> (capped 1–16)</td>
+            <td>Parallel embedding requests during <code>sync</code> (capped from 1 to 16)</td>
           </tr>
           <tr>
             <td><code>mutationPushMode</code></td>
             <td class="default">main-only</td>
-            <td><code>all</code>, <code>main-only</code>, or <code>none</code> — controls when writes auto-push to git</td>
+            <td><code>all</code>, <code>main-only</code>, or <code>none</code>. Controls when writes auto-push to git.</td>
           </tr>
         </tbody>
       </table>
     </div>
-    <p style="margin-top:16px"><code>projectMemoryPolicies</code> and <code>projectIdentityOverrides</code> are written automatically by MCP tools — no need to edit them by hand.</p>
+    <p style="margin-top:16px"><code>projectMemoryPolicies</code> and <code>projectIdentityOverrides</code> are written automatically by MCP tools. You do not need to edit them by hand.</p>
     <div class="code-block fade-up" style="margin-top:16px">
       <div class="code-block-header">
         <span class="code-label">~/mnemonic-vault/config.json</span>
@@ -1985,7 +1985,7 @@ VAULT_PATH = <span class="str">"/Users/you/mnemonic-vault"</span></pre>
 
     <div class="agent-snippet fade-up" style="margin-top:24px">
       <h3>Search another repository's docs without copying them</h3>
-      <p>Attach an external repo and its markdown documentation becomes searchable right alongside your memories — mnemonic reads the files, finds the right page for any question, and can hand back the exact section when you need the source text. Nothing is ever written back to that repository.</p>
+      <p>Attach an external repo and its markdown documentation becomes searchable alongside your memories. mnemonic reads the files, finds the right page for your question, and can return the exact section when you need the source text. Nothing is written back to that repository.</p>
       <p>Give mnemonic the local path to the repo, then narrow which files count as documentation when the defaults aren't right for you:</p>
     </div>
     <div class="code-block fade-up" style="margin-top:16px">
@@ -2025,7 +2025,7 @@ VAULT_PATH = <span class="str">"/Users/you/mnemonic-vault"</span></pre>
           <tr>
             <td><code>exclude</code></td>
             <td class="default">generated &amp; vendor files</td>
-            <td>Files to skip — <code>node_modules</code>, build output, caches, and the like</td>
+            <td>Files to skip, such as <code>node_modules</code>, build output, and caches</td>
           </tr>
           <tr>
             <td><code>acceptedMediaTypes</code></td>
@@ -2035,11 +2035,11 @@ VAULT_PATH = <span class="str">"/Users/you/mnemonic-vault"</span></pre>
         </tbody>
       </table>
     </div>
-    <p style="font-size:0.875rem;color:var(--text-dim);margin:14px 0 0">After attaching, run a quick <code style="font-family:JetBrains Mono,monospace;font-size:0.85em;color:var(--cyan-lt)">sync</code> to index the current revision. The same attachment also works with another repository's mnemonic notes — keep them read-only by default, or mark them writable so memories can flow both ways. The README covers every option for both kinds.</p>
+    <p style="font-size:0.875rem;color:var(--text-dim);margin:14px 0 0">After attaching, run a quick <code style="font-family:JetBrains Mono,monospace;font-size:0.85em;color:var(--cyan-lt)">sync</code> to index the current revision. The same attachment also works with another repository's mnemonic notes. Keep them read-only by default, or mark them writable so memories can flow both ways. The README covers every option for both kinds.</p>
 
     <div class="agent-snippet fade-up">
       <h3>No system prompt required</h3>
-      <p>Mnemonic's tools are self-describing — each includes "use when" / "do not use when" guidance, behavioral annotations, and typed schemas. Most models will use them correctly from tool metadata alone.</p>
+      <p>Mnemonic's tools are self-describing. Each includes "use when" and "do not use when" guidance, behavioral annotations, and typed schemas. Most models can use them correctly from tool metadata alone.</p>
       <p>For memory-tool protocol guidance, use <code style="font-family:JetBrains Mono,monospace;font-size:0.85em;color:var(--cyan-lt)">mnemonic-workflow-hint</code>. For structured task execution guidance, use <code style="font-family:JetBrains Mono,monospace;font-size:0.85em;color:var(--cyan-lt)">mnemonic-rpi-workflow</code>.</p>
     </div>
 
@@ -2119,7 +2119,7 @@ VAULT_PATH = <span class="str">"/Users/you/mnemonic-vault"</span></pre>
 
       <div class="qs-col">
         <h3>mnemonic migrate</h3>
-        <p style="color:var(--text-dim);font-size:0.9rem;margin-bottom:16px">Apply pending schema migrations to your vaults. Always preview with <code>--dry-run</code> first — failed runs roll staged writes back automatically.</p>
+        <p style="color:var(--text-dim);font-size:0.9rem;margin-bottom:16px">Apply pending schema migrations to your vaults. Always preview with <code>--dry-run</code> first. Failed runs roll staged writes back automatically.</p>
         <div class="code-block">
           <div class="code-block-header">
             <span class="code-label">bash</span>
@@ -2141,7 +2141,7 @@ VAULT_PATH = <span class="str">"/Users/you/mnemonic-vault"</span></pre>
 
       <div class="qs-col">
         <h3>mnemonic import-claude-memory</h3>
-        <p style="color:var(--text-dim);font-size:0.9rem;margin-bottom:16px">Import <a href="https://docs.anthropic.com/en/docs/claude-code/memory" style="color:var(--cyan-lt);text-decoration:none" target="_blank" rel="noopener">Claude Code auto-memory</a> into your vault. Each <code>##</code> heading in <code>~/.claude/projects/&lt;project&gt;/memory/*.md</code> becomes a separate mnemonic note — independently searchable via <code>recall</code>. Duplicate titles are skipped, so it's safe to re-run.</p>
+        <p style="color:var(--text-dim);font-size:0.9rem;margin-bottom:16px">Import <a href="https://docs.anthropic.com/en/docs/claude-code/memory" style="color:var(--cyan-lt);text-decoration:none" target="_blank" rel="noopener">Claude Code auto-memory</a> into your vault. Each <code>##</code> heading in <code>~/.claude/projects/&lt;project&gt;/memory/*.md</code> becomes a separate mnemonic note that you can search with <code>recall</code>. Duplicate titles are skipped, so it is safe to re-run.</p>
         <div class="code-block">
           <div class="code-block-header">
             <span class="code-label">bash</span>
@@ -2284,7 +2284,7 @@ VAULT_PATH = <span class="str">"/Users/you/mnemonic-vault"</span></pre>
         </div>
         <h3 class="dogfood-title">Temporal Interpretation Strategy</h3>
         <div class="dogfood-body">
-          <p>Temporal mode now explains <em>what kind</em> of change happened, not just that one occurred. Each history entry is classified into one of eight semantic categories — create, refine, expand, clarify, connect, restructure, reverse, unknown — using structural signals: additions/deletions ratio, churn, relationship changes, and commit message prefixes.</p>
+          <p>Temporal mode now explains <em>what kind</em> of change happened, not just that one occurred. Each history entry is classified into one of eight semantic categories: create, refine, expand, clarify, connect, restructure, reverse, or unknown. It uses structural signals such as the additions/deletions ratio, churn, relationship changes, and commit message prefixes.</p>
           <p>Classification is language-independent. Conservative thresholds prefer <code>unknown</code> over misclassification. Raw diffs are intentionally excluded from default output.</p>
         </div>
         <div class="dogfood-footer">
@@ -2296,7 +2296,7 @@ VAULT_PATH = <span class="str">"/Users/you/mnemonic-vault"</span></pre>
     </div>
 
     <div class="dogfood-cta fade-up">
-      <p>Every architectural call, trade-off, and lesson — committed to the repo inside <code>.mnemonic/notes/</code> as plain markdown. Human-readable. Open the folder and read them directly.</p>
+      <p>Every architectural call, trade-off, and lesson is committed to the repo inside <code>.mnemonic/notes/</code> as plain markdown. Open the folder and read the notes directly.</p>
       <a href="https://github.com/danielmarbach/mnemonic/tree/main/.mnemonic/notes" class="btn btn-ghost" target="_blank" rel="noopener" style="margin-top:16px;display:inline-flex">
         Browse the decision log on GitHub
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="margin-left:4px"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
@@ -2311,7 +2311,7 @@ VAULT_PATH = <span class="str">"/Users/you/mnemonic-vault"</span></pre>
   <div class="container">
     <div class="footer-inner">
       <div class="footer-brand">
-        <strong>mnemonic</strong> &mdash; MIT License &mdash; by danielmarbach
+        <strong>mnemonic</strong>, MIT License, by danielmarbach
       </div>
       <ul class="footer-links">
         <li><a href="https://github.com/danielmarbach/mnemonic" target="_blank" rel="noopener">GitHub</a></li>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@danielmarbach/mnemonic-mcp",
       "version": "0.38.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.10.1",
+        "@modelcontextprotocol/server": "^2.0.0",
         "gray-matter": "^4.0.3",
         "markdownlint": "^0.41.0",
         "remark-gfm": "^4.0.1",
@@ -608,18 +608,6 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
-    "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.14.1"
-      },
-      "peerDependencies": {
-        "hono": "^4"
-      }
-    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -708,44 +696,29 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
       "license": "MIT"
     },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
-      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9 || ^2.0.5",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
-        "cross-spawn": "^7.0.5",
-        "eventsource": "^3.0.2",
-        "eventsource-parser": "^3.0.0",
-        "express": "^5.2.1",
-        "express-rate-limit": "^8.2.1",
-        "hono": "^4.11.4",
-        "jose": "^6.1.3",
-        "json-schema-typed": "^8.0.2",
-        "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.1"
+        "zod": "^4.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
       },
-      "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
-          "optional": true
-        },
-        "zod": {
-          "optional": false
-        }
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@pkgr/core": {
@@ -1208,6 +1181,7 @@
       "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1736,25 +1710,13 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/accepts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "^3.0.0",
-        "negotiator": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1776,6 +1738,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -1786,23 +1749,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
       }
     },
     "node_modules/ansi-regex": {
@@ -1856,30 +1802,6 @@
         "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
-        "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
-        "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
@@ -1891,44 +1813,6 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/call-bound": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ccount": {
@@ -1990,28 +1874,6 @@
         "node": ">= 12"
       }
     },
-    "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/content-type": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2019,45 +1881,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/cookie-signature": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
-      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.6.0"
-      }
-    },
-    "node_modules/cors": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
-      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4",
-        "vary": "^1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2105,15 +1933,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -2136,71 +1955,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/ee-first": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT"
-    },
-    "node_modules/encodeurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -2244,12 +2004,6 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
-    "node_modules/escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT"
-    },
     "node_modules/escape-string-regexp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
@@ -2268,6 +2022,7 @@
       "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -2327,6 +2082,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -2524,36 +2280,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/etag": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/eventsource": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
-      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
-      "license": "MIT",
-      "dependencies": {
-        "eventsource-parser": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2562,67 +2288,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/express": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
-      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "^2.0.0",
-        "body-parser": "^2.2.1",
-        "content-disposition": "^1.0.0",
-        "content-type": "^1.0.5",
-        "cookie": "^0.7.1",
-        "cookie-signature": "^1.2.1",
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "finalhandler": "^2.1.0",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "merge-descriptors": "^2.0.0",
-        "mime-types": "^3.0.0",
-        "on-finished": "^2.4.1",
-        "once": "^1.4.0",
-        "parseurl": "^1.3.3",
-        "proxy-addr": "^2.0.7",
-        "qs": "^6.14.0",
-        "range-parser": "^1.2.1",
-        "router": "^2.2.0",
-        "send": "^1.1.0",
-        "serve-static": "^2.2.0",
-        "statuses": "^2.0.1",
-        "type-is": "^2.0.1",
-        "vary": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/express-rate-limit": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.0.tgz",
-      "integrity": "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==",
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "10.1.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
-      },
-      "peerDependencies": {
-        "express": ">= 4.11"
       }
     },
     "node_modules/extend": {
@@ -2647,6 +2312,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -2674,6 +2340,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2717,27 +2384,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/finalhandler": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
-      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "on-finished": "^2.4.1",
-        "parseurl": "^1.3.3",
-        "statuses": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -2776,24 +2422,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/forwarded": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
-      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2809,15 +2437,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/get-east-asian-width": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
@@ -2828,43 +2447,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/glob-parent": {
@@ -2880,18 +2462,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/gray-matter": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
@@ -2905,75 +2475,6 @@
       },
       "engines": {
         "node": ">=6.0"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/hono": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
-      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.9.0"
-      }
-    },
-    "node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -2994,30 +2495,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
-    "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/is-alphabetical": {
@@ -3108,26 +2585,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-promise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT"
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
-    },
-    "node_modules/jose": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.0.tgz",
-      "integrity": "sha512-xsfE1TcSCbUdo6U07tR0mvhg0flGxU8tPLbF03mirl2ukGQENhUg4ubGYQnhVH0b5stLlPM+WOqDkEl1R1y5sQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
     },
     "node_modules/js-yaml": {
       "version": "3.14.2",
@@ -3153,13 +2616,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json-schema-typed": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -3308,15 +2766,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/DavidAnson"
-      }
-    },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/mdast-util-find-and-replace": {
@@ -3518,27 +2967,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/merge-descriptors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
-      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/micromark": {
@@ -4142,31 +3570,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -4215,36 +3618,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-inspect": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -4255,27 +3628,6 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
-    },
-    "node_modules/on-finished": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -4346,15 +3698,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/parseurl": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4369,19 +3712,10 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -4409,15 +3743,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pkce-challenge": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
-      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.20.0"
       }
     },
     "node_modules/postcss": {
@@ -4465,6 +3790,7 @@
       "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4488,19 +3814,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/proxy-addr": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "license": "MIT",
-      "dependencies": {
-        "forwarded": "0.2.0",
-        "ipaddr.js": "1.9.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4509,45 +3822,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/raw-body": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
-      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.7.0",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/remark-gfm": {
@@ -4603,6 +3877,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4653,28 +3928,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/router": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
-      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "is-promise": "^4.0.0",
-        "parseurl": "^1.3.3",
-        "path-to-regexp": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
-    },
     "node_modules/section-matter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
@@ -4701,61 +3954,11 @@
         "node": ">=10"
       }
     },
-    "node_modules/send": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
-      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.3",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.1",
-        "mime-types": "^3.0.2",
-        "ms": "^2.1.3",
-        "on-finished": "^2.4.1",
-        "range-parser": "^1.2.1",
-        "statuses": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/serve-static": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
-      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
-      "license": "MIT",
-      "dependencies": {
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "parseurl": "^1.3.3",
-        "send": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/setprototypeof": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC"
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -4768,81 +3971,10 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
-        "side-channel-map": "^1.0.1",
-        "side-channel-weakmap": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-map": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-weakmap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3",
-        "side-channel-map": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -4902,15 +4034,6 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/statuses": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
-      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/std-env": {
       "version": "4.0.0",
@@ -5029,15 +4152,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/toidentifier": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/trough": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
@@ -5074,20 +4188,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
-      "license": "MIT",
-      "dependencies": {
-        "content-type": "^1.0.5",
-        "media-typer": "^1.1.0",
-        "mime-types": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/typescript": {
       "name": "@typescript/typescript6",
       "version": "6.0.2",
@@ -5095,6 +4195,7 @@
       "integrity": "sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@typescript/old": "npm:typescript@^6"
       },
@@ -5222,6 +4323,7 @@
       "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.65.0",
         "@typescript-eslint/types": "8.65.0",
@@ -5453,15 +4555,6 @@
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
     },
-    "node_modules/unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -5470,15 +4563,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/vary": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/vfile": {
@@ -5527,6 +4611,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5690,6 +4775,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -5728,12 +4814,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
-    },
     "node_modules/yaml": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
@@ -5769,17 +4849,9 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25 || ^4"
       }
     },
     "node_modules/zwitch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@danielmarbach/mnemonic-mcp",
-      "version": "0.38.0",
+      "version": "0.39.0",
       "dependencies": {
         "@modelcontextprotocol/server": "^2.0.0",
         "gray-matter": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     ]
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.10.1",
+    "@modelcontextprotocol/server": "^2.0.0",
     "gray-matter": "^4.0.3",
     "markdownlint": "^0.41.0",
     "remark-gfm": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "description": "A local MCP memory server backed by markdown + JSON files, synced via git",
   "type": "module",
   "repository": {

--- a/src/helpers/git-commit.ts
+++ b/src/helpers/git-commit.ts
@@ -3,6 +3,7 @@ import {
   isProtectedBranch,
   resolveProtectedBranchBehavior,
   resolveProtectedBranchPatterns,
+  type ProtectedBranchBehavior,
   type WriteScope,
   type ProjectMemoryPolicy,
 } from "../project-memory-policy.js";
@@ -149,6 +150,17 @@ export function formatProtectedBranchBlocked(
   ].join("\n");
 }
 
+export interface ProtectedBranchBlocked {
+  blocked: true;
+  message: string;
+  projectLabel: string;
+  branch: string;
+  patterns: string[];
+  behavior: ProtectedBranchBehavior;
+}
+
+export type ProtectedBranchCheck = { blocked: false } | ProtectedBranchBlocked;
+
 export async function shouldBlockProtectedBranchCommit(options: {
   ctx: ServerContext;
   cwd?: string;
@@ -158,7 +170,7 @@ export async function shouldBlockProtectedBranchCommit(options: {
   policy: ProjectMemoryPolicy | undefined;
   allowProtectedBranch: boolean;
   toolName: string;
-}): Promise<{ blocked: boolean; message?: string }> {
+}): Promise<ProtectedBranchCheck> {
   const { cwd, writeScope, automaticCommit, projectLabel, policy, allowProtectedBranch, toolName } =
     options;
   if (!cwd || writeScope !== "project" || !automaticCommit) {
@@ -184,7 +196,7 @@ export async function shouldBlockProtectedBranchCommit(options: {
     behavior === "block"
       ? formatProtectedBranchBlocked(projectLabel, branch, patterns, toolName)
       : formatAskForProtectedBranch(projectLabel, branch, patterns, toolName);
-  return { blocked: true, message };
+  return { blocked: true, message, projectLabel, branch, patterns, behavior };
 }
 
 export async function wouldRelationshipCleanupTouchProjectVault(
@@ -273,7 +285,7 @@ export async function commitVaultWithProtection(options: {
       return {
         status: "failed",
         reason: "error",
-        error: protectedBranchCheck.message ?? "Protected branch policy blocked this commit.",
+        error: protectedBranchCheck.message,
       };
     }
   }
@@ -287,7 +299,7 @@ export async function checkVaultProtectedBranch(options: {
   allowProtectedBranch: boolean;
   toolName: string;
   noteProjectId?: string;
-}): Promise<{ blocked: boolean; message?: string }> {
+}): Promise<ProtectedBranchCheck> {
   const { ctx, vault, allowProtectedBranch, toolName, noteProjectId } = options;
 
   if (!vault.writable || vault.provenance === "main") {

--- a/src/helpers/mrtr.ts
+++ b/src/helpers/mrtr.ts
@@ -1,0 +1,268 @@
+import {
+  CLIENT_CAPABILITIES_META_KEY,
+  inputRequired,
+  inputResponse,
+  type CallToolResult,
+  type InputRequiredResult,
+  type ServerContext as SdkServerContext,
+} from "@modelcontextprotocol/server";
+import { z } from "zod";
+import type { ProtectedBranchBlocked } from "./git-commit.js";
+import { WRITE_SCOPES } from "../project-memory-policy.js";
+
+/**
+ * Elicitation keys shared between an `inputRequired` request and the matching
+ * response entry in `ctx.mcpReq.inputResponses` on retry.
+ */
+export const ELICITATION_KEYS = {
+  protectedBranch: "protectedBranch",
+  writeScope: "writeScope",
+  vault: "vault",
+} as const;
+export type ElicitationKey = (typeof ELICITATION_KEYS)[keyof typeof ELICITATION_KEYS];
+
+/** Single source of truth for the protected-branch consent elicitation. */
+export const protectedBranchConsentSchema = z.object({
+  allowProtectedBranch: z.boolean().describe("Allow this one-time commit on the protected branch"),
+});
+export type ProtectedBranchConsent = z.infer<typeof protectedBranchConsentSchema>;
+
+/** Single source of truth for the write-scope selection elicitation. */
+export const writeScopeChoiceSchema = z.object({
+  scope: z.enum(WRITE_SCOPES).describe("Where to store this memory"),
+});
+export type WriteScopeChoice = z.infer<typeof writeScopeChoiceSchema>;
+
+/** Single source of truth for the vault selection elicitation. */
+export const vaultChoiceSchema = z.object({
+  vault: z.string().min(1).describe("Which vault to write to"),
+});
+export type VaultChoice = z.infer<typeof vaultChoiceSchema>;
+
+/** A candidate vault the user can pick when multiple writable vaults exist. */
+export interface VaultChoiceOption {
+  /** Stable key echoed by the client on retry (e.g. `"project"`, `"attached:slug"`). */
+  readonly key: string;
+  /** Human-readable label shown in the client UI and the elicitation message. */
+  readonly label: string;
+}
+
+/**
+ * Result of reading one elicitation response from a retried request:
+ * `accepted` carries the validated content, `declined` covers both explicit
+ * decline and cancel. `undefined` means the request carried no response for
+ * the key (the initial round, or a client that ignored the request).
+ */
+export type ElicitationOutcome<T> =
+  { readonly kind: "accepted"; readonly value: T } | { readonly kind: "declined" };
+
+/**
+ * Whether the current request can be answered with `inputRequired(...)`.
+ *
+ * Mirrors the .NET SDK's `McpServer.IsMrtrSupported`: modern (2026-07-28)
+ * clients carry their capabilities in the required per-request envelope, and
+ * `input_required` is native to that era — provided the client also declares
+ * the `elicitation` capability the embedded requests need (the SDK rejects
+ * `elicitation/create` with `-32021` otherwise). Legacy clients never carry
+ * an envelope; returning `inputRequired` would hand them to the SDK's legacy
+ * shim, which needs the client to have declared the `elicitation` capability
+ * and otherwise fails with a generic message. Those clients keep the existing
+ * error-text flow instead.
+ */
+export function isMrtrSupported(requestCtx: SdkServerContext): boolean {
+  // The SDK requires `io.modelcontextprotocol/clientCapabilities` in the
+  // `_meta` envelope of every modern (2026-07-28) request
+  // (REQUIRED_ENVELOPE_KEYS); legacy requests never carry an envelope. The
+  // SDK's public `RequestMetaEnvelope` type is empty (`{}`), so the reserved
+  // key is read through an index signature; the value is validated by the
+  // SDK's own envelope schema before it reaches handlers.
+  const envelope = requestCtx.mcpReq.envelope as Readonly<Record<string, unknown>> | undefined;
+  return declaresFormElicitation(envelope?.[CLIENT_CAPABILITIES_META_KEY]);
+}
+
+/**
+ * Whether the client's declared capabilities cover form-mode elicitation,
+ * mirroring the SDK's `missingClientCapabilities` lenient reading: a bare
+ * `elicitation: {}` declaration (the pre-mode 2025 meaning) counts as form
+ * support, as does an explicit `elicitation: { form: {} }`.
+ */
+function declaresFormElicitation(clientCapabilities: unknown): boolean {
+  if (typeof clientCapabilities !== "object" || clientCapabilities === null) {
+    return false;
+  }
+  const elicitation = (clientCapabilities as { elicitation?: unknown }).elicitation;
+  if (typeof elicitation !== "object" || elicitation === null) {
+    return false;
+  }
+  const entry = elicitation as Record<string, unknown>;
+  return entry["form"] !== undefined || Object.keys(entry).length === 0;
+}
+
+/**
+ * Reads one elicitation response from a retried request, validating the
+ * accepted content against `schema` (any Standard Schema, e.g. a zod object).
+ * The content arrives from the client untrusted, so invalid content is
+ * treated as a decline rather than trusted.
+ */
+export function readElicitation<S extends z.ZodType>(
+  requestCtx: SdkServerContext,
+  key: ElicitationKey,
+  schema: S,
+): ElicitationOutcome<z.infer<S>> | undefined {
+  const view = inputResponse(requestCtx.mcpReq.inputResponses, key);
+  if (view.kind !== "elicit") {
+    return undefined;
+  }
+  if (view.action !== "accept") {
+    return { kind: "declined" };
+  }
+  const parsed = schema.safeParse(view.content);
+  if (!parsed.success) {
+    console.error(
+      `[mrtr] Ignoring invalid elicitation content for '${key}': ${JSON.stringify(parsed.error.issues)}`,
+    );
+    return { kind: "declined" };
+  }
+  return { kind: "accepted", value: parsed.data };
+}
+
+export function readProtectedBranchConsent(
+  requestCtx: SdkServerContext,
+): ElicitationOutcome<ProtectedBranchConsent> | undefined {
+  return readElicitation(
+    requestCtx,
+    ELICITATION_KEYS.protectedBranch,
+    protectedBranchConsentSchema,
+  );
+}
+
+/**
+ * Effective protected-branch consent for the current round: `"granted"` when
+ * the user accepted with `allowProtectedBranch: true`, `"denied"` when the
+ * user declined, cancelled, or submitted the form with the consent unchecked
+ * (an accepted form carrying `allowProtectedBranch: false` is an explicit
+ * denial, not a grant), and `undefined` when the request carried no consent
+ * response (the initial round).
+ */
+export type ProtectedBranchConsentState = "granted" | "denied";
+
+export function readProtectedBranchConsentState(
+  requestCtx: SdkServerContext,
+): ProtectedBranchConsentState | undefined {
+  const consent = readProtectedBranchConsent(requestCtx);
+  if (consent === undefined) {
+    return undefined;
+  }
+  if (consent.kind === "declined") {
+    return "denied";
+  }
+  return consent.value.allowProtectedBranch === true ? "granted" : "denied";
+}
+
+export function readWriteScopeChoice(
+  requestCtx: SdkServerContext,
+): ElicitationOutcome<WriteScopeChoice> | undefined {
+  return readElicitation(requestCtx, ELICITATION_KEYS.writeScope, writeScopeChoiceSchema);
+}
+
+export function readVaultChoice(
+  requestCtx: SdkServerContext,
+): ElicitationOutcome<VaultChoice> | undefined {
+  return readElicitation(requestCtx, ELICITATION_KEYS.vault, vaultChoiceSchema);
+}
+
+function legacyErrorResult(message: string): CallToolResult {
+  return { content: [{ type: "text", text: message }], isError: true };
+}
+
+/**
+ * Builds the result for a blocked protected-branch commit: a native
+ * elicitation on MRTR-capable clients, the existing error text everywhere
+ * else (including the response to an explicit user decline, which callers
+ * handle before calling this).
+ */
+export function protectedBranchDecision(
+  requestCtx: SdkServerContext,
+  blocked: ProtectedBranchBlocked,
+): CallToolResult | InputRequiredResult {
+  if (!isMrtrSupported(requestCtx)) {
+    return legacyErrorResult(blocked.message);
+  }
+  return inputRequired({
+    inputRequests: {
+      [ELICITATION_KEYS.protectedBranch]: inputRequired.elicit({
+        message: formatProtectedBranchElicitMessage(blocked),
+        requestedSchema: protectedBranchConsentSchema,
+      }),
+    },
+  });
+}
+
+function formatProtectedBranchElicitMessage(blocked: ProtectedBranchBlocked): string {
+  const { projectLabel, branch, patterns, behavior } = blocked;
+  const patternsLabel = patterns.length > 0 ? patterns.join(", ") : "the configured patterns";
+  const header =
+    behavior === "block"
+      ? `Auto-commit blocked for ${projectLabel}: current branch \`${branch}\` matches protected patterns ${patternsLabel}.`
+      : `Protected branch check for ${projectLabel}: current branch \`${branch}\` matches ${patternsLabel}.`;
+  return `${header} Allow this one-time commit?`;
+}
+
+/**
+ * Builds the result for an unresolved write scope: a structured project vs
+ * global choice on MRTR-capable clients, the existing guidance error text
+ * everywhere else.
+ */
+export function scopeSelectionDecision(
+  requestCtx: SdkServerContext,
+  message: string,
+): CallToolResult | InputRequiredResult {
+  if (!isMrtrSupported(requestCtx)) {
+    return legacyErrorResult(message);
+  }
+  return inputRequired({
+    inputRequests: {
+      [ELICITATION_KEYS.writeScope]: inputRequired.elicit({
+        message,
+        requestedSchema: writeScopeChoiceSchema,
+      }),
+    },
+  });
+}
+
+/**
+ * Builds the result for an ambiguous write target: an enum picker over the
+ * candidate vaults on MRTR-capable clients. Callers only invoke this when
+ * multiple writable candidates exist; the legacy fallback (a plain error) is
+ * a defensive measure because the caller should already have resolved the
+ * default before deciding to elicit.
+ */
+export function vaultSelectionDecision(
+  requestCtx: SdkServerContext,
+  options: readonly VaultChoiceOption[],
+  message = "Which vault should this memory be written to?",
+): CallToolResult | InputRequiredResult {
+  if (!isMrtrSupported(requestCtx)) {
+    const optionsLabel = options.map((option) => `- ${option.key}: ${option.label}`).join("\n");
+    return legacyErrorResult(`${message}\nAvailable vaults:\n${optionsLabel}`);
+  }
+
+  const keys = options.map((option) => option.key);
+  const [first, ...rest] = keys;
+  if (!first) {
+    throw new Error("vaultSelectionDecision requires at least one candidate vault");
+  }
+  const requestedSchema = z.object({
+    vault: z.enum([first, ...rest]).describe("Which vault to write to"),
+  });
+
+  const optionsLabel = options.map((option) => `\`${option.key}\` — ${option.label}`).join("; ");
+  return inputRequired({
+    inputRequests: {
+      [ELICITATION_KEYS.vault]: inputRequired.elicit({
+        message: `${message} Options: ${optionsLabel}`,
+        requestedSchema,
+      }),
+    },
+  });
+}

--- a/src/helpers/project.ts
+++ b/src/helpers/project.ts
@@ -8,8 +8,7 @@ import {
 } from "../project.js";
 import type { ServerContext } from "../server-context.js";
 import type { ProjectRef } from "../structured-content.js";
-import type { Vault, MnemonicVaultAttachmentConfig } from "../vault.js";
-import type { WriteScope } from "../project-memory-policy.js";
+import type { MnemonicVaultAttachmentConfig } from "../vault.js";
 import { invalidateActiveProjectCache } from "../cache.js";
 import { checkBranchChange } from "../branch-tracker.js";
 import { backfillEmbeddingsAfterSync, removeStaleEmbeddings } from "./embed.js";
@@ -61,20 +60,6 @@ export async function resolveProjectIdentityForCwd(
       ctx.configStore.getProjectIdentityOverride(projectId),
   });
   return identity ?? undefined;
-}
-
-export async function resolveWriteVault(
-  ctx: ServerContext,
-  cwd: string | undefined,
-  scope: WriteScope,
-): Promise<Vault> {
-  if (scope === "project") {
-    return cwd
-      ? ((await ctx.vaultManager.getOrCreateProjectVault(cwd)) ?? ctx.vaultManager.main)
-      : ctx.vaultManager.main;
-  }
-
-  return ctx.vaultManager.main;
 }
 
 export function describeProject(project: Awaited<ReturnType<typeof resolveProject>>): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,5 @@
 #!/usr/bin/env node
-import { McpServer, type RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
-import { toJsonSchemaCompat } from "@modelcontextprotocol/sdk/server/zod-json-schema-compat.js";
-import { normalizeObjectSchema } from "@modelcontextprotocol/sdk/server/zod-compat.js";
+import { McpServer } from "@modelcontextprotocol/server";
 
 import { registerAllTools } from "./tools/index.js";
 import { registerPrompts } from "./prompts.js";
@@ -40,64 +37,19 @@ if (cliArg !== undefined && cliArg.startsWith("-")) {
 
 const ctx = await createServerContext();
 
-const server = new McpServer({
-  name: "mnemonic",
-  version: await readPackageVersion(),
-});
+const server = new McpServer(
+  {
+    name: "mnemonic",
+    version: await readPackageVersion(),
+  },
+  {
+    cacheHints: {
+      "tools/list": { ttlMs: 3_600_000, cacheScope: "private" as const },
+    },
+  },
+);
 
 registerAllTools(server, ctx);
 registerPrompts(server);
-
-// Override tools/list to emit JSON Schema 2020-12 instead of the SDK's default draft-07.
-// The MCP SDK's toJsonSchemaCompat supports 2020-12 but McpServer doesn't expose a
-// configuration option for the dialect. This runtime override is more robust than
-// patch-package because it works even when npm install runs with --ignore-scripts
-// (e.g. Homebrew).
-const EMPTY_OBJECT_JSON_SCHEMA = {
-  type: "object" as const,
-  properties: {} as Record<string, never>,
-};
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const internalServer = (server as any).server;
-// _registeredTools is internal SDK state; casting is required because it is private.
-type InternalRegisteredTools = { _registeredTools: Record<string, RegisteredTool> };
-const registeredTools = (server as unknown as InternalRegisteredTools)._registeredTools;
-
-internalServer.setRequestHandler(ListToolsRequestSchema, () => ({
-  tools: Object.entries(registeredTools)
-    .filter(([, tool]) => tool.enabled)
-    .map(([name, tool]) => {
-      const toolDefinition: Record<string, unknown> = {
-        name,
-        title: tool.title,
-        description: tool.description,
-        inputSchema: (() => {
-          const obj = normalizeObjectSchema(tool.inputSchema);
-          return obj
-            ? toJsonSchemaCompat(obj, {
-                strictUnions: true,
-                pipeStrategy: "input",
-                target: "draft-2020-12",
-              })
-            : EMPTY_OBJECT_JSON_SCHEMA;
-        })(),
-        annotations: tool.annotations,
-        execution: tool.execution,
-        _meta: tool._meta,
-      };
-      if (tool.outputSchema) {
-        const obj = normalizeObjectSchema(tool.outputSchema);
-        if (obj) {
-          toolDefinition.outputSchema = toJsonSchemaCompat(obj, {
-            strictUnions: true,
-            pipeStrategy: "output",
-            target: "draft-2020-12",
-          });
-        }
-      }
-      return toolDefinition;
-    }),
-}));
 
 await startServer(server, ctx);

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,4 +1,4 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpServer } from "@modelcontextprotocol/server";
 
 export function registerPrompts(server: McpServer): void {
   // ── mnemonic-workflow-hint prompt ─────────────────────────────────────────────

--- a/src/server-context.ts
+++ b/src/server-context.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { MnemonicConfig, MnemonicConfigStore } from "./config.js";
 import type { Migrator } from "./migration.js";
 import type { VaultManager } from "./vault.js";

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -1,7 +1,7 @@
 import { readVaultSchemaVersion } from "./config.js";
 import type { ServerContext } from "./server-context.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { serveStdio } from "@modelcontextprotocol/server/stdio";
+import type { McpServer } from "@modelcontextprotocol/server";
 
 export async function warnAboutPendingMigrationsOnStartup(ctx: ServerContext): Promise<void> {
   let totalPending = 0;
@@ -35,18 +35,9 @@ export async function warnAboutPendingMigrationsOnStartup(ctx: ServerContext): P
 
 export async function startServer(server: McpServer, ctx: ServerContext): Promise<void> {
   await warnAboutPendingMigrationsOnStartup(ctx);
-  const transport = new StdioServerTransport();
 
-  async function shutdown() {
-    await server.close();
-    process.exit(0);
-  }
-  process.on("SIGINT", shutdown);
-  process.on("SIGTERM", shutdown);
-  transport.onclose = async () => {
-    await server.close();
-  };
-
-  await server.connect(transport);
+  await serveStdio(() => server, {
+    onerror: (error) => console.error(`[mnemonic] stdio error:`, error),
+  });
   console.error(`[mnemonic] Started. Main vault: ${ctx.vaultPath}`);
 }

--- a/src/tools/add-attachment.ts
+++ b/src/tools/add-attachment.ts
@@ -3,7 +3,7 @@ import fs from "fs/promises";
 import path from "path";
 import crypto from "crypto";
 import { simpleGit } from "simple-git";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import type {
   ProjectAttachmentConfig,

--- a/src/tools/consolidate-helpers.ts
+++ b/src/tools/consolidate-helpers.ts
@@ -1,4 +1,14 @@
 import type { ServerContext } from "../server-context.js";
+import type {
+  CallToolResult,
+  InputRequiredResult,
+  ServerContext as SdkServerContext,
+} from "@modelcontextprotocol/server";
+import {
+  isMrtrSupported,
+  protectedBranchDecision,
+  readProtectedBranchConsentState,
+} from "../helpers/mrtr.js";
 import type { ProjectInfo } from "../project.js";
 import {
   aggregateMergeRisk,
@@ -431,10 +441,8 @@ export async function executeMerge(
   policy?: ProjectMemoryPolicy,
   allowProtectedBranch: boolean = false,
   evidence: boolean = true,
-): Promise<{
-  content: Array<{ type: "text"; text: string }>;
-  structuredContent: ConsolidateResult;
-}> {
+  requestCtx?: SdkServerContext,
+): Promise<CallToolResult | InputRequiredResult> {
   const { vaultManager } = ctx;
   const sourceIds = normalizeMergePlanSourceIds(mergePlan.sourceIds);
   const targetTitle = mergePlan.targetTitle.trim();
@@ -492,6 +500,8 @@ export async function executeMerge(
   };
 
   // Pre-check protected branches for vaults we are about to modify
+  const declinedBranchConsent =
+    requestCtx !== undefined && readProtectedBranchConsentState(requestCtx) === "denied";
   const vaultsToCheck = new Set<Vault>([targetVault, ...sourceEntries.map((e) => e.vault)]);
   for (const vault of vaultsToCheck) {
     const protectedBranchCheck = await checkVaultProtectedBranch({
@@ -508,19 +518,15 @@ export async function executeMerge(
         project: toProjectRef(project),
         notesProcessed: entries.length,
         notesModified: 0,
-        warnings: [
-          protectedBranchCheck.message ?? "Protected branch policy blocked this operation.",
-        ],
+        warnings: [protectedBranchCheck.message],
       };
-      return {
-        content: [
-          {
-            type: "text",
-            text: protectedBranchCheck.message ?? "Protected branch policy blocked this operation.",
-          },
-        ],
-        structuredContent,
-      };
+      if (declinedBranchConsent || requestCtx === undefined || !isMrtrSupported(requestCtx)) {
+        return {
+          content: [{ type: "text", text: protectedBranchCheck.message }],
+          structuredContent,
+        };
+      }
+      return protectedBranchDecision(requestCtx, protectedBranchCheck);
     }
   }
 
@@ -540,14 +546,15 @@ export async function executeMerge(
         project: toProjectRef(project),
         notesProcessed: entries.length,
         notesModified: 0,
-        warnings: [check.message ?? "Protected branch policy blocked this commit."],
+        warnings: [check.message],
       };
-      return {
-        content: [
-          { type: "text", text: check.message ?? "Protected branch policy blocked this commit." },
-        ],
-        structuredContent,
-      };
+      if (declinedBranchConsent || requestCtx === undefined || !isMrtrSupported(requestCtx)) {
+        return {
+          content: [{ type: "text", text: check.message }],
+          structuredContent,
+        };
+      }
+      return protectedBranchDecision(requestCtx, check);
     }
   }
 
@@ -1207,11 +1214,11 @@ export async function pruneSuperseded(
   cwd?: string,
   policy?: ProjectMemoryPolicy,
   allowProtectedBranch: boolean = false,
-): Promise<{
-  content: Array<{ type: "text"; text: string }>;
-  structuredContent: ConsolidateResult;
-}> {
+  requestCtx?: SdkServerContext,
+): Promise<CallToolResult | InputRequiredResult> {
   const { vaultManager } = ctx;
+  const declinedBranchConsent =
+    requestCtx !== undefined && readProtectedBranchConsentState(requestCtx) === "denied";
 
   if (consolidationMode !== "delete") {
     const structuredContent: ConsolidateResult = {
@@ -1282,14 +1289,15 @@ export async function pruneSuperseded(
         project: toProjectRef(project),
         notesProcessed: entries.length,
         notesModified: 0,
-        warnings: [check.message ?? "Protected branch policy blocked this commit."],
+        warnings: [check.message],
       };
-      return {
-        content: [
-          { type: "text", text: check.message ?? "Protected branch policy blocked this commit." },
-        ],
-        structuredContent,
-      };
+      if (declinedBranchConsent || requestCtx === undefined || !isMrtrSupported(requestCtx)) {
+        return {
+          content: [{ type: "text", text: check.message }],
+          structuredContent,
+        };
+      }
+      return protectedBranchDecision(requestCtx, check);
     }
   }
 

--- a/src/tools/consolidate.ts
+++ b/src/tools/consolidate.ts
@@ -5,6 +5,7 @@ import { ConsolidateResultSchema } from "../structured-content.js";
 import { projectParam, resolveProject, ensureBranchSynced } from "../helpers/project.js";
 import { collectVisibleNotes, projectNotFoundResponse } from "../helpers/vault.js";
 import { CONSOLIDATION_MODES, resolveConsolidationMode } from "../project-memory-policy.js";
+import { readProtectedBranchConsentState } from "../helpers/mrtr.js";
 import { invalidateActiveProjectCache } from "../cache.js";
 import { guardIdsAgainstDocumentSourceMutation } from "../mutation-guard.js";
 import {
@@ -121,15 +122,20 @@ export function registerConsolidateTool(server: McpServer, ctx: ServerContext): 
       }),
       outputSchema: ConsolidateResultSchema,
     },
-    async ({
-      cwd,
-      strategy,
-      mode,
-      threshold,
-      evidence = true,
-      mergePlan,
-      allowProtectedBranch = false,
-    }) => {
+    async (
+      {
+        cwd,
+        strategy,
+        mode,
+        threshold,
+        evidence = true,
+        mergePlan,
+        allowProtectedBranch: allowProtectedBranchArg = false,
+      },
+      requestCtx,
+    ) => {
+      const branchConsent = readProtectedBranchConsentState(requestCtx);
+      const allowProtectedBranch = allowProtectedBranchArg || branchConsent === "granted";
       await ensureBranchSynced(ctx, cwd);
 
       // Guard against document-source mutations
@@ -200,6 +206,7 @@ export function registerConsolidateTool(server: McpServer, ctx: ServerContext): 
             policy,
             allowProtectedBranch,
             evidence,
+            requestCtx,
           );
           invalidateActiveProjectCache();
           return mergeResult;
@@ -214,6 +221,7 @@ export function registerConsolidateTool(server: McpServer, ctx: ServerContext): 
             cwd,
             policy,
             allowProtectedBranch,
+            requestCtx,
           );
           invalidateActiveProjectCache();
           return pruneResult;

--- a/src/tools/consolidate.ts
+++ b/src/tools/consolidate.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import { ConsolidateResultSchema } from "../structured-content.js";
 import { projectParam, resolveProject, ensureBranchSynced } from "../helpers/project.js";

--- a/src/tools/detect-project.ts
+++ b/src/tools/detect-project.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import { resolveProjectIdentityForCwd as resolveProjectIdentityForCwdFromModule } from "../helpers/project.js";
 import {

--- a/src/tools/discover-tags.ts
+++ b/src/tools/discover-tags.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import { NOTE_LIFECYCLES, type NoteLifecycle } from "../storage.js";
 import { DiscoverTagsResultSchema, type DiscoverTagsResult } from "../structured-content.js";

--- a/src/tools/forget.ts
+++ b/src/tools/forget.ts
@@ -19,6 +19,7 @@ import {
   commitVaultWithProtection,
   checkVaultProtectedBranch,
 } from "../helpers/git-commit.js";
+import { protectedBranchDecision, readProtectedBranchConsentState } from "../helpers/mrtr.js";
 import {
   buildMutationRetryContract,
   formatRetrySummary,
@@ -73,7 +74,9 @@ export function registerForgetTool(server: McpServer, ctx: ServerContext): void 
       }),
       outputSchema: ForgetResultSchema,
     },
-    async ({ id, cwd, allowProtectedBranch = false }) => {
+    async ({ id, cwd, allowProtectedBranch: allowProtectedBranchArg = false }, requestCtx) => {
+      const branchConsent = readProtectedBranchConsentState(requestCtx);
+      const allowProtectedBranch = allowProtectedBranchArg || branchConsent === "granted";
       await ensureBranchSynced(ctx, cwd);
       guardAgainstDocumentSourceMutation(id, "forget");
       const project = await resolveProject(ctx, cwd);
@@ -105,15 +108,13 @@ export function registerForgetTool(server: McpServer, ctx: ServerContext): void 
         noteProjectId: note.project ?? undefined,
       });
       if (protectedBranchCheck.blocked) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: protectedBranchCheck.message ?? "Protected branch policy blocked this commit.",
-            },
-          ],
-          isError: true,
-        };
+        if (branchConsent === "denied") {
+          return {
+            content: [{ type: "text", text: protectedBranchCheck.message }],
+            isError: true,
+          };
+        }
+        return protectedBranchDecision(requestCtx, protectedBranchCheck);
       }
 
       const deleted = await noteVault.storage.deleteNote(memoryId(id));

--- a/src/tools/forget.ts
+++ b/src/tools/forget.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import {
   EntityRefSchema,

--- a/src/tools/get-project-identity.ts
+++ b/src/tools/get-project-identity.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import { resolveProjectIdentityForCwd as resolveProjectIdentityForCwdFromModule } from "../helpers/project.js";
 import { projectNotFoundResponse } from "../helpers/vault.js";

--- a/src/tools/get.ts
+++ b/src/tools/get.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { performance } from "perf_hooks";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import type { Note } from "../storage.js";
 import type { Vault } from "../vault.js";

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 
 import { registerDetectProjectTool } from "./detect-project.js";

--- a/src/tools/list-attachments.ts
+++ b/src/tools/list-attachments.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import path from "path";
 import fs from "fs/promises";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import type { MnemonicVaultAttachmentConfig, DocumentSourceAttachmentConfig } from "../vault.js";
 import { resolveProject as resolveProjectFromModule } from "../helpers/project.js";

--- a/src/tools/list.ts
+++ b/src/tools/list.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import { ListResultSchema, type ListResult, type ProjectRef } from "../structured-content.js";
 import type { Note, NoteLifecycle } from "../storage.js";

--- a/src/tools/memory-graph.ts
+++ b/src/tools/memory-graph.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import { MemoryGraphResultSchema, type MemoryGraphResult } from "../structured-content.js";
 import { projectParam, toProjectRef, ensureBranchSynced } from "../helpers/project.js";

--- a/src/tools/migration.ts
+++ b/src/tools/migration.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import { readVaultSchemaVersion } from "../config.js";
 import {

--- a/src/tools/move-memory.ts
+++ b/src/tools/move-memory.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import type { Vault } from "../vault.js";
 import { EntityRefSchema, MoveResultSchema, type MoveResult } from "../structured-content.js";

--- a/src/tools/move-memory.ts
+++ b/src/tools/move-memory.ts
@@ -7,6 +7,8 @@ import { projectParam, resolveProject, ensureBranchSynced } from "../helpers/pro
 import { memoryId, isoDateString } from "../brands.js";
 import { formatPersistenceSummary } from "../helpers/persistence.js";
 import { moveNoteBetweenVaults, projectNotFoundResponse, storageLabel } from "../helpers/vault.js";
+import { checkVaultProtectedBranch } from "../helpers/git-commit.js";
+import { protectedBranchDecision, readProtectedBranchConsentState } from "../helpers/mrtr.js";
 import { attempt, getErrorMessage } from "../error-utils.js";
 import { invalidateActiveProjectCache } from "../cache.js";
 import { guardAgainstDocumentSourceMutation } from "../mutation-guard.js";
@@ -64,7 +66,12 @@ export function registerMoveMemoryTool(server: McpServer, ctx: ServerContext): v
       }),
       outputSchema: MoveResultSchema,
     },
-    async ({ id, target, vaultFolder, cwd, allowProtectedBranch = false }) => {
+    async (
+      { id, target, vaultFolder, cwd, allowProtectedBranch: allowProtectedBranchArg = false },
+      requestCtx,
+    ) => {
+      const branchConsent = readProtectedBranchConsentState(requestCtx);
+      const allowProtectedBranch = allowProtectedBranchArg || branchConsent === "granted";
       await ensureBranchSynced(ctx, cwd);
       guardAgainstDocumentSourceMutation(id, "move");
 
@@ -189,6 +196,36 @@ export function registerMoveMemoryTool(server: McpServer, ctx: ServerContext): v
           projectName: rewrittenProjectName,
           updatedAt: isoDateString(new Date().toISOString()),
         };
+      }
+
+      // Pre-check protected branches for both source and target vaults before
+      // mutating anything, so an MRTR consent round happens before any write.
+      const movePreChecks = await Promise.all([
+        checkVaultProtectedBranch({
+          ctx,
+          vault: found.vault,
+          allowProtectedBranch,
+          toolName: "move_memory",
+          noteProjectId: found.note.project ?? undefined,
+        }),
+        checkVaultProtectedBranch({
+          ctx,
+          vault: targetVault,
+          allowProtectedBranch,
+          toolName: "move_memory",
+          noteProjectId: targetProject?.id,
+        }),
+      ]);
+      for (const check of movePreChecks) {
+        if (check.blocked) {
+          if (branchConsent === "denied") {
+            return {
+              content: [{ type: "text", text: check.message }],
+              isError: true,
+            };
+          }
+          return protectedBranchDecision(requestCtx, check);
+        }
       }
 
       const moveAttempt = await attempt("move:between-vaults", () =>

--- a/src/tools/policy.ts
+++ b/src/tools/policy.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import { resolveProject as resolveProjectFromModule } from "../helpers/project.js";
 import { projectNotFoundResponse } from "../helpers/vault.js";

--- a/src/tools/project-memory-summary.ts
+++ b/src/tools/project-memory-summary.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import { performance } from "perf_hooks";
 

--- a/src/tools/recall.ts
+++ b/src/tools/recall.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { performance } from "perf_hooks";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import type { Vault } from "../vault.js";
 import type { Note, NoteLifecycle, RelationshipType } from "../storage.js";

--- a/src/tools/recent-memories.ts
+++ b/src/tools/recent-memories.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import { RecentResultSchema, type RecentResult } from "../structured-content.js";
 import {

--- a/src/tools/relate.ts
+++ b/src/tools/relate.ts
@@ -17,6 +17,7 @@ import {
   commitVaultWithProtection,
   checkVaultProtectedBranch,
 } from "../helpers/git-commit.js";
+import { protectedBranchDecision, readProtectedBranchConsentState } from "../helpers/mrtr.js";
 import {
   buildMutationRetryContract,
   formatRetrySummary,
@@ -67,7 +68,9 @@ export function registerRelateTool(server: McpServer, ctx: ServerContext): void 
       }),
       outputSchema: RelateResultSchema,
     },
-    async ({ fromId, toId, type, bidirectional, cwd }) => {
+    async ({ fromId, toId, type, bidirectional, cwd }, requestCtx) => {
+      const branchConsent = readProtectedBranchConsentState(requestCtx);
+      const allowProtectedBranch = branchConsent === "granted";
       await ensureBranchSynced(ctx, cwd);
       guardIdsAgainstDocumentSourceMutation([fromId, toId], "relate");
       const project = await resolveProject(ctx, cwd);
@@ -127,7 +130,7 @@ export function registerRelateTool(server: McpServer, ctx: ServerContext): void 
           checkVaultProtectedBranch({
             ctx,
             vault,
-            allowProtectedBranch: false,
+            allowProtectedBranch,
             toolName: "relate",
             noteProjectId:
               vault === fromVault ? (fromNote.project ?? undefined) : (toNote.project ?? undefined),
@@ -136,15 +139,13 @@ export function registerRelateTool(server: McpServer, ctx: ServerContext): void 
       );
       for (const check of preChecks) {
         if (check.blocked) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: check.message ?? "Protected branch policy blocked this commit.",
-              },
-            ],
-            isError: true,
-          };
+          if (branchConsent === "denied") {
+            return {
+              content: [{ type: "text", text: check.message }],
+              isError: true,
+            };
+          }
+          return protectedBranchDecision(requestCtx, check);
         }
       }
 
@@ -219,7 +220,7 @@ export function registerRelateTool(server: McpServer, ctx: ServerContext): void 
               commitMessage,
               files: pendingFiles,
               commitBody,
-              allowProtectedBranch: false,
+              allowProtectedBranch,
               toolName: "relate",
             });
 
@@ -292,7 +293,7 @@ export function registerRelateTool(server: McpServer, ctx: ServerContext): void 
           commitMessage,
           files,
           commitBody,
-          allowProtectedBranch: false,
+          allowProtectedBranch,
           toolName: "relate",
         });
         if (!retry) {

--- a/src/tools/relate.ts
+++ b/src/tools/relate.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import path from "node:path";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import { RELATIONSHIP_TYPES, type Relationship } from "../storage.js";
 import {

--- a/src/tools/remember.ts
+++ b/src/tools/remember.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import { NOTE_LIFECYCLES, NOTE_ROLES, type Note } from "../storage.js";
 import { isoDateString } from "../brands.js";

--- a/src/tools/remember.ts
+++ b/src/tools/remember.ts
@@ -1,7 +1,13 @@
 import { z } from "zod";
-import type { McpServer } from "@modelcontextprotocol/server";
+import type {
+  CallToolResult,
+  InputRequiredResult,
+  McpServer,
+  ServerContext as SdkServerContext,
+} from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import { NOTE_LIFECYCLES, NOTE_ROLES, type Note } from "../storage.js";
+import type { Vault } from "../vault.js";
 import { isoDateString } from "../brands.js";
 import { getErrorMessage, attempt } from "../error-utils.js";
 import { embed, embeddingMetadata } from "../embeddings.js";
@@ -13,19 +19,25 @@ import {
 } from "../cache.js";
 import { suggestAutoRelationships } from "../auto-relate.js";
 import { MarkdownLintError, cleanMarkdown } from "../markdown.js";
-import { resolveWriteScope, WRITE_SCOPES } from "../project-memory-policy.js";
-import {
-  resolveProject,
-  resolveWriteVault,
-  ensureBranchSynced,
-  describeProject,
-} from "../helpers/project.js";
+import { resolveWriteScope, WRITE_SCOPES, type WriteScope } from "../project-memory-policy.js";
+import { resolveProject, ensureBranchSynced, describeProject } from "../helpers/project.js";
 import {
   extractSummary,
   formatCommitBody,
   formatAskForWriteScope,
+  checkVaultProtectedBranch,
   commitVaultWithProtection,
 } from "../helpers/git-commit.js";
+import {
+  isMrtrSupported,
+  protectedBranchDecision,
+  readProtectedBranchConsentState,
+  readVaultChoice,
+  readWriteScopeChoice,
+  scopeSelectionDecision,
+  vaultSelectionDecision,
+  type VaultChoiceOption,
+} from "../helpers/mrtr.js";
 import { embedTextForNote } from "../helpers/embed.js";
 import {
   buildPersistenceStatus,
@@ -33,13 +45,96 @@ import {
   buildMutationRetryContract,
   pushAfterMutation,
 } from "../helpers/persistence.js";
-import { storageLabel, ROLE_LIFECYCLE_DEFAULTS } from "../helpers/vault.js";
+import {
+  storageLabel,
+  ROLE_LIFECYCLE_DEFAULTS,
+  ensureAttachmentsLoaded,
+} from "../helpers/vault.js";
 import { makeId } from "../helpers/index.js";
 import {
   type RememberResult,
   RememberToolResultSchema,
   type RememberLintErrorResult,
 } from "../structured-content.js";
+
+type WriteVaultResolution =
+  | { kind: "vault"; vault: Vault }
+  | { kind: "decision"; result: CallToolResult | InputRequiredResult };
+
+interface RememberVaultCandidate extends VaultChoiceOption {
+  vault: Vault;
+}
+
+/**
+ * Resolves the vault a `remember` write targets.
+ *
+ * Writes to the main vault for global scope. For project scope, the primary
+ * project vault is the default; when writable attached vaults also exist for
+ * the project, an MRTR elicitation lets the user pick the target on
+ * modern clients. Legacy clients and explicit declines fall back to the
+ * primary project vault (the pre-existing behavior). A retry that names a
+ * vault outside the offered candidate list re-elicits rather than writing to
+ * an unoffered vault.
+ */
+export async function resolveWriteVaultForRemember(
+  ctx: ServerContext,
+  cwd: string | undefined,
+  writeScope: WriteScope,
+  project: Awaited<ReturnType<typeof resolveProject>> | undefined,
+  requestCtx: SdkServerContext,
+): Promise<WriteVaultResolution> {
+  if (writeScope === "global") {
+    return { kind: "vault", vault: ctx.vaultManager.main };
+  }
+
+  const projectVault = cwd ? await ctx.vaultManager.getOrCreateProjectVault(cwd) : null;
+  if (!projectVault) {
+    return { kind: "vault", vault: ctx.vaultManager.main };
+  }
+
+  const candidates: RememberVaultCandidate[] = [
+    {
+      key: "project",
+      label: `${project?.name ?? "this project"} project vault`,
+      vault: projectVault,
+    },
+  ];
+
+  if (project) {
+    await ensureAttachmentsLoaded(ctx, project.id);
+    for (const attached of ctx.vaultManager.getAttachmentsForProject(project.id)) {
+      if (!attached.writable) {
+        continue;
+      }
+      const ref = attached.attachmentRef;
+      candidates.push({
+        key: ref?.projectSlug ? `attached:${ref.projectSlug}` : storageLabel(attached),
+        label: ref?.projectName
+          ? `${ref.projectName} (${ref.projectSlug})`
+          : storageLabel(attached),
+        vault: attached,
+      });
+    }
+  }
+
+  if (candidates.length === 1) {
+    return { kind: "vault", vault: projectVault };
+  }
+
+  const vaultChoice = readVaultChoice(requestCtx);
+  if (vaultChoice?.kind === "accepted") {
+    const chosen = candidates.find((candidate) => candidate.key === vaultChoice.value.vault);
+    if (chosen) {
+      return { kind: "vault", vault: chosen.vault };
+    }
+  }
+
+  if (vaultChoice?.kind === "declined" || !isMrtrSupported(requestCtx)) {
+    return { kind: "vault", vault: projectVault };
+  }
+
+  return { kind: "decision", result: vaultSelectionDecision(requestCtx, candidates) };
+}
 
 export function registerRememberTool(server: McpServer, ctx: ServerContext): void {
   server.registerTool(
@@ -128,7 +223,7 @@ export function registerRememberTool(server: McpServer, ctx: ServerContext): voi
           .describe(
             "Where to store: 'project' writes to the shared project vault visible to all contributors; " +
               "'global' writes to the private main vault visible only on this machine. " +
-              "Attached vaults are read-only and cannot be written to. " +
+              "When writable attached vaults exist for the project, you may be asked to pick the write target. " +
               "When omitted, uses the project's saved policy or defaults to 'project'.",
           ),
         allowProtectedBranch: z
@@ -147,21 +242,31 @@ export function registerRememberTool(server: McpServer, ctx: ServerContext): voi
       }),
       outputSchema: RememberToolResultSchema,
     },
-    async ({
-      title,
-      content,
-      tags,
-      lifecycle,
-      role,
-      summary,
-      alwaysLoad,
-      cwd,
-      scope,
-      allowProtectedBranch = false,
-    }) => {
+    async (
+      {
+        title,
+        content,
+        tags,
+        lifecycle,
+        role,
+        summary,
+        alwaysLoad,
+        cwd,
+        scope,
+        allowProtectedBranch: allowProtectedBranchArg = false,
+      },
+      requestCtx,
+    ) => {
+      const branchConsent = readProtectedBranchConsentState(requestCtx);
+      const allowProtectedBranch = allowProtectedBranchArg || branchConsent === "granted";
+
       await ensureBranchSynced(ctx, cwd);
 
       const project = await resolveProject(ctx, cwd);
+
+      // A retried MRTR round carries the protected-branch consent, the write
+      // scope choice, and the vault choice as input responses; fold them into
+      // the effective arguments before reaching any decision point.
 
       const cleanResult = await attempt("remember:clean-markdown", async () =>
         cleanMarkdown(content),
@@ -188,21 +293,55 @@ export function registerRememberTool(server: McpServer, ctx: ServerContext): voi
       const projectVaultExists = cwd
         ? Boolean(await ctx.vaultManager.getProjectVaultIfExists(cwd))
         : true;
-      const writeScope = resolveWriteScope(
-        scope,
-        policyScope,
-        Boolean(project),
-        projectVaultExists,
-      );
+      let writeScope = resolveWriteScope(scope, policyScope, Boolean(project), projectVaultExists);
       if (writeScope === "ask") {
         const unadopted = !projectVaultExists && !policyScope;
-        return {
-          content: [{ type: "text", text: formatAskForWriteScope(project, unadopted) }],
-          isError: true,
-        };
+        const scopeChoice = readWriteScopeChoice(requestCtx);
+        if (scopeChoice?.kind === "accepted") {
+          writeScope = scopeChoice.value.scope;
+        } else if (scopeChoice?.kind === "declined" || !isMrtrSupported(requestCtx)) {
+          return {
+            content: [{ type: "text", text: formatAskForWriteScope(project, unadopted) }],
+            isError: true,
+          };
+        } else {
+          const header = formatAskForWriteScope(project, unadopted).split("\n")[0] ?? "";
+          const message =
+            `${header} Where should this memory be stored? ` +
+            `"project" stores in the shared project vault for all contributors; ` +
+            `"global" stores in the private main vault for this machine only.`;
+          return scopeSelectionDecision(requestCtx, message);
+        }
       }
 
-      const vault = await resolveWriteVault(ctx, cwd, writeScope);
+      const vaultResolution = await resolveWriteVaultForRemember(
+        ctx,
+        cwd,
+        writeScope,
+        project,
+        requestCtx,
+      );
+      if (vaultResolution.kind === "decision") {
+        return vaultResolution.result;
+      }
+      const vault = vaultResolution.vault;
+
+      const protectedBranchCheck = await checkVaultProtectedBranch({
+        ctx,
+        vault,
+        allowProtectedBranch,
+        toolName: "remember",
+        noteProjectId: project?.id,
+      });
+      if (protectedBranchCheck.blocked) {
+        if (branchConsent === "denied") {
+          return {
+            content: [{ type: "text", text: protectedBranchCheck.message }],
+            isError: true,
+          };
+        }
+        return protectedBranchDecision(requestCtx, protectedBranchCheck);
+      }
 
       const id = makeId(title);
       const now = isoDateString(new Date().toISOString());

--- a/src/tools/remove-attachment.ts
+++ b/src/tools/remove-attachment.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import fs from "fs/promises";
 import path from "path";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import type { MnemonicVaultAttachmentConfig } from "../vault.js";
 import { resolveProject as resolveProjectFromModule } from "../helpers/project.js";

--- a/src/tools/set-attachment-branch.ts
+++ b/src/tools/set-attachment-branch.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import path from "path";
 import { simpleGit } from "simple-git";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import type { MnemonicVaultAttachmentConfig } from "../vault.js";
 import { resolveProject as resolveProjectFromModule } from "../helpers/project.js";

--- a/src/tools/set-attachment-enabled.ts
+++ b/src/tools/set-attachment-enabled.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import { resolveProject as resolveProjectFromModule } from "../helpers/project.js";
 import { projectNotFoundResponse } from "../helpers/vault.js";

--- a/src/tools/set-project-identity.ts
+++ b/src/tools/set-project-identity.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import { resolveProjectIdentity } from "../project.js";
 import { projectNotFoundResponse } from "../helpers/vault.js";

--- a/src/tools/sync.ts
+++ b/src/tools/sync.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import path from "path";
 import { simpleGit } from "simple-git";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import {
   SyncResultSchema,

--- a/src/tools/unrelate.ts
+++ b/src/tools/unrelate.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import { projectParam, ensureBranchSynced, resolveProject } from "../helpers/project.js";
 import { isoDateString } from "../brands.js";

--- a/src/tools/unrelate.ts
+++ b/src/tools/unrelate.ts
@@ -15,6 +15,7 @@ import {
   commitVaultWithProtection,
   checkVaultProtectedBranch,
 } from "../helpers/git-commit.js";
+import { protectedBranchDecision, readProtectedBranchConsentState } from "../helpers/mrtr.js";
 import {
   buildMutationRetryContract,
   formatRetrySummary,
@@ -59,7 +60,9 @@ export function registerUnrelateTool(server: McpServer, ctx: ServerContext): voi
       }),
       outputSchema: RelateResultSchema,
     },
-    async ({ fromId, toId, bidirectional, cwd }) => {
+    async ({ fromId, toId, bidirectional, cwd }, requestCtx) => {
+      const branchConsent = readProtectedBranchConsentState(requestCtx);
+      const allowProtectedBranch = branchConsent === "granted";
       await ensureBranchSynced(ctx, cwd);
       guardIdsAgainstDocumentSourceMutation([fromId, toId], "unrelate");
       const project = await resolveProject(ctx, cwd);
@@ -104,7 +107,7 @@ export function registerUnrelateTool(server: McpServer, ctx: ServerContext): voi
           checkVaultProtectedBranch({
             ctx,
             vault,
-            allowProtectedBranch: false,
+            allowProtectedBranch,
             toolName: "unrelate",
             noteProjectId:
               vault === foundFrom?.vault
@@ -115,15 +118,13 @@ export function registerUnrelateTool(server: McpServer, ctx: ServerContext): voi
       );
       for (const check of preChecks) {
         if (check.blocked) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: check.message ?? "Protected branch policy blocked this commit.",
-              },
-            ],
-            isError: true,
-          };
+          if (branchConsent === "denied") {
+            return {
+              content: [{ type: "text", text: check.message }],
+              isError: true,
+            };
+          }
+          return protectedBranchDecision(requestCtx, check);
         }
       }
 
@@ -182,7 +183,7 @@ export function registerUnrelateTool(server: McpServer, ctx: ServerContext): voi
               commitMessage,
               files: pendingFiles,
               commitBody,
-              allowProtectedBranch: false,
+              allowProtectedBranch,
               toolName: "unrelate",
             });
 
@@ -249,7 +250,7 @@ export function registerUnrelateTool(server: McpServer, ctx: ServerContext): voi
           commitMessage,
           files,
           commitBody,
-          allowProtectedBranch: false,
+          allowProtectedBranch,
           toolName: "unrelate",
         });
         if (!retry) {

--- a/src/tools/update.ts
+++ b/src/tools/update.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import {
   ensureBranchSynced,

--- a/src/tools/update.ts
+++ b/src/tools/update.ts
@@ -12,6 +12,7 @@ import {
   commitVaultWithProtection,
   checkVaultProtectedBranch,
 } from "../helpers/git-commit.js";
+import { protectedBranchDecision, readProtectedBranchConsentState } from "../helpers/mrtr.js";
 import {
   buildPersistenceStatus,
   buildMutationRetryContract,
@@ -192,19 +193,24 @@ export function registerUpdateTool(server: McpServer, ctx: ServerContext): void 
       }),
       outputSchema: UpdateToolResultSchema,
     },
-    async ({
-      id,
-      content,
-      semanticPatch,
-      title,
-      tags,
-      lifecycle,
-      role,
-      summary,
-      alwaysLoad,
-      cwd,
-      allowProtectedBranch = false,
-    }) => {
+    async (
+      {
+        id,
+        content,
+        semanticPatch,
+        title,
+        tags,
+        lifecycle,
+        role,
+        summary,
+        alwaysLoad,
+        cwd,
+        allowProtectedBranch: allowProtectedBranchArg = false,
+      },
+      requestCtx,
+    ) => {
+      const branchConsent = readProtectedBranchConsentState(requestCtx);
+      const allowProtectedBranch = allowProtectedBranchArg || branchConsent === "granted";
       await ensureBranchSynced(ctx, cwd);
       guardIdsAgainstDocumentSourceMutation([id], "update");
       const noteId = memoryId(id);
@@ -438,15 +444,13 @@ export function registerUpdateTool(server: McpServer, ctx: ServerContext): void 
         noteProjectId: note.project ?? undefined,
       });
       if (protectedBranchCheck.blocked) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: protectedBranchCheck.message ?? "Protected branch policy blocked this commit.",
-            },
-          ],
-          isError: true,
-        };
+        if (branchConsent === "denied") {
+          return {
+            content: [{ type: "text", text: protectedBranchCheck.message }],
+            isError: true,
+          };
+        }
+        return protectedBranchDecision(requestCtx, protectedBranchCheck);
       }
 
       await vault.storage.writeNote(updated);

--- a/src/tools/where-is-memory.ts
+++ b/src/tools/where-is-memory.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import {
   ensureBranchSynced,

--- a/tests/__snapshots__/mcp-schema-contract.integration.test.ts.snap
+++ b/tests/__snapshots__/mcp-schema-contract.integration.test.ts.snap
@@ -6194,7 +6194,7 @@ Typical next step:
           "type": "string",
         },
         "scope": {
-          "description": "Where to store: 'project' writes to the shared project vault visible to all contributors; 'global' writes to the private main vault visible only on this machine. Attached vaults are read-only and cannot be written to. When omitted, uses the project's saved policy or defaults to 'project'.",
+          "description": "Where to store: 'project' writes to the shared project vault visible to all contributors; 'global' writes to the private main vault visible only on this machine. When writable attached vaults exist for the project, you may be asked to pick the write target. When omitted, uses the project's saved policy or defaults to 'project'.",
           "enum": [
             "project",
             "global",

--- a/tests/git-commit.unit.test.ts
+++ b/tests/git-commit.unit.test.ts
@@ -94,6 +94,36 @@ describe("commitVaultWithProtection", () => {
     expect(getCurrentGitBranchMock).toHaveBeenCalledWith("/project");
   });
 
+  it("includes branch, patterns and behavior in the blocked message", async () => {
+    const vault = makeFakeVault("project-local", {
+      storage: { vaultPath: "/project/.mnemonic" } as unknown as Vault["storage"],
+    });
+    getCurrentGitBranchMock.mockResolvedValue("release/1.0");
+    const policy = {
+      protectedBranchBehavior: "block",
+      protectedBranchPatterns: ["release*"],
+      projectId: "pid",
+      projectName: "PName",
+      defaultScope: "project",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    };
+    const ctx = fakeCtx(policy);
+
+    const result = await commitVaultWithProtection({
+      ctx,
+      vault,
+      commitMessage: "test commit",
+      files: ["notes/test.md"],
+      allowProtectedBranch: false,
+      toolName: "test-tool",
+      noteProjectId: "pid",
+    });
+
+    expect(result.status).toBe("failed");
+    expect((result as any).error).toContain("`release/1.0`");
+    expect((result as any).error).toContain("release*");
+  });
+
   it("succeeds with override when allowProtectedBranch is true", async () => {
     const vault = makeFakeVault("project-local", {
       storage: { vaultPath: "/project/.mnemonic" } as unknown as Vault["storage"],

--- a/tests/helpers/mcp.ts
+++ b/tests/helpers/mcp.ts
@@ -523,3 +523,201 @@ export async function listLocalMcpTools(
 
   return tools;
 }
+
+// ── Modern (2026-07-28) test client ─────────────────────────────────────────
+
+/** The modern protocol revision served by the SDK (`SUPPORTED_MODERN_PROTOCOL_VERSIONS`). */
+export const MODERN_PROTOCOL_VERSION = "2026-07-28";
+
+/**
+ * Per-request `_meta` envelope every modern request must carry
+ * (`REQUIRED_ENVELOPE_KEYS`): protocolVersion + clientCapabilities.
+ * clientInfo is a SHOULD and included for realism.
+ */
+const MODERN_ENVELOPE = {
+  "io.modelcontextprotocol/protocolVersion": MODERN_PROTOCOL_VERSION,
+  "io.modelcontextprotocol/clientCapabilities": { elicitation: { form: {} } },
+  "io.modelcontextprotocol/clientInfo": { name: "vitest-modern", version: "1.0" },
+};
+
+/** Builds an accepted elicitation response entry for `inputResponses`. */
+export function elicitAccept(content: Record<string, unknown>): Record<string, unknown> {
+  return { action: "accept", content };
+}
+
+/** Builds a declined elicitation response entry for `inputResponses`. */
+export function elicitDecline(): Record<string, unknown> {
+  return { action: "decline" };
+}
+
+export interface ModernMcpSession {
+  /** Sends a request with the modern envelope attached. */
+  callMethod: (method: string, params: Record<string, unknown>) => Promise<Record<string, unknown>>;
+  /**
+   * One tools/call round. The result may be an `input_required` result
+   * (`resultType: "input_required"`, with `inputRequests` and optionally
+   * `requestState`) or a complete tool result.
+   */
+  callToolRaw: (
+    toolName: string,
+    args: Record<string, unknown>,
+  ) => Promise<Record<string, unknown>>;
+  /**
+   * tools/call with automatic MRTR fulfilment: re-issues the call with the
+   * collected `inputResponses` until the handler returns a complete result.
+   * `respond` maps the server's `inputRequests` to `inputResponses` entries.
+   */
+  callTool: (
+    toolName: string,
+    args: Record<string, unknown>,
+    respond: (inputRequests: Record<string, unknown>) => Record<string, unknown>,
+  ) => Promise<Record<string, unknown>>;
+  close: () => Promise<void>;
+}
+
+/**
+ * Creates a persistent MODERN (2026-07-28) MCP session against the built
+ * server. Unlike the legacy helpers this client speaks the modern protocol:
+ * it pins the era with `server/discover`, carries the required `_meta`
+ * envelope on every request, and can fulfil `input_required` results by
+ * re-issuing the call with `inputResponses` (the native MRTR flow).
+ */
+export async function createModernMcpSession(
+  vaultDir: string,
+  options?: { ollamaUrl?: string; disableGit?: boolean; env?: Record<string, string> },
+): Promise<ModernMcpSession> {
+  const child = spawn("node", [builtEntryPoint], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      DISABLE_GIT: options?.disableGit === false ? "false" : "true",
+      VAULT_PATH: vaultDir,
+      ...(options?.ollamaUrl ? { OLLAMA_URL: options.ollamaUrl } : {}),
+      ...options?.env,
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  let stdoutBuffer = "";
+  let stderrBuffer = "";
+  let nextId = 1;
+  const pending = new Map<
+    number,
+    {
+      resolve: (value: Record<string, unknown>) => void;
+      reject: (error: Error) => void;
+    }
+  >();
+
+  child.stdout.on("data", (chunk) => {
+    stdoutBuffer += chunk.toString();
+    const lines = stdoutBuffer.split("\n");
+    stdoutBuffer = lines.pop() ?? "";
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      const message = JSON.parse(line) as {
+        id?: number;
+        result?: Record<string, unknown>;
+        error?: { code?: number; message?: string };
+      };
+      if (message.id === undefined) continue;
+      const waiter = pending.get(message.id);
+      if (!waiter) continue;
+      pending.delete(message.id);
+      if (message.error) {
+        waiter.reject(
+          new Error(
+            `MCP JSON-RPC error ${message.error.code ?? "unknown"}: ${message.error.message ?? "unknown error"}`,
+          ),
+        );
+        continue;
+      }
+      if (!message.result) {
+        waiter.reject(new Error("MCP JSON-RPC response missing result"));
+        continue;
+      }
+      waiter.resolve(message.result);
+    }
+  });
+
+  child.stderr.on("data", (chunk) => {
+    stderrBuffer += chunk.toString();
+  });
+
+  child.on("close", (code) => {
+    if (code === 0) return;
+    const error = new Error(`Modern MCP session exited with code ${code}: ${stderrBuffer}`);
+    for (const waiter of pending.values()) {
+      waiter.reject(error);
+    }
+    pending.clear();
+  });
+
+  const callMethod = async (
+    method: string,
+    params: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> => {
+    const id = nextId++;
+    const resultPromise = new Promise<Record<string, unknown>>((resolve, reject) => {
+      pending.set(id, { resolve, reject });
+    });
+    child.stdin.write(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id,
+        method,
+        params: { ...params, _meta: MODERN_ENVELOPE },
+      }) + "\n",
+    );
+    return resultPromise;
+  };
+
+  // Pin the connection to the modern era before any tool traffic.
+  await callMethod("server/discover", {});
+
+  const callToolRaw = async (
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> =>
+    callMethod("tools/call", { name: toolName, arguments: args });
+
+  const callTool = async (
+    toolName: string,
+    args: Record<string, unknown>,
+    respond: (inputRequests: Record<string, unknown>) => Record<string, unknown>,
+  ): Promise<Record<string, unknown>> => {
+    let params: Record<string, unknown> = { name: toolName, arguments: args };
+    const collectedResponses: Record<string, unknown> = {};
+    for (let round = 0; round < 8; round += 1) {
+      const result = await callMethod("tools/call", params);
+      if (result?.resultType !== "input_required") {
+        return result;
+      }
+      const responses = respond(result.inputRequests ?? {});
+      if (Object.keys(responses).length === 0) {
+        throw new Error(`input_required from '${toolName}' but responder produced no responses`);
+      }
+      Object.assign(collectedResponses, responses);
+      const retry: Record<string, unknown> = {
+        name: toolName,
+        arguments: args,
+        inputResponses: collectedResponses,
+      };
+      if (result.requestState !== undefined) {
+        retry.requestState = result.requestState;
+      }
+      params = retry;
+    }
+    throw new Error(`input_required fulfilment exceeded 8 rounds for '${toolName}'`);
+  };
+
+  return {
+    callMethod,
+    callToolRaw,
+    callTool,
+    close: async () => {
+      child.stdin.end();
+      await new Promise<void>((resolve) => child.once("close", () => resolve()));
+    },
+  };
+}

--- a/tests/mrtr.integration.test.ts
+++ b/tests/mrtr.integration.test.ts
@@ -1,0 +1,380 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import { mkdtemp, mkdir, readdir, stat, writeFile } from "fs/promises";
+import os from "os";
+import path from "path";
+
+import {
+  createModernMcpSession,
+  elicitAccept,
+  elicitDecline,
+  ensureBuiltEntryPointReady,
+  execFileAsync,
+  extractRememberedId,
+  initTestRepo,
+  initTestVaultRepo,
+  startFakeEmbeddingServer,
+  tempDirs,
+} from "./helpers/mcp.js";
+
+/**
+ * End-to-end tests of the native MRTR (2026-07-28) flow through a real
+ * modern client against the built server. The legacy test helpers cannot
+ * exercise `input_required` results, so these cover the round-trip mechanics
+ * the unit tests can only approximate.
+ */
+
+async function setupWritableAttachedVaultFixture() {
+  const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mrtr-vault-"));
+  const repoDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mrtr-repo-"));
+  const bareDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mrtr-bare-"));
+  const attachedDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mrtr-attached-"));
+
+  tempDirs.push(vaultDir, repoDir, bareDir, attachedDir);
+
+  await initTestVaultRepo(vaultDir);
+  await initTestRepo(repoDir);
+
+  await execFileAsync("git", ["init", "--bare", "-b", "main"], { cwd: bareDir });
+  await execFileAsync("git", ["init", "-b", "main"], { cwd: attachedDir });
+  await execFileAsync("git", ["config", "user.name", "Test User"], { cwd: attachedDir });
+  await execFileAsync("git", ["config", "user.email", "test@example.com"], { cwd: attachedDir });
+  await execFileAsync("git", ["config", "commit.gpgsign", "false"], { cwd: attachedDir });
+
+  const notesDir = path.join(attachedDir, ".mnemonic", "notes");
+  await mkdir(notesDir, { recursive: true });
+
+  const noteContent = `---
+title: Writable attached note
+tags: [integration, mrtr]
+lifecycle: permanent
+createdAt: "2025-01-01T00:00:00.000Z"
+updatedAt: "2025-01-01T00:00:00.000Z"
+---
+Content from writable attached vault.`;
+  await writeFile(path.join(notesDir, "attached-note.md"), noteContent, "utf-8");
+
+  await execFileAsync("git", ["add", ".mnemonic/"], { cwd: attachedDir });
+  await execFileAsync(
+    "git",
+    [
+      "-c",
+      "user.email=test@example.com",
+      "-c",
+      "user.name=Test User",
+      "commit",
+      "-m",
+      "chore: add mnemonic notes",
+    ],
+    { cwd: attachedDir },
+  );
+  await execFileAsync("git", ["remote", "add", "origin", bareDir], { cwd: attachedDir });
+  await execFileAsync("git", ["push", "-u", "origin", "main"], { cwd: attachedDir });
+  await execFileAsync("git", ["remote", "set-head", "origin", "--auto"], { cwd: attachedDir });
+
+  return { vaultDir, repoDir, attachedDir };
+}
+
+describe("MRTR native round-trips (modern 2026-07-28 client)", () => {
+  beforeAll(async () => {
+    await ensureBuiltEntryPointReady();
+  }, 120000);
+
+  it("elicits branch consent via input_required and commits after acceptance", async () => {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mrtr-vault-"));
+    const repoDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mrtr-repo-"));
+    tempDirs.push(vaultDir, repoDir);
+
+    await initTestVaultRepo(vaultDir);
+    await initTestRepo(repoDir, "main");
+    const embeddingServer = await startFakeEmbeddingServer();
+
+    try {
+      const session = await createModernMcpSession(vaultDir, {
+        ollamaUrl: embeddingServer.url,
+        disableGit: false,
+      });
+
+      try {
+        // Round 1: the protected-branch check blocks and returns input_required.
+        const raw = await session.callToolRaw("remember", {
+          title: "MRTR protected branch note",
+          content: "Should be committed after branch consent.",
+          tags: ["integration", "mrtr"],
+          summary: "Protected branch MRTR consent test",
+          cwd: repoDir,
+          scope: "project",
+        });
+
+        expect(raw.resultType).toBe("input_required");
+        const branchRequest = raw.inputRequests?.["protectedBranch"] as {
+          method?: string;
+          params?: { message?: string };
+        };
+        expect(branchRequest?.method).toBe("elicitation/create");
+        expect(branchRequest?.params?.message).toContain("main");
+
+        // Round 2: accept the consent; the note must be written and committed.
+        const accepted = await session.callTool(
+          "remember",
+          {
+            title: "MRTR protected branch note",
+            content: "Should be committed after branch consent.",
+            tags: ["integration", "mrtr"],
+            summary: "Protected branch MRTR consent test",
+            cwd: repoDir,
+            scope: "project",
+          },
+          (requests) => {
+            expect(Object.keys(requests)).toEqual(["protectedBranch"]);
+            return {
+              protectedBranch: elicitAccept({ allowProtectedBranch: true }),
+            };
+          },
+        );
+
+        const acceptedId = extractRememberedId(accepted.content?.[0]?.text ?? "");
+        await expect(
+          stat(path.join(repoDir, ".mnemonic", "notes", `${acceptedId}.md`)),
+        ).resolves.toBeDefined();
+      } finally {
+        await session.close();
+      }
+    } finally {
+      await embeddingServer.close();
+    }
+  }, 60000);
+
+  it("does not write when the user declines the branch consent", async () => {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mrtr-vault-"));
+    const repoDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mrtr-repo-"));
+    tempDirs.push(vaultDir, repoDir);
+
+    await initTestVaultRepo(vaultDir);
+    await initTestRepo(repoDir, "main");
+    const embeddingServer = await startFakeEmbeddingServer();
+
+    try {
+      const session = await createModernMcpSession(vaultDir, {
+        ollamaUrl: embeddingServer.url,
+        disableGit: false,
+      });
+
+      try {
+        const declined = await session.callTool(
+          "remember",
+          {
+            title: "MRTR declined note",
+            content: "Must not be stored when the user declines.",
+            tags: ["integration", "mrtr"],
+            summary: "Declined MRTR branch consent test",
+            cwd: repoDir,
+            scope: "project",
+          },
+          () => ({
+            protectedBranch: elicitDecline(),
+          }),
+        );
+
+        expect(declined.isError).toBe(true);
+        expect(declined.content?.[0]?.text).toContain("Protected branch check");
+
+        const notes = await readdir(path.join(repoDir, ".mnemonic", "notes")).catch(() => []);
+        expect(notes.filter((name) => name.endsWith(".md"))).toEqual([]);
+      } finally {
+        await session.close();
+      }
+    } finally {
+      await embeddingServer.close();
+    }
+  }, 60000);
+
+  it("elicits the write scope on an unadopted project and stores globally when chosen", async () => {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mrtr-vault-"));
+    const repoDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mrtr-repo-"));
+    tempDirs.push(vaultDir, repoDir);
+
+    await initTestVaultRepo(vaultDir);
+    await initTestRepo(repoDir);
+    const embeddingServer = await startFakeEmbeddingServer();
+
+    try {
+      const session = await createModernMcpSession(vaultDir, {
+        ollamaUrl: embeddingServer.url,
+        disableGit: false,
+      });
+
+      try {
+        const raw = await session.callToolRaw("remember", {
+          title: "MRTR scope choice note",
+          content: "Stored where the user picks.",
+          tags: ["integration", "mrtr"],
+          summary: "MRTR scope selection test",
+          cwd: repoDir,
+        });
+
+        expect(raw.resultType).toBe("input_required");
+        const scopeRequest = raw.inputRequests?.["writeScope"] as {
+          params?: { requestedSchema?: { properties?: Record<string, unknown> } };
+        };
+        const scopeProp = scopeRequest?.params?.requestedSchema?.properties?.["scope"] as
+          { enum?: string[] } | undefined;
+        expect(scopeProp?.enum).toEqual(["project", "global"]);
+
+        const chosen = await session.callTool(
+          "remember",
+          {
+            title: "MRTR scope choice note",
+            content: "Stored where the user picks.",
+            tags: ["integration", "mrtr"],
+            summary: "MRTR scope selection test",
+            cwd: repoDir,
+          },
+          () => ({
+            writeScope: elicitAccept({ scope: "global" }),
+          }),
+        );
+
+        const chosenId = extractRememberedId(chosen.content?.[0]?.text ?? "");
+        expect(chosen.content?.[0]?.text).toContain("stored=global");
+        await expect(stat(path.join(vaultDir, "notes", `${chosenId}.md`))).resolves.toBeDefined();
+      } finally {
+        await session.close();
+      }
+    } finally {
+      await embeddingServer.close();
+    }
+  }, 60000);
+
+  it("writes into a writable attached vault when the vault picker selects it", async () => {
+    const { vaultDir, repoDir, attachedDir } = await setupWritableAttachedVaultFixture();
+    const embeddingServer = await startFakeEmbeddingServer();
+
+    try {
+      const session = await createModernMcpSession(vaultDir, {
+        ollamaUrl: embeddingServer.url,
+        disableGit: false,
+      });
+
+      try {
+        const addResult = await session.callTool(
+          "add_attachment",
+          {
+            cwd: repoDir,
+            localPath: attachedDir,
+            writable: true,
+            pushBranch: "main",
+          },
+          () => ({}),
+        );
+        const slugMatch = (addResult.content?.[0]?.text ?? "").match(/\(([^)]+)\) at /);
+        expect(slugMatch).not.toBeNull();
+        const attachedSlug = slugMatch?.[1];
+        expect(attachedSlug).toBeTruthy();
+        const attachedKey = `attached:${attachedSlug}`;
+
+        const raw = await session.callToolRaw("remember", {
+          title: "MRTR vault picker note",
+          content: "Should land in the writable attached vault.",
+          tags: ["integration", "mrtr"],
+          summary: "MRTR vault selection test",
+          cwd: repoDir,
+          scope: "project",
+        });
+
+        expect(raw.resultType).toBe("input_required");
+        const vaultRequest = raw.inputRequests?.["vault"] as {
+          params?: { requestedSchema?: { properties?: Record<string, unknown> } };
+        };
+        const vaultProp = vaultRequest?.params?.requestedSchema?.properties?.["vault"] as
+          { enum?: string[] } | undefined;
+        expect(vaultProp?.enum).toContain("project");
+        expect(vaultProp?.enum).toContain(attachedKey);
+
+        const chosen = await session.callTool(
+          "remember",
+          {
+            title: "MRTR vault picker note",
+            content: "Should land in the writable attached vault.",
+            tags: ["integration", "mrtr"],
+            summary: "MRTR vault selection test",
+            cwd: repoDir,
+            scope: "project",
+          },
+          () => ({
+            vault: elicitAccept({ vault: attachedKey }),
+          }),
+        );
+
+        const chosenId = extractRememberedId(chosen.content?.[0]?.text ?? "");
+        expect(chosen.content?.[0]?.text).toContain(attachedKey);
+        await expect(
+          stat(path.join(attachedDir, ".mnemonic", "notes", `${chosenId}.md`)),
+        ).resolves.toBeDefined();
+      } finally {
+        await session.close();
+      }
+    } finally {
+      await embeddingServer.close();
+    }
+  }, 60000);
+
+  it("chains scope and branch elicitations across rounds on an unadopted protected branch", async () => {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mrtr-vault-"));
+    const repoDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mrtr-repo-"));
+    tempDirs.push(vaultDir, repoDir);
+
+    await initTestVaultRepo(vaultDir);
+    await initTestRepo(repoDir, "main");
+    const embeddingServer = await startFakeEmbeddingServer();
+
+    try {
+      const session = await createModernMcpSession(vaultDir, {
+        ollamaUrl: embeddingServer.url,
+        disableGit: false,
+      });
+
+      try {
+        const raw = await session.callToolRaw("remember", {
+          title: "MRTR chained rounds note",
+          content: "Exercises scope then branch consent across rounds.",
+          tags: ["integration", "mrtr"],
+          summary: "MRTR chained elicitation test",
+          cwd: repoDir,
+        });
+
+        expect(raw.resultType).toBe("input_required");
+        expect(raw.inputRequests?.["writeScope"]).toBeDefined();
+
+        const result = await session.callTool(
+          "remember",
+          {
+            title: "MRTR chained rounds note",
+            content: "Exercises scope then branch consent across rounds.",
+            tags: ["integration", "mrtr"],
+            summary: "MRTR chained elicitation test",
+            cwd: repoDir,
+          },
+          (requests) => {
+            const responses: Record<string, unknown> = {};
+            if (requests["writeScope"]) {
+              responses["writeScope"] = elicitAccept({ scope: "project" });
+            }
+            if (requests["protectedBranch"]) {
+              responses["protectedBranch"] = elicitAccept({ allowProtectedBranch: true });
+            }
+            return responses;
+          },
+        );
+
+        const resultId = extractRememberedId(result.content?.[0]?.text ?? "");
+        await expect(
+          stat(path.join(repoDir, ".mnemonic", "notes", `${resultId}.md`)),
+        ).resolves.toBeDefined();
+      } finally {
+        await session.close();
+      }
+    } finally {
+      await embeddingServer.close();
+    }
+  }, 60000);
+});

--- a/tests/mrtr.unit.test.ts
+++ b/tests/mrtr.unit.test.ts
@@ -1,0 +1,302 @@
+import { describe, expect, it } from "vitest";
+import type { ServerContext as SdkServerContext } from "@modelcontextprotocol/server";
+import {
+  ELICITATION_KEYS,
+  isMrtrSupported,
+  protectedBranchDecision,
+  readProtectedBranchConsent,
+  readProtectedBranchConsentState,
+  readVaultChoice,
+  readWriteScopeChoice,
+  scopeSelectionDecision,
+  vaultSelectionDecision,
+} from "../src/helpers/mrtr.js";
+import type { ProtectedBranchBlocked } from "../src/helpers/git-commit.js";
+
+const CLIENT_CAPABILITIES_META_KEY = "io.modelcontextprotocol/clientCapabilities";
+
+function makeRequestCtx(options?: {
+  inputResponses?: Record<string, unknown>;
+  envelope?: Record<string, unknown>;
+}): SdkServerContext {
+  return {
+    mcpReq: {
+      id: 1,
+      method: "tools/call",
+      inputResponses: options?.inputResponses,
+      envelope: options?.envelope,
+      requestState: () => undefined,
+      signal: new AbortController().signal,
+    },
+  } as unknown as SdkServerContext;
+}
+
+function makeBlockedCheck(overrides: Partial<ProtectedBranchBlocked> = {}): ProtectedBranchBlocked {
+  return {
+    blocked: true,
+    message: "Auto-commit blocked for P (pid): current branch `main` matches protected patterns.",
+    projectLabel: "P (pid)",
+    branch: "main",
+    patterns: ["main", "master", "release*"],
+    behavior: "block",
+    ...overrides,
+  };
+}
+
+describe("isMrtrSupported", () => {
+  it("returns false on a legacy request without an envelope", () => {
+    const requestCtx = makeRequestCtx();
+    expect(isMrtrSupported(requestCtx)).toBe(false);
+  });
+
+  it("returns false when the envelope lacks the client capabilities key", () => {
+    const requestCtx = makeRequestCtx({
+      envelope: { "io.modelcontextprotocol/logLevel": "debug" },
+    });
+    expect(isMrtrSupported(requestCtx)).toBe(false);
+  });
+
+  it("returns true on a modern request carrying client capabilities in the envelope", () => {
+    const requestCtx = makeRequestCtx({
+      envelope: { [CLIENT_CAPABILITIES_META_KEY]: { elicitation: { form: {} } } },
+    });
+    expect(isMrtrSupported(requestCtx)).toBe(true);
+  });
+
+  it("returns false on a modern request whose capabilities lack form elicitation", () => {
+    const requestCtx = makeRequestCtx({
+      envelope: { [CLIENT_CAPABILITIES_META_KEY]: { roots: {} } },
+    });
+    expect(isMrtrSupported(requestCtx)).toBe(false);
+  });
+});
+
+describe("readProtectedBranchConsent", () => {
+  it("returns undefined when the request carried no input responses", () => {
+    expect(readProtectedBranchConsent(makeRequestCtx())).toBeUndefined();
+  });
+
+  it("returns undefined when the response for the key is missing", () => {
+    const requestCtx = makeRequestCtx({
+      inputResponses: { other: { action: "accept", content: { x: 1 } } },
+    });
+    expect(readProtectedBranchConsent(requestCtx)).toBeUndefined();
+  });
+
+  it("returns accepted with the consent when the user allows", () => {
+    const requestCtx = makeRequestCtx({
+      inputResponses: {
+        [ELICITATION_KEYS.protectedBranch]: {
+          action: "accept",
+          content: { allowProtectedBranch: true },
+        },
+      },
+    });
+    expect(readProtectedBranchConsent(requestCtx)).toEqual({
+      kind: "accepted",
+      value: { allowProtectedBranch: true },
+    });
+  });
+
+  it("returns declined when the user declines or cancels", () => {
+    for (const action of ["decline", "cancel"]) {
+      const requestCtx = makeRequestCtx({
+        inputResponses: {
+          [ELICITATION_KEYS.protectedBranch]: { action },
+        },
+      });
+      expect(readProtectedBranchConsent(requestCtx)).toEqual({ kind: "declined" });
+    }
+  });
+
+  it("returns declined when accepted content fails schema validation", () => {
+    const requestCtx = makeRequestCtx({
+      inputResponses: {
+        [ELICITATION_KEYS.protectedBranch]: {
+          action: "accept",
+          content: { allowProtectedBranch: "yes" },
+        },
+      },
+    });
+    expect(readProtectedBranchConsent(requestCtx)).toEqual({ kind: "declined" });
+  });
+});
+
+describe("readProtectedBranchConsentState", () => {
+  it("returns granted when the user accepts with allowProtectedBranch: true", () => {
+    const requestCtx = makeRequestCtx({
+      inputResponses: {
+        [ELICITATION_KEYS.protectedBranch]: {
+          action: "accept",
+          content: { allowProtectedBranch: true },
+        },
+      },
+    });
+    expect(readProtectedBranchConsentState(requestCtx)).toBe("granted");
+  });
+
+  it("returns denied when the user submits the form with the consent unchecked", () => {
+    const requestCtx = makeRequestCtx({
+      inputResponses: {
+        [ELICITATION_KEYS.protectedBranch]: {
+          action: "accept",
+          content: { allowProtectedBranch: false },
+        },
+      },
+    });
+    expect(readProtectedBranchConsentState(requestCtx)).toBe("denied");
+  });
+
+  it("returns denied on explicit decline or cancel", () => {
+    for (const action of ["decline", "cancel"]) {
+      const requestCtx = makeRequestCtx({
+        inputResponses: {
+          [ELICITATION_KEYS.protectedBranch]: { action },
+        },
+      });
+      expect(readProtectedBranchConsentState(requestCtx)).toBe("denied");
+    }
+  });
+
+  it("returns undefined when the request carried no consent response", () => {
+    expect(readProtectedBranchConsentState(makeRequestCtx())).toBeUndefined();
+  });
+});
+
+describe("readWriteScopeChoice", () => {
+  it("returns accepted with a valid scope", () => {
+    const requestCtx = makeRequestCtx({
+      inputResponses: {
+        [ELICITATION_KEYS.writeScope]: { action: "accept", content: { scope: "project" } },
+      },
+    });
+    expect(readWriteScopeChoice(requestCtx)).toEqual({
+      kind: "accepted",
+      value: { scope: "project" },
+    });
+  });
+
+  it("returns declined for an out-of-enum scope", () => {
+    const requestCtx = makeRequestCtx({
+      inputResponses: {
+        [ELICITATION_KEYS.writeScope]: { action: "accept", content: { scope: "elsewhere" } },
+      },
+    });
+    expect(readWriteScopeChoice(requestCtx)).toEqual({ kind: "declined" });
+  });
+});
+
+describe("readVaultChoice", () => {
+  it("returns accepted with the chosen vault key", () => {
+    const requestCtx = makeRequestCtx({
+      inputResponses: {
+        [ELICITATION_KEYS.vault]: { action: "accept", content: { vault: "attached:team" } },
+      },
+    });
+    expect(readVaultChoice(requestCtx)).toEqual({
+      kind: "accepted",
+      value: { vault: "attached:team" },
+    });
+  });
+});
+
+describe("protectedBranchDecision", () => {
+  const blocked = makeBlockedCheck();
+
+  it("falls back to the error text on a legacy request", () => {
+    const result = protectedBranchDecision(makeRequestCtx(), blocked);
+    expect(result).toEqual({
+      content: [{ type: "text", text: blocked.message }],
+      isError: true,
+    });
+  });
+
+  it("returns an input_required elicitation on a modern request", () => {
+    const result = protectedBranchDecision(
+      makeRequestCtx({
+        envelope: { [CLIENT_CAPABILITIES_META_KEY]: { elicitation: { form: {} } } },
+      }),
+      blocked,
+    );
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty("resultType", "input_required");
+
+    const input = (result as { inputRequests: Record<string, unknown> }).inputRequests;
+    const request = input[ELICITATION_KEYS.protectedBranch] as {
+      method: string;
+      params: { message: string; requestedSchema: { properties: Record<string, unknown> } };
+    };
+    expect(request.method).toBe("elicitation/create");
+    expect(request.params.message).toContain("main");
+    expect(request.params.message).toContain("Allow this one-time commit?");
+    expect(request.params.requestedSchema.properties["allowProtectedBranch"]).toMatchObject({
+      type: "boolean",
+    });
+  });
+});
+
+describe("scopeSelectionDecision", () => {
+  it("falls back to the guidance error text on a legacy request", () => {
+    const message = "Project memory policy for P is set to always ask.";
+    const result = scopeSelectionDecision(makeRequestCtx(), message);
+    expect(result).toEqual({ content: [{ type: "text", text: message }], isError: true });
+  });
+
+  it("returns an input_required elicitation with a scope enum on a modern request", () => {
+    const result = scopeSelectionDecision(
+      makeRequestCtx({
+        envelope: { [CLIENT_CAPABILITIES_META_KEY]: { elicitation: { form: {} } } },
+      }),
+      "Where should this memory be stored?",
+    );
+    const request = (result as { inputRequests: Record<string, unknown> }).inputRequests[
+      ELICITATION_KEYS.writeScope
+    ] as { params: { requestedSchema: { properties: Record<string, unknown> } } };
+    expect(request.params.requestedSchema.properties["scope"]).toMatchObject({
+      type: "string",
+      enum: ["project", "global"],
+    });
+  });
+});
+
+describe("vaultSelectionDecision", () => {
+  const options = [
+    { key: "project", label: "P project vault" },
+    { key: "attached:team", label: "Team (team)" },
+  ];
+
+  it("falls back to an error listing the options on a legacy request", () => {
+    const result = vaultSelectionDecision(makeRequestCtx(), options);
+    expect(result).toMatchObject({
+      isError: true,
+      content: [{ type: "text", text: expect.stringContaining("attached:team") }],
+    });
+  });
+
+  it("returns an input_required elicitation with a vault enum on a modern request", () => {
+    const result = vaultSelectionDecision(
+      makeRequestCtx({
+        envelope: { [CLIENT_CAPABILITIES_META_KEY]: { elicitation: { form: {} } } },
+      }),
+      options,
+    );
+    const request = (result as { inputRequests: Record<string, unknown> }).inputRequests[
+      ELICITATION_KEYS.vault
+    ] as { params: { requestedSchema: { properties: Record<string, unknown> } } };
+    expect(request.params.requestedSchema.properties["vault"]).toMatchObject({
+      type: "string",
+      enum: ["project", "attached:team"],
+    });
+  });
+
+  it("throws when no candidate vaults are given", () => {
+    expect(() =>
+      vaultSelectionDecision(
+        makeRequestCtx({
+          envelope: { [CLIENT_CAPABILITIES_META_KEY]: { elicitation: { form: {} } } },
+        }),
+        [],
+      ),
+    ).toThrow(/at least one candidate vault/);
+  });
+});

--- a/tests/remember-vault-selection.unit.test.ts
+++ b/tests/remember-vault-selection.unit.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ServerContext as SdkServerContext } from "@modelcontextprotocol/server";
+import type { ServerContext } from "../src/server-context.js";
+import type { Vault } from "../src/vault.js";
+import { resolveWriteVaultForRemember } from "../src/tools/remember.js";
+import type { ProjectInfo } from "../src/project.js";
+import { ELICITATION_KEYS } from "../src/helpers/mrtr.js";
+
+const CLIENT_CAPABILITIES_META_KEY = "io.modelcontextprotocol/clientCapabilities";
+
+const mainVault = { provenance: "main", writable: true } as unknown as Vault;
+const projectVault = {
+  provenance: "project-local",
+  vaultFolderName: ".mnemonic",
+  writable: true,
+} as unknown as Vault;
+const attachedWritable = {
+  provenance: "project-attached",
+  writable: true,
+  attachmentRef: { projectSlug: "team", projectName: "Team" },
+} as unknown as Vault;
+const attachedReadOnly = {
+  provenance: "project-attached",
+  writable: false,
+  attachmentRef: { projectSlug: "ro", projectName: "Read Only" },
+} as unknown as Vault;
+
+const project: ProjectInfo = {
+  id: "project-id",
+  name: "Project",
+  root: "/repo",
+};
+
+function fakeCtx(options: { projectVault: Vault | null; attachments: Vault[] }): ServerContext {
+  return {
+    vaultManager: {
+      main: mainVault,
+      getOrCreateProjectVault: vi.fn().mockResolvedValue(options.projectVault),
+      getAttachmentsForProject: vi.fn().mockReturnValue(options.attachments),
+    },
+    configStore: {
+      getProjectAttachments: vi.fn().mockResolvedValue([]),
+    },
+  } as unknown as ServerContext;
+}
+
+function modernRequestCtx(inputResponses?: Record<string, unknown>): SdkServerContext {
+  return {
+    mcpReq: {
+      id: 1,
+      method: "tools/call",
+      inputResponses,
+      envelope: { [CLIENT_CAPABILITIES_META_KEY]: { elicitation: { form: {} } } },
+      requestState: () => undefined,
+      signal: new AbortController().signal,
+    },
+  } as unknown as SdkServerContext;
+}
+
+function legacyRequestCtx(): SdkServerContext {
+  return {
+    mcpReq: {
+      id: 1,
+      method: "tools/call",
+      inputResponses: undefined,
+      envelope: undefined,
+      requestState: () => undefined,
+      signal: new AbortController().signal,
+    },
+  } as unknown as SdkServerContext;
+}
+
+describe("resolveWriteVaultForRemember", () => {
+  it("writes to the main vault for global scope", async () => {
+    const result = await resolveWriteVaultForRemember(
+      fakeCtx({ projectVault, attachments: [] }),
+      "/repo",
+      "global",
+      project,
+      modernRequestCtx(),
+    );
+    expect(result).toEqual({ kind: "vault", vault: mainVault });
+  });
+
+  it("falls back to the main vault for project scope without a resolvable project vault", async () => {
+    const result = await resolveWriteVaultForRemember(
+      fakeCtx({ projectVault: null, attachments: [] }),
+      "/repo",
+      "project",
+      project,
+      modernRequestCtx(),
+    );
+    expect(result).toEqual({ kind: "vault", vault: mainVault });
+  });
+
+  it("picks the project vault directly when it is the only write candidate", async () => {
+    const result = await resolveWriteVaultForRemember(
+      fakeCtx({ projectVault, attachments: [] }),
+      "/repo",
+      "project",
+      project,
+      modernRequestCtx(),
+    );
+    expect(result).toEqual({ kind: "vault", vault: projectVault });
+  });
+
+  it("elicits a vault choice on a modern client when writable attached vaults exist, excluding read-only attachments", async () => {
+    const result = await resolveWriteVaultForRemember(
+      fakeCtx({ projectVault, attachments: [attachedWritable, attachedReadOnly] }),
+      "/repo",
+      "project",
+      project,
+      modernRequestCtx(),
+    );
+    expect(result.kind).toBe("decision");
+
+    const input = (result as { result: { inputRequests: Record<string, unknown> } }).result
+      .inputRequests[ELICITATION_KEYS.vault] as {
+      params: { requestedSchema: { properties: Record<string, unknown> } };
+    };
+    expect(input.params.requestedSchema.properties["vault"]).toMatchObject({
+      type: "string",
+      enum: ["project", "attached:team"],
+    });
+  });
+
+  it("writes to the chosen writable attached vault on retry", async () => {
+    const result = await resolveWriteVaultForRemember(
+      fakeCtx({ projectVault, attachments: [attachedWritable] }),
+      "/repo",
+      "project",
+      project,
+      modernRequestCtx({
+        [ELICITATION_KEYS.vault]: { action: "accept", content: { vault: "attached:team" } },
+      }),
+    );
+    expect(result).toEqual({ kind: "vault", vault: attachedWritable });
+  });
+
+  it("re-elicits when the retry names a vault outside the candidate list instead of writing to an unoffered vault", async () => {
+    const result = await resolveWriteVaultForRemember(
+      fakeCtx({ projectVault, attachments: [attachedWritable] }),
+      "/repo",
+      "project",
+      project,
+      modernRequestCtx({
+        [ELICITATION_KEYS.vault]: { action: "accept", content: { vault: "attached:forged" } },
+      }),
+    );
+    expect(result.kind).toBe("decision");
+  });
+
+  it("falls back to the project vault when the user declines the vault picker", async () => {
+    const result = await resolveWriteVaultForRemember(
+      fakeCtx({ projectVault, attachments: [attachedWritable] }),
+      "/repo",
+      "project",
+      project,
+      modernRequestCtx({
+        [ELICITATION_KEYS.vault]: { action: "decline" },
+      }),
+    );
+    expect(result).toEqual({ kind: "vault", vault: projectVault });
+  });
+
+  it("never elicits on a legacy client and picks the project vault", async () => {
+    const result = await resolveWriteVaultForRemember(
+      fakeCtx({ projectVault, attachments: [attachedWritable, attachedReadOnly] }),
+      "/repo",
+      "project",
+      project,
+      legacyRequestCtx(),
+    );
+    expect(result).toEqual({ kind: "vault", vault: projectVault });
+  });
+});


### PR DESCRIPTION
## Summary

Single PR, 5 stages executed sequentially.

## Workflow Artifacts

**Research:**

- Research: MCP 2026-07-28 spec changes and TypeScript SDK v2 migration impact — - `initialize`/`initialized` handshake **retired** (SEP-2575, SEP-2567)

**Plan:**

- Plan: Migrate mnemonic to MCP 2026-07-28 spec and TypeScript SDK v2 — Single PR, 5 stages executed sequentially.

**Context:**

- Request: Migrate mnemonic to MCP 2026-07-28 specification and TypeScript SDK v2 — Migrate mnemonic from `@modelcontextprotocol/sdk` v1.x to `@modelcontextprotocol/server` v2.0.0, adopting the MCP 2026-07-28 protocol revision.

## Notes / References

_Detailed notes in `.mnemonic/notes/`:_

- `.mnemonic/notes/plan-migrate-mnemonic-to-mcp-2026-07-28-spec-and-typescript--072d79cd.md` — Plan: Migrate mnemonic to MCP 2026-07-28 spec and TypeScript SDK v2 _(plan)_
- `.mnemonic/notes/request-migrate-mnemonic-to-mcp-2026-07-28-specification-and-fda9bab6.md` — Request: Migrate mnemonic to MCP 2026-07-28 specification and TypeScript SDK v2 _(context)_
- `.mnemonic/notes/research-mcp-2026-07-28-spec-changes-and-typescript-sdk-v2-m-57bad211.md` — Research: MCP 2026-07-28 spec changes and TypeScript SDK v2 migration impact _(research)_

---

_Generated from 3 design decision note(s) in `.mnemonic/notes/`. Run `/update-pr` to regenerate._