### PR TITLE
Document-source chunk embedding

### DIFF
--- a/.mnemonic/notes/document-source-attachment-five-bugs-found-and-fixed-via-pac-24bedd4b.md
+++ b/.mnemonic/notes/document-source-attachment-five-bugs-found-and-fixed-via-pac-24bedd4b.md
@@ -8,13 +8,15 @@ tags:
   - fixed
 lifecycle: permanent
 createdAt: '2026-07-29T21:44:03.817Z'
-updatedAt: '2026-07-29T21:44:30.910Z'
+updatedAt: '2026-08-01T20:35:22.137Z'
 role: review
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
   - id: pack-d-document-source-attachment-dogfood-pack-and-a-b-c-con-4f75a70c
+    type: related-to
+  - id: document-source-chunk-embeddings-specified-but-never-deliver-6e867617
     type: related-to
 memoryVersion: 1
 ---

--- a/.mnemonic/notes/document-source-attachments-design-delivery-and-verification-1517e52b.md
+++ b/.mnemonic/notes/document-source-attachments-design-delivery-and-verification-1517e52b.md
@@ -9,7 +9,7 @@ tags:
   - decision
 lifecycle: permanent
 createdAt: '2026-08-01T09:26:59.248Z'
-updatedAt: '2026-08-01T20:35:22.138Z'
+updatedAt: '2026-08-01T20:43:23.908Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
@@ -21,6 +21,8 @@ relatedTo:
     type: related-to
   - id: document-source-chunk-embeddings-specified-but-never-deliver-6e867617
     type: explains
+  - id: plan-deliver-document-source-chunk-semantic-retrieval-embedd-dba90b71
+    type: follows
 memoryVersion: 1
 ---
 Consolidates the completed document-source attachment workflow (request, research, two design reviews, six-stage plan, stage review) into one permanent canonical note. Source notes are deleted; durable detail remains in the related permanent notes.

--- a/.mnemonic/notes/document-source-attachments-design-delivery-and-verification-1517e52b.md
+++ b/.mnemonic/notes/document-source-attachments-design-delivery-and-verification-1517e52b.md
@@ -9,7 +9,7 @@ tags:
   - decision
 lifecycle: permanent
 createdAt: '2026-08-01T09:26:59.248Z'
-updatedAt: '2026-08-01T09:27:10.056Z'
+updatedAt: '2026-08-01T20:35:22.138Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
@@ -19,6 +19,8 @@ relatedTo:
     type: related-to
   - id: pack-d-document-source-attachment-dogfood-pack-and-a-b-c-con-4f75a70c
     type: related-to
+  - id: document-source-chunk-embeddings-specified-but-never-deliver-6e867617
+    type: explains
 memoryVersion: 1
 ---
 Consolidates the completed document-source attachment workflow (request, research, two design reviews, six-stage plan, stage review) into one permanent canonical note. Source notes are deleted; durable detail remains in the related permanent notes.

--- a/.mnemonic/notes/document-source-chunk-embeddings-specified-but-never-deliver-6e867617.md
+++ b/.mnemonic/notes/document-source-chunk-embeddings-specified-but-never-deliver-6e867617.md
@@ -11,10 +11,13 @@ tags:
   - bug
 lifecycle: permanent
 createdAt: '2026-08-01T20:35:12.274Z'
-updatedAt: '2026-08-01T20:35:12.274Z'
+updatedAt: '2026-08-01T20:35:22.137Z'
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: document-source-attachment-five-bugs-found-and-fixed-via-pac-24bedd4b
+    type: related-to
 memoryVersion: 1
 ---
 The canonical design note `document-source-attachments-design-delivery-and-verification-1517e52b` explicitly specified that document-source chunks be embedded, with lexical-only as the fail-soft fallback. Line 41: "embedding failures publish with lexical-only coverage" — a contract that only makes sense if embeddings are the primary path. Line 42 lists `embeddingCompatibilityIdentity` as part of the generation manifest, implying embeddings are produced and need a compatibility fingerprint for invalidation. Line 43 frames document chunks as full participants in recall ranking ("result diversity enforced after final scoring"), consistent with semantic+lexical hybrid fusion.

--- a/.mnemonic/notes/document-source-chunk-embeddings-specified-but-never-deliver-6e867617.md
+++ b/.mnemonic/notes/document-source-chunk-embeddings-specified-but-never-deliver-6e867617.md
@@ -1,0 +1,30 @@
+---
+title: >-
+  Document-source chunk embeddings specified but never delivered
+  (spec-vs-implementation gap)
+tags:
+  - attachments
+  - document-source
+  - retrieval
+  - architecture
+  - decision
+  - bug
+lifecycle: permanent
+createdAt: '2026-08-01T20:35:12.274Z'
+updatedAt: '2026-08-01T20:35:12.274Z'
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+The canonical design note `document-source-attachments-design-delivery-and-verification-1517e52b` explicitly specified that document-source chunks be embedded, with lexical-only as the fail-soft fallback. Line 41: "embedding failures publish with lexical-only coverage" — a contract that only makes sense if embeddings are the primary path. Line 42 lists `embeddingCompatibilityIdentity` as part of the generation manifest, implying embeddings are produced and need a compatibility fingerprint for invalidation. Line 43 frames document chunks as full participants in recall ranking ("result diversity enforced after final scoring"), consistent with semantic+lexical hybrid fusion.
+
+What shipped in 0.38.0 (PR #292, commit a8e3322) and remains today: document chunks are lexical-only. `buildGenerationFromFiles` (src/document-source-index.ts) never calls `embed()`, and `DocumentGeneration` (src/retrieval-document.ts) has no embeddings map — verified via `git log -S "embed(" -- src/document-source-index.ts src/document-sync.ts` (empty) and `git log -S "chunkEmbeddings|embeddings: Map" -- src/retrieval-document.ts` (empty). `collectDocumentChunkCandidates` (src/document-recall.ts) uses only `computeLexicalScore`; document results render in a trailing `## Document Results` section, never fused into the note RRF ranking. So lexical-only is not the fallback the spec described — it is the only path.
+
+The scaffolding was laid as if to support the spec but the wiring never landed: `GenerationManifest.embeddingCompatibilityIdentity` exists but its value is just `${extractorId}::${extractorVersion}::${chunkerId}::${chunkerVersion}` (extractor+chunker, not the embedding model), so it cannot actually serve its named invalidation purpose. `DOCUMENT_SOURCE_LIMITS.maxEmbeddingWork = 10000` ("max chunks to embed per sync") is dead config — referenced only by a unit test asserting its numeric range, never by production code.
+
+The gap was then rationalized as a feature. The five-bugs note `document-source-attachment-five-bugs-found-and-fixed-via-pac-24bedd4b` (Bug 2) says "the lexical-only document-source chunks even though they need no embeddings" — reframing lexical-only as the intended design, directly contradicting the canonical note. The canonical note was never corrected.
+
+Downstream symptoms a user hit in 0.39.1 against the Platform attachment: a document containing MarkAsCompleted/MarkAsFailed/MarkAsCancelled was retrievable only with `minSimilarity: 1` (semantic suppressed), and in normal queries the `## Document Results` section truncated below memory results because chunks have no semantic vector to fuse into the main RRF ranking. Separately, heading text extraction dropped inline-code spans (e.g. `### \`MarkAsCompleted()\`` -> ""), compounding the lexical weakness.
+
+Implication: this is an unimplemented spec, not "future work." The fail-soft contract and manifest scaffolding are already half in place, so the work to complete it is moderate: add a chunk-embedding map to DocumentGeneration, embed chunk projection text during syncDocumentSource (fail-soft, bounded by maxEmbeddingWork, reusing embed()/reindexEmbedConcurrency), make embeddingCompatibilityIdentity incorporate currentEmbeddingIdentity, fuse chunk cosine into the document-chunk score via RRF alongside the lexical composite, and decide chunk-embedding persistence (recompute per sync vs persist to disk keyed by chunkId+content hash). The biggest piece is persistence, since DocumentGeneration is in-memory and rebuilt from source bytes every sync.

--- a/.mnemonic/notes/document-source-chunk-embeddings-specified-but-never-deliver-6e867617.md
+++ b/.mnemonic/notes/document-source-chunk-embeddings-specified-but-never-deliver-6e867617.md
@@ -11,13 +11,15 @@ tags:
   - bug
 lifecycle: permanent
 createdAt: '2026-08-01T20:35:12.274Z'
-updatedAt: '2026-08-01T20:35:22.137Z'
+updatedAt: '2026-08-01T20:43:23.909Z'
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
   - id: document-source-attachment-five-bugs-found-and-fixed-via-pac-24bedd4b
     type: related-to
+  - id: plan-deliver-document-source-chunk-semantic-retrieval-embedd-dba90b71
+    type: derives-from
 memoryVersion: 1
 ---
 The canonical design note `document-source-attachments-design-delivery-and-verification-1517e52b` explicitly specified that document-source chunks be embedded, with lexical-only as the fail-soft fallback. Line 41: "embedding failures publish with lexical-only coverage" — a contract that only makes sense if embeddings are the primary path. Line 42 lists `embeddingCompatibilityIdentity` as part of the generation manifest, implying embeddings are produced and need a compatibility fingerprint for invalidation. Line 43 frames document chunks as full participants in recall ranking ("result diversity enforced after final scoring"), consistent with semantic+lexical hybrid fusion.

--- a/.mnemonic/notes/plan-deliver-document-source-chunk-semantic-retrieval-embedd-dba90b71.md
+++ b/.mnemonic/notes/plan-deliver-document-source-chunk-semantic-retrieval-embedd-dba90b71.md
@@ -11,11 +11,14 @@ tags:
   - architecture
 lifecycle: permanent
 createdAt: '2026-08-01T20:43:19.999Z'
-updatedAt: '2026-08-01T20:43:19.999Z'
+updatedAt: '2026-08-01T20:43:23.909Z'
 role: plan
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: document-source-chunk-embeddings-specified-but-never-deliver-6e867617
+    type: derives-from
 memoryVersion: 1
 ---
 Plan to deliver the document-source chunk semantic retrieval that the canonical design note (`document-source-attachments-design-delivery-and-verification-1517e52b`) specified but never shipped (see `document-source-chunk-embeddings-specified-but-never-deliver-6e867617`). Today document chunks are lexical-only and render in a trailing `## Document Results` section never fused into the note RRF ranking. This plan makes embeddings the primary channel with lexical as the fail-soft fallback (the spec's line-41 contract), fuses chunks into the unified ranking below notes, and persists chunk embeddings to disk for cheap re-syncs.

--- a/.mnemonic/notes/plan-deliver-document-source-chunk-semantic-retrieval-embedd-dba90b71.md
+++ b/.mnemonic/notes/plan-deliver-document-source-chunk-semantic-retrieval-embedd-dba90b71.md
@@ -1,0 +1,52 @@
+---
+title: >-
+  Plan: deliver document-source chunk semantic retrieval (embeddings +
+  persistence + RRF fusion)
+tags:
+  - plan
+  - attachments
+  - document-source
+  - retrieval
+  - embeddings
+  - architecture
+lifecycle: permanent
+createdAt: '2026-08-01T20:43:19.999Z'
+updatedAt: '2026-08-01T20:43:19.999Z'
+role: plan
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+Plan to deliver the document-source chunk semantic retrieval that the canonical design note (`document-source-attachments-design-delivery-and-verification-1517e52b`) specified but never shipped (see `document-source-chunk-embeddings-specified-but-never-deliver-6e867617`). Today document chunks are lexical-only and render in a trailing `## Document Results` section never fused into the note RRF ranking. This plan makes embeddings the primary channel with lexical as the fail-soft fallback (the spec's line-41 contract), fuses chunks into the unified ranking below notes, and persists chunk embeddings to disk for cheap re-syncs.
+
+## Decisions (resolved)
+
+- **No privacy settings gate.** Embedding provider is env-configured; local Ollama is the privacy-preserving default. Document-source attachments add one sentence to the existing embedding-privacy docs: attaching an external repo sends its chunk content to the configured embedding provider — use a local provider or don't attach if content is restricted. Privacy-oriented users use Ollama or don't attach; no per-attachment toggle, no new config field.
+- **Recency, not popularity, for embedding-cap selection.** Popularity has no signal at index time (no query log, no view counts). Recency is git-native: compute per-path last-modified commit in one `git log --name-only --format=%H <indexedCommit>` pass, sort each document's chunks by lastModCommit descending, tie-break by source path. Key nuance: with Option B content-hash reuse, recency is only the selection priority for which still-unembedded chunks to embed this sync — NOT a progress cursor — so re-syncs never get stuck re-embedding recently-touched chunks; content-hash reuse handles incrementality. Ship plain recency first; a later tuning follow-up may add a small boost for top-level/overview chunks (heading ancestry depth ≤ 2) so stable-but-important core docs aren't starved.
+- **Option B persistence (similar to notes).** Per-attachment subdirectory under the project vault's already-gitignored `.mnemonic/embeddings/` (the project already centralizes all project embeddings there; `Storage` already accepts `embeddingsDirOverride`, used by submodule vaults). New lightweight `ChunkEmbeddingStorage` mirrors `Storage`'s embedding file IO but is keyed by string chunk IDs (slugged via `normalizePathToSlug`) — deliberately NOT forced through the `MemoryId` branded type, since chunk IDs aren't memory IDs (honors the codebase's make-invalid-states-unrepresentable principle). Reuses the `EmbeddingRecord` on-disk shape. Content hash stored per record so re-syncs reuse unchanged vectors and only embed new/changed chunks. Per-attachment staleness sweep on sync mirrors `removeStaleEmbeddings` (delete files whose chunkId isn't in the current generation). `remove-attachment` deletes the whole `.mnemonic/embeddings/doc-source/<attachmentId>/` dir.
+- **Document chunks rank below notes (resolves Fix D).** Chunks fuse into the unified recall ranking — not a trailing appendix — with a prior smaller than `ATTACHMENT_BOOST` (which is already smaller than `PROJECT_SCOPE_BOOST`). Net effect: project/main vault notes always rank above document chunks unless a document is a dramatically stronger semantic+lexical match. No truncation risk; the spec's "document chunks participate in recall ranking" (line 43) becomes true. Retire the `## Document Results` section.
+
+## Stages
+
+- [ ] **Stage 1 — Data model + storage.** Add `chunkEmbeddings: Map<ChunkId, EmbeddingRecord>` to `DocumentGeneration` (`src/retrieval-document.ts`). Add `embeddedChunkCount` and `embeddingFailures: Array<{ chunkId: string; reason: string }>` to `GenerationManifest`. Make `embeddingCompatibilityIdentity` incorporate `currentEmbeddingIdentity` (provider+model+dimensions+metric) so the existing `isGenerationCurrent` check triggers a full re-embed on model change. Bump `indexSchemaVersion` ("1" → "2"). Implement `ChunkEmbeddingStorage` (string chunk IDs, content-hash field) pointed at `.mnemonic/embeddings/doc-source/<attachmentId>/`.
+- [ ] **Stage 2 — Embed on sync (fail-soft, bounded, recency-priority, content-hash reuse).** New `embedGenerationChunks(gen, ctx, attachmentId)` step in `syncDocumentSource` (keep `buildGenerationFromFiles` pure). Embed each chunk's projection text = content + headingAncestry + sourcePath (reuse `joinHeadingAncestry`/enrichment). Reuse `ctx.config.reindexEmbedConcurrency` workers and `attempt("embed:chunk", …)` per chunk. Respect `DOCUMENT_SOURCE_LIMITS.maxEmbeddingWork` (finally wire the dead constant). Recency-priority selection of un-embedded chunks when cap bites. Reuse on-disk embeddings whose content hash + embedding identity match. Fail-soft: if embedding unavailable (Ollama down/quota), publish with `chunkEmbeddings` empty and `embeddingFailures` populated — lexical-only coverage, exactly the spec contract; do NOT fail the sync. Per-attachment staleness sweep after publish.
+- [ ] **Stage 4 — Recall fusion.** In `collectDocumentChunkCandidates` (`src/document-recall.ts`), embed the query once (already fail-soft via `attempt` in `recall.ts`), compute `safeCosineSimilarity(queryVec, chunkEmbedding)` for chunks with embeddings, fuse with the lexical composite using the note path's RRF primitives (`RRF_K`, dense ranks, `computeHybridScore`-style). When `queryVec` is null, keep lexical composite only. Expose `semanticScore`/`lexicalScore` split on `DocumentChunkRecallResult` for diagnostics (mirrors `RetrievalEvidence.scoreDecomposition`).
+- [ ] **Stage 5 — Unified ranking.** Fuse document chunks into the unified ranked list in `src/tools/recall.ts` with a prior < `ATTACHMENT_BOOST` so notes outrank them by default. Retire the trailing `## Document Results` section. Guarantee documents are visible (rank just below notes by default).
+- [ ] **Stage 6 — Verify + docs.** Unit: embed-during-sync with a fake provider, fail-soft when embedding unavailable (publishes lexical-only generation), `maxEmbeddingWork` cap, `embeddingCompatibilityIdentity` model-change invalidation, content-hash reuse, staleness sweep, `remove-attachment` cleanup. Integration: extend `tests/document-source.integration.test.ts` — semantic recall surfaces a chunk lexical-only misses; query-embedding-failure still returns lexical chunks; re-index on chunker/embedding-version bump via `isGenerationCurrent`. Dogfood: re-run `scripts/dogfood-document-source.mjs` (Pack D) and the real Platform attachment repro (MarkAsCompleted/MarkAsFailed/MarkAsCancelled with a NORMAL minSimilarity). Docs: add the one-sentence privacy note.
+
+## Constraints
+
+- No database, daemon, synced index in the source repo, or breaking default output shape. Reuse existing `embed()`, `currentEmbeddingIdentity`, `checkEmbeddingCompatibility`, `EmbeddingRecord`, `reindexEmbedConcurrency`, `removeStaleEmbeddings` pattern, `embeddingsDirOverride` mechanism. DocumentGeneration stays in-memory; chunk embeddings persist to disk separately.
+- Determinism: recency tie-break by source path; RRF ties by chunkId (mirror the note path's stable note-id tie-breaker).
+- Privacy: external providers receive chunk content — documented, not gated.
+
+## Open follow-ups (not blocking)
+
+- Recency tuning boost for top-level/overview chunks.
+- `sync` structured output currently omits document-source results (text-only) — minor gap noted in the five-bugs note; fold in `embeddedChunkCount`/`embeddingFailures` while adding structured doc-source results.
+- Lazy backfill on recall for chunks whose on-disk embedding is missing (mirror `embedMissingNotes` pre-recall) — decide after measuring cold-start latency.
+
+## Self-check
+
+Every stage is executable and maps to a concrete file/contract. No placeholders. The spec's fail-soft contract (line 41) is the acceptance gate: embedding failures publish with lexical-only coverage and recall never throws. Fresh adversarial review (typescript-code-review skill) is the final gate before merge.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -105,6 +105,8 @@ When `cwd` is present, recall searches the project vault first and then widens t
 
 The ranking pipeline is bounded and fail-soft. Semantic embeddings, an always-on lexical channel over compact projections, and semantic-conditioned graph expansion each produce channel ranks. RRF fuses those ranks, then applies bounded semantic-confidence, project, metadata, temporal, and canonical adjustments. Explicit high-confidence temporal windows still filter candidates before ranking. Lexical candidate generation reuses the existing session projection/token cache and TF-IDF machinery, without introducing a database or synced index.
 
+Document-source attachments feed document chunks into the same unified ranking. Each chunk is scored semantically (cosine against the query vector, when a persisted chunk embedding exists) and lexically (content + heading ancestry + source path), fused via RRF on the note-ranking scale, and given a bounded prior smaller than the attachment boost so memories outrank chunks by default. Chunks render inline in the ranked list rather than in a separate section.
+
 ```mermaid
 flowchart TD
     Query[recall query] --> Embed[Embed query text]
@@ -173,10 +175,11 @@ flowchart TD
 | `src/document-extractor.ts`    | Extractor registry for document-source media types                                            |
 | `src/markdown-extractor.ts`    | Markdown extractor for document-source attachments (uses MDAST)                               |
 | `src/markdown-chunker.ts`      | Heading-aware chunker that splits markdown into retrievable chunks                            |
-| `src/document-source-index.ts` | Document source index builder: enumerates blobs, extracts, chunks, publishes generations     |
-| `src/document-recall.ts`       | Collects document-chunk candidates for recall ranking pipeline                                 |
-| `src/document-sync.ts`         | Syncs document-source attachments: fetches commit, enumerates blobs, builds generation        |
-| `src/generation-storage.ts`    | Atomic generation storage with pointer-swap publication for document sources                  |
+| `src/document-source-index.ts` | Builds a document-source generation from extracted/chunked files and publishes it            |
+| `src/document-recall.ts`       | Collects and ranks document-chunk candidates via semantic+lexical RRF fusion                 |
+| `src/document-sync.ts`         | Syncs document-source attachments: fetch, enumerate, build generation, embed chunks (fail-soft)|
+| `src/chunk-embedding-storage.ts`| Persists per-attachment chunk embeddings to disk, keyed by chunk ID with content-hash reuse   |
+| `src/generation-storage.ts`    | Atomic in-memory generation storage with pointer-swap publication for document sources       |
 | `src/mutation-guard.ts`        | Guards mutation tools against document-source entity references                               |
 | `tests/`                       | Vitest unit and integration coverage, including MCP smoke tests                               |
 
@@ -222,7 +225,7 @@ Document-source attachments extend the attachment system to support read-only re
 
 - **RetrievalDocument**: represents a single file from a document-source attachment. Contains source path, blob OID, byte size, source media type, extraction metadata, and the extracted text content.
 - **RetrievalChunk**: a bounded segment of a document produced by a chunker. Contains heading ancestry, excerpt, and a stable chunk ID derived from the document ID and heading path.
-- **DocumentGeneration**: an atomic snapshot of all documents and chunks from one sync operation. Stored under per-attachment generation directories with a pointer-swap publication mechanism.
+- **DocumentGeneration**: an atomic snapshot of all documents, chunks, and chunk embeddings from one sync operation. Held in memory with an atomic pointer-swap publication mechanism; chunk embeddings persist separately to disk under `.mnemonic/embeddings/doc-source/<attachmentId>/`.
 
 ### Entity namespaces
 
@@ -243,18 +246,20 @@ The entity resolver in `src/document-entity-ref.ts` classifies references and ro
 Document-source attachments are indexed into atomic generations during sync:
 1. `sync` fetches the exact remote-tracking commit for the attachment's configured branch.
 2. Blobs matching the `include`/`exclude` glob patterns are enumerated from that commit.
-3. Each blob is extracted and chunked; fingerprints are compared against the current generation to skip unchanged content.
-4. A new generation is built in a temporary directory, validated, and atomically published by replacing a small pointer file.
-5. Readers capture one generation at request start and use it for the entire request.
+3. Each blob is extracted and chunked into a `DocumentGeneration` held in memory.
+4. Chunk vectors are embedded (fail-soft: if the embedding provider is unavailable, the generation still publishes with lexical-only coverage) and persisted to `.mnemonic/embeddings/doc-source/<attachmentId>/`, keyed by chunk ID with a content hash so unchanged chunks reuse their existing vector across syncs. A per-sync cap bounds embedding work; the most-recently-modified chunks are embedded first.
+5. The generation is atomically published via an in-memory pointer swap in `generation-storage.ts`; a provider/model/version change invalidates it and forces a full re-embed on the next sync.
+6. Readers capture one generation at request start and use it for the entire request.
 
 ### Recall integration
 
 Document chunks participate in the recall ranking pipeline alongside memory results:
-- Chunks enter the common semantic and lexical candidate pools before dense rank assignment.
+- Each chunk is scored semantically (cosine against the query vector, when an embedding exists) and lexically (content + heading ancestry + source path), then the two channels are fused via reciprocal-rank-fusion on the same scale as the note ranking.
+- Only positively-correlated chunks receive a semantic rank; anti-correlated or zero-cosine chunks contribute lexical evidence alone.
 - A per-document chunk cap prevents one document from consuming the candidate pool.
-- After final scoring, result diversity is enforced by scanning farther down the ranked list to refill the requested limit.
+- Document chunks are fused into the unified ranked list with a bounded prior smaller than the attachment boost, so memories outrank them by default while a dramatically stronger chunk can still rise; chunks render inline rather than in a separate section.
 - Document chunks are excluded from graph, canonical-memory, role, lifecycle, relationship, confidence, and temporal contributions.
-- Results carry `kind: "document-chunk"` with source path, heading ancestry, excerpt, attachment identity, and a revision-qualified retrieval handle.
+- Results carry `kind: "document-chunk"` with source path, heading ancestry, excerpt, attachment identity, a revision-qualified retrieval handle, and optional `semanticScore`/`lexicalScore` diagnostics.
 
 ### Mutation rejection
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 - Document-source chunk heading ancestry now retains text from `inlineCode`, `strong`, `emphasis`, `link`, and `footnoteReference` nodes. Previously `getHeadingText` only kept plain `text` children, so headings like `### \`MarkAsCompleted()\`` were stored empty or garbled (e.g. `" and "`, `": Polling-Based Completion"`), corrupting both display and chunk IDs. `markdownChunker.chunkerVersion` bumped `"1"` → `"2"`.
 - `sync` now re-indexes a document-source attachment when the extractor/chunker version or embedding-compatibility identity changes, even if the pinned commit is unchanged. Previously the reuse check compared only `indexedCommit`, so a chunker fix would not take effect for already-attached repos until the source commit changed.
 - Document-source chunk scoring now includes heading ancestry and source path alongside content (weighted 0.5 / 0.35 / 0.15), so navigation-style queries matching headings or paths surface relevant chunks instead of relying on body prose alone.
+- `get` no longer fails with a structured-content schema error when fetching a plain memory by id. The ordered `items` note branch now admits `alwaysLoad` and `relatedTo`, matching the `notes` array and what the handler emits.
 
 ## [0.39.1] - 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `mnemonic` will be documented in this file.
 
 The format is loosely based on Keep a Changelog and uses semver-style version headings.
 
+## [Unreleased]
+
+### Fixed
+
+- Document-source chunk heading ancestry now retains text from `inlineCode`, `strong`, `emphasis`, `link`, and `footnoteReference` nodes. Previously `getHeadingText` only kept plain `text` children, so headings like `### \`MarkAsCompleted()\`` were stored empty or garbled (e.g. `" and "`, `": Polling-Based Completion"`), corrupting both display and chunk IDs. `markdownChunker.chunkerVersion` bumped `"1"` → `"2"`.
+- `sync` now re-indexes a document-source attachment when the extractor/chunker version or embedding-compatibility identity changes, even if the pinned commit is unchanged. Previously the reuse check compared only `indexedCommit`, so a chunker fix would not take effect for already-attached repos until the source commit changed.
+- Document-source chunk scoring now includes heading ancestry and source path alongside content (weighted 0.5 / 0.35 / 0.15), so navigation-style queries matching headings or paths surface relevant chunks instead of relying on body prose alone.
+
 ## [0.39.1] - 2026-08-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,21 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 
 ## [Unreleased]
 
+## [0.40.0] - 2026-08-01
+
+### Added
+
+- Document-source chunks are now retrieved by meaning as well as keyword matching, so a section answers your question even when it uses different words. Chunks appear inline in recall results, ranked just below your memories by default.
+- Document-source chunk embeddings persist locally and are reused across syncs, so re-syncing an unchanged attachment skips re-embedding and finishes fast.
+- Document-source attachment content is sent to the configured embedding provider to build chunk vectors; use a local provider (or don't attach) for restricted content.
+
 ### Fixed
 
 - Document-source chunk heading ancestry now retains text from `inlineCode`, `strong`, `emphasis`, `link`, and `footnoteReference` nodes. Previously `getHeadingText` only kept plain `text` children, so headings like `### \`MarkAsCompleted()\`` were stored empty or garbled (e.g. `" and "`, `": Polling-Based Completion"`), corrupting both display and chunk IDs. `markdownChunker.chunkerVersion` bumped `"1"` → `"2"`.
 - `sync` now re-indexes a document-source attachment when the extractor/chunker version or embedding-compatibility identity changes, even if the pinned commit is unchanged. Previously the reuse check compared only `indexedCommit`, so a chunker fix would not take effect for already-attached repos until the source commit changed.
 - Document-source chunk scoring now includes heading ancestry and source path alongside content (weighted 0.5 / 0.35 / 0.15), so navigation-style queries matching headings or paths surface relevant chunks instead of relying on body prose alone.
 
-## [0.39.1] - 2026-08-02
+## [0.39.1] - 2026-08-01
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Provider configuration is read from the process environment at startup. Only non
 
 After changing `EMBED_PROVIDER`, `EMBED_MODEL`, `EMBED_DIMENSIONS`, or endpoint semantics behind the same model alias, call the `sync` MCP tool with `{ "force": true }` to rebuild local embeddings. Until rebuilt, incompatible embeddings are skipped rather than compared across vector spaces, so semantic recall may return fewer results.
 
-Privacy note: Ollama keeps projection text local. OpenAI-compatible cloud proxies, native OpenAI, and Gemini send the note projection text used for embeddings to the configured external endpoint.
+Privacy note: Ollama keeps projection text local. OpenAI-compatible cloud proxies, native OpenAI, and Gemini send the note projection text used for embeddings to the configured external endpoint. Document-source attachments send each chunk's text (content plus heading ancestry and source path) to the configured embedding provider — use a local provider or do not attach a repository whose content is restricted.
 
 ### config.json
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1945,7 +1945,7 @@ VAULT_PATH = <span class="str">"/Users/you/mnemonic-vault"</span></pre>
         </tbody>
       </table>
     </div>
-    <p>Provider configuration is read from the process environment only. API keys are never stored in notes, embedding records, vault config, or git. Ollama keeps projection text local; OpenAI-compatible cloud proxies, native OpenAI, and Gemini send projection text to the configured external endpoint.</p>
+    <p>Provider configuration is read from the process environment only. API keys are never stored in notes, embedding records, vault config, or git. Ollama keeps projection text local; OpenAI-compatible cloud proxies, native OpenAI, and Gemini send projection text to the configured external endpoint. Document-source attachments send each chunk's text (content plus heading ancestry and source path) to the configured embedding provider.</p>
     <p>After changing <code>EMBED_PROVIDER</code>, <code>EMBED_MODEL</code>, <code>EMBED_DIMENSIONS</code>, or endpoint semantics behind the same model alias, call the <code>sync</code> MCP tool with <code>force: true</code>. Incompatible embeddings are skipped rather than compared across vector spaces.</p>
     <p>The main vault's <code>~/mnemonic-vault/config.json</code> holds machine-local settings you can edit by hand. Two fields are user-tunable:</p>
     <div class="config-table-wrap fade-up" style="margin-top:16px">
@@ -1985,7 +1985,7 @@ VAULT_PATH = <span class="str">"/Users/you/mnemonic-vault"</span></pre>
 
     <div class="agent-snippet fade-up" style="margin-top:24px">
       <h3>Search another repository's docs without copying them</h3>
-      <p>Attach an external repo and its markdown documentation becomes searchable alongside your memories. mnemonic reads the files, finds the right page for your question, and can return the exact section when you need the source text. Nothing is written back to that repository.</p>
+      <p>Attach an external repo and its markdown documentation becomes searchable alongside your memories. mnemonic reads the files, finds the right page for your question, and can return the exact section when you need the source text. It matches by meaning, not just by the words the docs use, so a question phrased differently from the documentation still lands on the right section. Nothing is written back to that repository.</p>
       <p>Give mnemonic the local path to the repo, then narrow which files count as documentation when the defaults aren't right for you:</p>
     </div>
     <div class="code-block fade-up" style="margin-top:16px">

--- a/docs/index.html
+++ b/docs/index.html
@@ -451,6 +451,7 @@
 
     .vault-pill.main    { background: rgba(74,222,128,0.12); color: var(--primary-lt); }
     .vault-pill.project { background: rgba(6,182,212,0.12);  color: var(--cyan-lt); }
+    .vault-pill.source  { background: rgba(251,191,36,0.14); color: #fbbf24; }
 
     .vault-card h3 {
       font-size: 1rem;
@@ -1410,7 +1411,7 @@
   <div class="container">
     <div class="section-label">How it works</div>
     <h2 class="section-title">Two vaults, one mental model.</h2>
-    <p class="section-desc">mnemonic routes memories between a private main vault and a shareable project vault based on where you are and what you're storing.</p>
+    <p class="section-desc">mnemonic routes memories between a private main vault and a shareable project vault based on where you are and what you're storing, and pulls read-only knowledge from external repositories you attach.</p>
 
     <div class="how-grid">
       <div class="vault-card fade-up">
@@ -1448,6 +1449,22 @@
 <span class="dir">    projections/</span>
 <span class="gray">      *.json  ← gitignored</span>
         </div>
+      </div>
+    </div>
+
+    <div class="vault-card fade-up" style="margin-top:32px;">
+      <div class="vault-card-header">
+        <div class="vault-pill source">document sources</div>
+      </div>
+      <p>Read-only knowledge from other repositories you point at, with no copying and nothing written back. Attach a repo and its markdown documentation becomes searchable alongside your memories, so context from adjacent projects, frameworks, or runbooks surfaces when it matters. <code style="font-family:JetBrains Mono,monospace;font-size:0.8em;color:var(--cyan-lt)">sync</code> pulls a pinned revision and indexes it; the index lives next to your project vault and is rebuilt on demand.</p>
+      <div class="file-tree">
+<span class="dir">external-repo/</span>
+<span class="gray">  docs/                   ← attached, read-only</span>
+<span class="note">    api.md</span>
+<span class="note">    getting-started.md</span>
+<span class="dir">your-project/.mnemonic/</span>
+<span class="dir">  embeddings/doc-source/</span>
+<span class="gray">    *.json  ← gitignored, rebuilt on sync</span>
       </div>
     </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@danielmarbach/mnemonic-mcp",
-      "version": "0.39.1",
+      "version": "0.40.0",
       "dependencies": {
         "@modelcontextprotocol/server": "^2.0.0",
         "gray-matter": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "A local MCP memory server backed by markdown + JSON files, synced via git",
   "type": "module",
   "repository": {

--- a/scripts/dogfood-document-source.mjs
+++ b/scripts/dogfood-document-source.mjs
@@ -300,7 +300,7 @@ async function main() {
             Array.isArray(d.headingAncestry) &&
             typeof d.excerpt === "string",
         ),
-      { count: dcs.length, sample: dcs.slice(0, 2), sourcePaths: [...new Set(dcs.map((d) => d.sourcePath))], textHasDocumentResults: recall.text.includes("Document Results") },
+      { count: dcs.length, sample: dcs.slice(0, 2), sourcePaths: [...new Set(dcs.map((d) => d.sourcePath))], textHasDocumentChunks: (recall.structured?.documentChunks?.length ?? 0) > 0, textHasChunkHandles: recall.text.includes("chunk:") },
     );
 
     // D5 — get resolves chunk: and doc: handles

--- a/src/chunk-embedding-storage.ts
+++ b/src/chunk-embedding-storage.ts
@@ -1,0 +1,159 @@
+import { promises as fs } from "fs";
+import path from "path";
+import type {
+  EmbeddingCompatibilityKey,
+  EmbeddingDimensions,
+  EmbeddingMetric,
+  EmbeddingModelId,
+  EmbeddingProviderId,
+  ISO8601DateString,
+} from "./brands.js";
+import {
+  embeddingCompatibilityKey,
+  embeddingDimensions,
+  embeddingMetric,
+  embeddingModelId,
+  embeddingProviderId,
+  isValidIsoDateString,
+} from "./brands.js";
+import { attempt } from "./error-utils.js";
+import { normalizePathToSlug } from "./retrieval-document.js";
+
+/**
+ * A persisted embedding record for a single retrieval chunk.
+ *
+ * Keyed by the plain-string form of a `ChunkId`. Chunk IDs are NOT `MemoryId`s
+ * (they are derived from attachment + document path + heading ancestry), so
+ * they deliberately reuse no branding from the note-embedding storage path.
+ */
+export interface ChunkEmbeddingRecord {
+  chunkId: string; // the ChunkId (branded string) serialized as plain string
+  contentHash: string; // hex sha256 of the chunk's projection text (set by Stage 2)
+  model: EmbeddingModelId;
+  provider?: EmbeddingProviderId;
+  dimensions?: EmbeddingDimensions;
+  metric?: EmbeddingMetric;
+  compatibilityKey?: EmbeddingCompatibilityKey;
+  embedding: number[];
+  updatedAt: ISO8601DateString;
+}
+
+/**
+ * File-backed storage for chunk embeddings.
+ *
+ * Owns a single directory (the per-attachment directory resolved by the caller,
+ * e.g. `.mnemonic/embeddings/doc-source/<attachmentId>/`). Files are named by
+ * the slugified chunk ID: `<slug(chunkId)>.json`.
+ */
+export class ChunkEmbeddingStorage {
+  constructor(private readonly dir: string) {}
+
+  async init(): Promise<void> {
+    await fs.mkdir(this.dir, { recursive: true });
+  }
+
+  private pathFor(chunkId: string): string {
+    return path.join(this.dir, normalizePathToSlug(chunkId) + ".json");
+  }
+
+  async read(chunkId: string): Promise<ChunkEmbeddingRecord | null> {
+    const raw = await attempt("chunk-embedding:read", () =>
+      fs.readFile(this.pathFor(chunkId), "utf-8"),
+    );
+    if (!raw.ok) return null;
+    const parsed = await attempt("chunk-embedding:read", (): unknown => JSON.parse(raw.value));
+    if (!parsed.ok) return null;
+    return validateChunkEmbeddingRecord(parsed.value);
+  }
+
+  async write(record: ChunkEmbeddingRecord): Promise<void> {
+    await fs.mkdir(this.dir, { recursive: true });
+    await fs.writeFile(this.pathFor(record.chunkId), JSON.stringify(record, null, 2), "utf-8");
+  }
+
+  async list(): Promise<ChunkEmbeddingRecord[]> {
+    const filesResult = await attempt(
+      "chunk-embedding:list",
+      () => fs.readdir(this.dir),
+      [] as string[],
+    );
+    const files = filesResult.ok ? filesResult.value : [];
+    const chunkIds = files
+      .filter((file) => file.endsWith(".json"))
+      .map((file) => file.replace(/\.json$/, ""));
+    const records = await Promise.all(chunkIds.map((id) => this.read(id)));
+    return records.filter((record): record is ChunkEmbeddingRecord => record !== null);
+  }
+
+  async remove(chunkId: string): Promise<void> {
+    await attempt("chunk-embedding:remove", () => fs.unlink(this.pathFor(chunkId)));
+  }
+
+  async removeAll(): Promise<void> {
+    await attempt("chunk-embedding:removeAll", () =>
+      fs.rm(this.dir, { recursive: true, force: true }),
+    );
+  }
+}
+
+/**
+ * Validate an unknown value as a `ChunkEmbeddingRecord`. Returns null on any
+ * shape mismatch so callers can fail-soft when a file is missing or corrupt.
+ */
+export function validateChunkEmbeddingRecord(value: unknown): ChunkEmbeddingRecord | null {
+  if (!isRecord(value)) return null;
+
+  const chunkId = asString(value["chunkId"]);
+  const contentHash = asString(value["contentHash"]);
+  const model = asString(value["model"]);
+  const updatedAt = asString(value["updatedAt"]);
+  const embedding = asNumberArray(value["embedding"]);
+  if (
+    chunkId === null ||
+    contentHash === null ||
+    model === null ||
+    updatedAt === null ||
+    embedding === null
+  ) {
+    return null;
+  }
+  if (!isValidIsoDateString(updatedAt)) return null;
+
+  const provider = asString(value["provider"]);
+  const dimensions = asPositiveInteger(value["dimensions"]);
+  const metric = asString(value["metric"]);
+  const compatibilityKey = asString(value["compatibilityKey"]);
+
+  return {
+    chunkId,
+    contentHash,
+    model: embeddingModelId(model),
+    provider: provider !== null ? embeddingProviderId(provider) : undefined,
+    dimensions: dimensions !== null ? embeddingDimensions(dimensions) : undefined,
+    metric: metric !== null ? embeddingMetric(metric) : undefined,
+    compatibilityKey:
+      compatibilityKey !== null ? embeddingCompatibilityKey(compatibilityKey) : undefined,
+    embedding,
+    updatedAt,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function asPositiveInteger(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null;
+}
+
+function asNumberArray(value: unknown): number[] | null {
+  if (!Array.isArray(value) || value.length === 0) return null;
+  for (const item of value) {
+    if (typeof item !== "number" || !Number.isFinite(item)) return null;
+  }
+  return value;
+}

--- a/src/document-recall.ts
+++ b/src/document-recall.ts
@@ -4,6 +4,36 @@ import type { ProjectAttachmentConfig } from "./vault.js";
 
 import { computeLexicalScore } from "./lexical.js";
 
+// Heading ancestry and the source path are high-signal retrieval cues (they are
+// where API terms like `MarkAsCompleted` most reliably appear) but they are
+// stored separately from chunk content and were previously never scored. We
+// score each surface independently and combine with weights that keep content
+// as the primary signal while letting navigation-style queries (matching
+// headings/paths rather than body prose) surface relevant chunks.
+const CONTENT_SCORE_WEIGHT = 0.5;
+const HEADING_SCORE_WEIGHT = 0.35;
+const PATH_SCORE_WEIGHT = 0.15;
+
+function joinHeadingAncestry(headingAncestry: Array<{ depth: number; text: string }>): string {
+  return headingAncestry.map((h) => h.text).join(" / ");
+}
+
+/**
+ * Composite lexical score over a chunk's content, heading ancestry, and source
+ * path. Each surface is scored with `computeLexicalScore` and combined with
+ * fixed weights so a match in any surface can promote the chunk.
+ */
+function scoreDocumentChunk(query: string, chunk: RetrievalChunk, sourcePath: string): number {
+  const contentScore = computeLexicalScore(query, chunk.content);
+  const headingScore = computeLexicalScore(query, joinHeadingAncestry(chunk.headingAncestry));
+  const pathScore = computeLexicalScore(query, sourcePath);
+  return (
+    CONTENT_SCORE_WEIGHT * contentScore +
+    HEADING_SCORE_WEIGHT * headingScore +
+    PATH_SCORE_WEIGHT * pathScore
+  );
+}
+
 // Helper to get all chunks from a generation
 function getAllChunks(attachmentId: string): RetrievalChunk[] {
   const generation = getCurrentGeneration(attachmentId);
@@ -50,17 +80,19 @@ export function collectDocumentChunkCandidates(
 
     const chunks = getAllChunks(attachmentId);
     for (const chunk of chunks) {
-      // Score using lexical matching before applying the per-document cap. A
-      // document's early chunks may have weak bigram-only matches that should
-      // not hide a later chunk with a much stronger exact match.
-      const score = computeLexicalScore(query, chunk.content);
+      // Score using composite lexical matching over content, heading ancestry,
+      // and source path before applying the per-document cap. A document's
+      // early chunks may have weak bigram-only matches that should not hide a
+      // later chunk with a much stronger exact match.
+      const sourcePath = generation.documents.get(chunk.documentId)?.sourcePath ?? chunk.documentId;
+      const score = scoreDocumentChunk(query, chunk, sourcePath);
       if (score <= 0) continue;
 
       candidates.push({
         kind: "document-chunk",
         chunkId: chunk.chunkId,
         documentId: chunk.documentId,
-        sourcePath: generation.documents.get(chunk.documentId)?.sourcePath ?? chunk.documentId,
+        sourcePath,
         headingAncestry: chunk.headingAncestry,
         excerpt: chunk.excerpt,
         contentMediaType: chunk.contentMediaType,

--- a/src/document-recall.ts
+++ b/src/document-recall.ts
@@ -3,6 +3,15 @@ import type { RetrievalChunk } from "./retrieval-document.js";
 import type { ProjectAttachmentConfig } from "./vault.js";
 
 import { computeLexicalScore } from "./lexical.js";
+import { safeCosineSimilarity } from "./embeddings.js";
+import { assignDenseRanks } from "./recall.js";
+
+// RRF constants mirror the note-ranking path (src/recall.ts) so chunk fused
+// scores sit on the same scale and can be interleaved into the unified recall
+// ranking (Stage 5).
+const RRF_K = 60;
+const RRF_SCALING_FACTOR = 3.0;
+const MAX_CHUNKS_PER_DOCUMENT = 5; // per-document chunk cap
 
 // Heading ancestry and the source path are high-signal retrieval cues (they are
 // where API terms like `MarkAsCompleted` most reliably appear) but they are
@@ -53,26 +62,65 @@ export interface DocumentChunkRecallResult {
   generationId: string;
   indexedCommit: string;
   score: number;
+  /** Raw cosine similarity against the query vector, when available. */
+  semanticScore?: number;
+  /** Composite lexical score over content, heading ancestry, and source path. */
+  lexicalScore?: number;
 }
 
 /**
- * Collect document-chunk candidates from document-source attachments for a recall query.
- * Applies per-document chunk cap and scores using lexical matching.
+ * Internal working item for chunk ranking: the chunk plus its per-channel
+ * scores and (once assigned) per-channel dense ranks.
+ */
+interface ChunkCandidate {
+  chunk: RetrievalChunk;
+  sourcePath: string;
+  attachmentId: string;
+  generationId: string;
+  indexedCommit: string;
+  lexicalScore: number;
+  semanticScore?: number;
+  semanticRank?: number;
+  lexicalRank?: number;
+}
+
+/**
+ * Reciprocal-rank fusion over the available channels, mirroring the note path.
+ * Missing channels contribute zero; the result is scaled identically to
+ * `computeHybridScore` so note and chunk scores remain comparable.
+ */
+function computeChunkFusedScore(candidate: ChunkCandidate): number {
+  const semanticContribution =
+    candidate.semanticRank !== undefined ? 1 / (RRF_K + candidate.semanticRank) : 0;
+  const lexicalContribution =
+    candidate.lexicalRank !== undefined ? 1 / (RRF_K + candidate.lexicalRank) : 0;
+  return (semanticContribution + lexicalContribution) * RRF_SCALING_FACTOR;
+}
+
+/**
+ * Collect document-chunk candidates from document-source attachments for a
+ * recall query. When a query embedding is available, chunks with persisted
+ * embeddings are scored semantically and fused with the lexical composite via
+ * reciprocal-rank fusion; otherwise (or when no chunk embedding exists) the
+ * lexical composite is used alone.
+ *
+ * Applies a per-document chunk cap and a global result limit.
  *
  * @param attachmentIds - List of attachment IDs to search
  * @param query - The recall query
  * @param limit - Maximum number of results to return
+ * @param queryVec - Query embedding vector, or null when embedding is unavailable
  * @returns Scored document-chunk results
  */
 export function collectDocumentChunkCandidates(
   attachmentIds: string[],
   query: string,
   limit: number,
+  queryVec: number[] | null = null,
 ): DocumentChunkRecallResult[] {
   if (limit <= 0) return [];
 
-  const candidates: DocumentChunkRecallResult[] = [];
-  const maxChunksPerDocument = 5; // per-document chunk cap
+  const candidates: ChunkCandidate[] = [];
 
   for (const attachmentId of attachmentIds) {
     const generation = getCurrentGeneration(attachmentId);
@@ -81,41 +129,104 @@ export function collectDocumentChunkCandidates(
     const chunks = getAllChunks(attachmentId);
     for (const chunk of chunks) {
       // Score using composite lexical matching over content, heading ancestry,
-      // and source path before applying the per-document cap. A document's
-      // early chunks may have weak bigram-only matches that should not hide a
-      // later chunk with a much stronger exact match.
+      // and source path. A document's early chunks may have weak bigram-only
+      // matches that should not hide a later chunk with a much stronger exact
+      // match, so candidate admission happens before the per-document cap.
       const sourcePath = generation.documents.get(chunk.documentId)?.sourcePath ?? chunk.documentId;
-      const score = scoreDocumentChunk(query, chunk, sourcePath);
-      if (score <= 0) continue;
+      const lexicalScore = scoreDocumentChunk(query, chunk, sourcePath);
+
+      // Semantic score only when the query vector and a persisted chunk
+      // embedding both exist. `safeCosineSimilarity` returns undefined on
+      // dimension mismatch, which is treated as "no semantic evidence".
+      let semanticScore: number | undefined;
+      if (queryVec) {
+        const embedding = generation.chunkEmbeddings.get(chunk.chunkId);
+        if (embedding) {
+          semanticScore = safeCosineSimilarity(queryVec, embedding.embedding);
+        }
+      }
+
+      if (lexicalScore <= 0 && (semanticScore === undefined || semanticScore <= 0)) continue;
 
       candidates.push({
-        kind: "document-chunk",
-        chunkId: chunk.chunkId,
-        documentId: chunk.documentId,
+        chunk,
         sourcePath,
-        headingAncestry: chunk.headingAncestry,
-        excerpt: chunk.excerpt,
-        contentMediaType: chunk.contentMediaType,
         attachmentId,
         generationId: generation.manifest.generationId,
         indexedCommit: generation.manifest.indexedCommit,
-        score,
+        lexicalScore,
+        semanticScore,
       });
     }
   }
 
+  // Assign dense ranks per channel, mirroring the note path. Only chunks with
+  // evidence in a channel participate in that channel's ranking; the rest keep
+  // an undefined rank (zero RRF contribution). A chunk gets a semantic rank only
+  // when it is POSITIVELY correlated with the query — anti-correlated or
+  // zero-cosine chunks contribute nothing to the semantic channel (matching the
+  // note path's minSimilarity gate), so a weak lexical match cannot earn a
+  // spurious RRF boost from a negative embedding score. Sorts are stable via
+  // the chunkId tie-break so ranking is deterministic.
+  const semanticRanked = candidates
+    .filter(
+      (c): c is ChunkCandidate & { semanticScore: number } =>
+        c.semanticScore !== undefined && c.semanticScore > 0,
+    )
+    .sort(
+      (a, b) => b.semanticScore - a.semanticScore || a.chunk.chunkId.localeCompare(b.chunk.chunkId),
+    );
+  assignDenseRanks(
+    semanticRanked,
+    (c) => c.semanticScore,
+    (c, rank) => {
+      c.semanticRank = rank;
+    },
+  );
+
+  const lexicalRanked = candidates
+    .filter((c) => c.lexicalScore > 0)
+    .sort(
+      (a, b) => b.lexicalScore - a.lexicalScore || a.chunk.chunkId.localeCompare(b.chunk.chunkId),
+    );
+  assignDenseRanks(
+    lexicalRanked,
+    (c) => c.lexicalScore,
+    (c, rank) => {
+      c.lexicalRank = rank;
+    },
+  );
+
   // Rank globally first, then cap each document's contribution. Applying the
   // cap while iterating chunks makes document order determine which matches
   // survive instead of relevance.
-  candidates.sort((a, b) => b.score - a.score);
+  candidates.sort(
+    (a, b) =>
+      computeChunkFusedScore(b) - computeChunkFusedScore(a) ||
+      a.chunk.chunkId.localeCompare(b.chunk.chunkId),
+  );
   const results: DocumentChunkRecallResult[] = [];
   const perDocumentCounts = new Map<string, number>();
   for (const candidate of candidates) {
-    const docCount = perDocumentCounts.get(candidate.documentId) ?? 0;
-    if (docCount >= maxChunksPerDocument) continue;
+    const docCount = perDocumentCounts.get(candidate.chunk.documentId) ?? 0;
+    if (docCount >= MAX_CHUNKS_PER_DOCUMENT) continue;
 
-    perDocumentCounts.set(candidate.documentId, docCount + 1);
-    results.push(candidate);
+    perDocumentCounts.set(candidate.chunk.documentId, docCount + 1);
+    results.push({
+      kind: "document-chunk",
+      chunkId: candidate.chunk.chunkId,
+      documentId: candidate.chunk.documentId,
+      sourcePath: candidate.sourcePath,
+      headingAncestry: candidate.chunk.headingAncestry,
+      excerpt: candidate.chunk.excerpt,
+      contentMediaType: candidate.chunk.contentMediaType,
+      attachmentId: candidate.attachmentId,
+      generationId: candidate.generationId,
+      indexedCommit: candidate.indexedCommit,
+      score: computeChunkFusedScore(candidate),
+      semanticScore: candidate.semanticScore,
+      lexicalScore: candidate.lexicalScore,
+    });
     if (results.length >= limit) break;
   }
 

--- a/src/document-source-index.ts
+++ b/src/document-source-index.ts
@@ -106,12 +106,14 @@ export function buildGenerationFromFiles(
     chunkerVersion: chunker.chunkerVersion,
     chunkerOptionsHash: "default",
     projectionSchemaVersion: "1",
-    indexSchemaVersion: "1",
+    indexSchemaVersion: "2",
     embeddingCompatibilityIdentity: `${extractor.extractorId}::${extractor.extractorVersion}::${chunker.chunkerId}::${chunker.chunkerVersion}`,
     sourceMediaTypeCounts: { [extractor.sourceMediaType]: documents.size },
     documentCount: documents.size,
     chunkCount: chunkMap.size,
+    embeddedChunkCount: 0,
     skippedFiles: skipped.map((s) => ({ path: s.path, reason: s.reason })),
+    embeddingFailures: [],
     builtAt: new Date().toISOString(),
   };
 
@@ -119,6 +121,7 @@ export function buildGenerationFromFiles(
     manifest,
     documents,
     chunks: chunkMap,
+    chunkEmbeddings: new Map(),
     sourceBytes,
     extractedText,
   };

--- a/src/document-sync.ts
+++ b/src/document-sync.ts
@@ -23,6 +23,37 @@ export interface DocumentSyncResult {
 }
 
 /**
+ * Decide whether an existing generation can be reused for the given commit
+ * against the currently registered extractor/chunker. A version bump (e.g. a
+ * fix to heading-text extraction) must re-index even when the pinned commit has
+ * not changed, otherwise stale derived state hides the fix.
+ */
+export function isGenerationCurrent(
+  generation:
+    | {
+        manifest: {
+          indexedCommit: string;
+          extractorVersion: string;
+          chunkerVersion: string;
+          embeddingCompatibilityIdentity: string;
+        };
+      }
+    | undefined,
+  indexedCommit: string,
+  extractor: { extractorVersion: string; extractorId: string },
+  chunker: { chunkerId: string; chunkerVersion: string },
+): generation is NonNullable<typeof generation> {
+  if (!generation) return false;
+  const expectedCompatibilityIdentity = `${extractor.extractorId}::${extractor.extractorVersion}::${chunker.chunkerId}::${chunker.chunkerVersion}`;
+  return (
+    generation.manifest.indexedCommit === indexedCommit &&
+    generation.manifest.extractorVersion === extractor.extractorVersion &&
+    generation.manifest.chunkerVersion === chunker.chunkerVersion &&
+    generation.manifest.embeddingCompatibilityIdentity === expectedCompatibilityIdentity
+  );
+}
+
+/**
  * Sync a document-source attachment: fetch the remote commit, enumerate blobs,
  * build a generation, and publish it.
  */
@@ -70,9 +101,28 @@ export async function syncDocumentSource(
     };
   }
 
-  // Check if we already have a generation for this commit
-  const currentGen = getCurrentGeneration(config.attachmentId);
-  if (currentGen && currentGen.manifest.indexedCommit === indexedCommit) {
+  // Check if we already have a generation for this commit that is still
+  // compatible with the currently registered extractor/chunker. A version bump
+  // (e.g. a fix to heading-text extraction) must re-index even when the pinned
+  // commit has not changed, otherwise stale derived state hides the fix.
+  const mediaType = config.acceptedMediaTypes[0] || "text/markdown";
+  const extractor = getExtractor(mediaType);
+  if (!extractor) {
+    return {
+      attachmentId: config.attachmentId,
+      projectSlug: config.projectSlug,
+      indexedCommit,
+      generationId: "",
+      documentCount: 0,
+      chunkCount: 0,
+      skippedFiles: [],
+      errors: [`no-extractor-for-media-type: ${mediaType}`],
+      status: "failed",
+      message: `No extractor registered for media type '${mediaType}'`,
+    };
+  }
+  const currentGen = getCurrentGeneration(config.attachmentId) ?? undefined;
+  if (isGenerationCurrent(currentGen, indexedCommit, extractor, markdownChunker)) {
     return {
       attachmentId: config.attachmentId,
       projectSlug: config.projectSlug,
@@ -135,24 +185,6 @@ export async function syncDocumentSource(
   }
 
   const files = enumerateResult.value;
-
-  // Get the extractor for the first accepted media type
-  const mediaType = config.acceptedMediaTypes[0] || "text/markdown";
-  const extractor = getExtractor(mediaType);
-  if (!extractor) {
-    return {
-      attachmentId: config.attachmentId,
-      projectSlug: config.projectSlug,
-      indexedCommit,
-      generationId: "",
-      documentCount: 0,
-      chunkCount: 0,
-      skippedFiles: [],
-      errors: [`no-extractor-for-media-type: ${mediaType}`],
-      status: "failed",
-      message: `No extractor registered for media type '${mediaType}'`,
-    };
-  }
 
   // Build the generation
   const buildResult = buildGenerationFromFiles(

--- a/src/document-sync.ts
+++ b/src/document-sync.ts
@@ -1,13 +1,26 @@
 import { simpleGit } from "simple-git";
 import path from "path";
+import { createHash } from "node:crypto";
 import { expandHomePath } from "./paths.js";
 import { getExtractor } from "./document-extractor.js";
 import { markdownChunker } from "./markdown-chunker.js";
 import { buildGenerationFromFiles } from "./document-source-index.js";
 import { getCurrentGeneration } from "./generation-storage.js";
 import { matchAnyGlob } from "./glob-match.js";
-import type { DocumentSourceAttachmentConfig } from "./vault.js";
+import { DOCUMENT_SOURCE_LIMITS } from "./retrieval-document.js";
+import type { DocumentGeneration, RetrievalChunk } from "./retrieval-document.js";
+import { ChunkEmbeddingStorage } from "./chunk-embedding-storage.js";
+import type { ChunkEmbeddingRecord } from "./chunk-embedding-storage.js";
 import { attempt, getErrorMessage } from "./error-utils.js";
+import {
+  checkEmbeddingCompatibility,
+  currentEmbeddingIdentity,
+  embed,
+  embeddingMetadata,
+} from "./embeddings.js";
+import { isoDateString } from "./brands.js";
+import type { DocumentSourceAttachmentConfig } from "./vault.js";
+import type { ServerContext } from "./server-context.js";
 
 export interface DocumentSyncResult {
   attachmentId: string;
@@ -23,10 +36,33 @@ export interface DocumentSyncResult {
 }
 
 /**
+ * Full embedding-compatibility identity: extractor + chunker + the current
+ * embedding identity (provider + model + dimensions + metric). A change to any
+ * component (e.g. a different embedding model) invalidates the generation and
+ * forces a full re-index/re-embed on the next sync.
+ */
+function buildEmbeddingCompatibilityIdentity(
+  extractor: { extractorId: string; extractorVersion: string },
+  chunker: { chunkerId: string; chunkerVersion: string },
+): string {
+  return [
+    extractor.extractorId,
+    extractor.extractorVersion,
+    chunker.chunkerId,
+    chunker.chunkerVersion,
+    currentEmbeddingIdentity.provider,
+    currentEmbeddingIdentity.model,
+    currentEmbeddingIdentity.dimensions ?? "",
+    currentEmbeddingIdentity.metric,
+  ].join("::");
+}
+
+/**
  * Decide whether an existing generation can be reused for the given commit
  * against the currently registered extractor/chunker. A version bump (e.g. a
- * fix to heading-text extraction) must re-index even when the pinned commit has
- * not changed, otherwise stale derived state hides the fix.
+ * fix to heading-text extraction) or an embedding-model change must re-index
+ * even when the pinned commit has not changed, otherwise stale derived state
+ * hides the fix.
  */
 export function isGenerationCurrent(
   generation:
@@ -35,6 +71,7 @@ export function isGenerationCurrent(
           indexedCommit: string;
           extractorVersion: string;
           chunkerVersion: string;
+          indexSchemaVersion: string;
           embeddingCompatibilityIdentity: string;
         };
       }
@@ -44,21 +81,189 @@ export function isGenerationCurrent(
   chunker: { chunkerId: string; chunkerVersion: string },
 ): generation is NonNullable<typeof generation> {
   if (!generation) return false;
-  const expectedCompatibilityIdentity = `${extractor.extractorId}::${extractor.extractorVersion}::${chunker.chunkerId}::${chunker.chunkerVersion}`;
+  const expectedCompatibilityIdentity = buildEmbeddingCompatibilityIdentity(extractor, chunker);
   return (
     generation.manifest.indexedCommit === indexedCommit &&
     generation.manifest.extractorVersion === extractor.extractorVersion &&
     generation.manifest.chunkerVersion === chunker.chunkerVersion &&
+    generation.manifest.indexSchemaVersion === "2" &&
     generation.manifest.embeddingCompatibilityIdentity === expectedCompatibilityIdentity
   );
 }
 
+function joinHeadingAncestry(headingAncestry: Array<{ depth: number; text: string }>): string {
+  return headingAncestry.map((h) => h.text).join(" / ");
+}
+
+interface ChunkEmbeddingWorkItem {
+  chunk: RetrievalChunk;
+  projectionText: string;
+  contentHash: string;
+  sourcePath: string;
+}
+
+/** Safety bound for the recency git-log walk so huge histories cannot stall a sync. */
+const RECENCY_LOG_LINE_BUDGET = 200_000;
+
+/**
+ * Compute the newest commit date for each source path with a single `git log`
+ * walk (newest-first). Used to prioritize which still-un-embedded chunks to
+ * embed first when the per-sync embedding work cap bites. Fail-soft: any git
+ * failure returns an empty map and callers fall back to source-path ordering.
+ */
+async function computePerPathLastMod(
+  resolvedLocalPath: string,
+  indexedCommit: string,
+  paths: string[],
+): Promise<Map<string, string>> {
+  const targetPaths = new Set(paths);
+  if (targetPaths.size === 0) return new Map();
+
+  const result = await attempt("sync:doc-source-recency", async () => {
+    const git = simpleGit(resolvedLocalPath);
+    const logOutput = await git.raw(["log", "--name-only", "--format=%cI", indexedCommit]);
+    const lastModByPath = new Map<string, string>();
+    let currentDate = "";
+    let lineCount = 0;
+    for (const line of logOutput.split("\n")) {
+      lineCount++;
+      if (lineCount > RECENCY_LOG_LINE_BUDGET) break;
+      if (line.length === 0) continue;
+      if (/^\d{4}-\d{2}-\d{2}T/.test(line)) {
+        currentDate = line;
+        continue;
+      }
+      if (currentDate === "") continue;
+      if (targetPaths.has(line) && !lastModByPath.has(line)) {
+        lastModByPath.set(line, currentDate);
+        if (lastModByPath.size === targetPaths.size) break;
+      }
+    }
+    return lastModByPath;
+  });
+
+  return result.ok ? result.value : new Map();
+}
+
+/**
+ * Embed generation chunks with fail-soft semantics (the spec's line-41
+ * contract): per-chunk embed failures are recorded in the manifest and never
+ * fail the sync. Reuses on-disk embeddings whose content hash + embedding
+ * identity match the current projection text. When the per-sync embedding work
+ * cap bites, the most-recently-modified chunks are embedded first; the rest
+ * remain lexical-only.
+ */
+export async function embedGenerationChunks(
+  gen: DocumentGeneration,
+  ctx: ServerContext,
+  attachmentId: string,
+  storage: ChunkEmbeddingStorage,
+  lastModByPath: Map<string, string>,
+  maxEmbeddingWork: number = DOCUMENT_SOURCE_LIMITS.maxEmbeddingWork,
+): Promise<void> {
+  const toEmbed: ChunkEmbeddingWorkItem[] = [];
+
+  for (const chunk of gen.chunks.values()) {
+    const sourcePath = gen.documents.get(chunk.documentId)?.sourcePath ?? chunk.documentId;
+    const projectionText = `${chunk.content}\n${joinHeadingAncestry(chunk.headingAncestry)}\n${sourcePath}`;
+    const contentHash = createHash("sha256").update(projectionText, "utf-8").digest("hex");
+
+    const existing = await storage.read(chunk.chunkId);
+    if (
+      existing &&
+      existing.contentHash === contentHash &&
+      checkEmbeddingCompatibility(existing, currentEmbeddingIdentity).status === "compatible"
+    ) {
+      gen.chunkEmbeddings.set(chunk.chunkId, existing);
+      continue;
+    }
+
+    toEmbed.push({ chunk, projectionText, contentHash, sourcePath });
+  }
+
+  // Recency-priority ordering: newest last-modified first, tie-break by source
+  // path for determinism. ISO dates compare lexicographically = chronologically.
+  toEmbed.sort((a, b) => {
+    const aLastMod = lastModByPath.get(a.sourcePath) ?? "";
+    const bLastMod = lastModByPath.get(b.sourcePath) ?? "";
+    if (aLastMod !== bLastMod) {
+      return aLastMod < bLastMod ? 1 : -1;
+    }
+    return a.sourcePath.localeCompare(b.sourcePath);
+  });
+
+  const capped = toEmbed.slice(0, maxEmbeddingWork);
+
+  const embeddingFailures: Array<{ chunkId: string; reason: string }> = [];
+  let index = 0;
+
+  const workerCount = Math.min(ctx.config.reindexEmbedConcurrency, Math.max(capped.length, 1));
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (true) {
+      const item = capped[index++];
+      if (!item) return;
+
+      const embedResult = await attempt(`embed:chunk:${attachmentId}`, async () => {
+        const vector = await embed(item.projectionText);
+        const meta = embeddingMetadata(vector);
+        const record: ChunkEmbeddingRecord = {
+          chunkId: item.chunk.chunkId,
+          contentHash: item.contentHash,
+          ...meta,
+          embedding: vector,
+          updatedAt: isoDateString(new Date().toISOString()),
+        };
+        await storage.write(record);
+        gen.chunkEmbeddings.set(item.chunk.chunkId, record);
+      });
+      if (!embedResult.ok) {
+        embeddingFailures.push({
+          chunkId: item.chunk.chunkId,
+          reason: getErrorMessage(embedResult.error),
+        });
+      }
+    }
+  });
+
+  await Promise.all(workers);
+
+  embeddingFailures.sort((a, b) => a.chunkId.localeCompare(b.chunkId));
+
+  gen.manifest.embeddedChunkCount = gen.chunkEmbeddings.size;
+  gen.manifest.embeddingFailures = embeddingFailures;
+}
+
+/**
+ * Delete on-disk chunk embeddings whose chunkId no longer exists in the current
+ * generation (mirrors `removeStaleEmbeddings` for note embeddings).
+ */
+export async function sweepStaleChunkEmbeddings(
+  storage: ChunkEmbeddingStorage,
+  currentChunkIds: Set<string>,
+): Promise<void> {
+  const onDisk = await storage.list();
+  for (const record of onDisk) {
+    if (!currentChunkIds.has(record.chunkId)) {
+      await storage.remove(record.chunkId);
+    }
+  }
+}
+
+function buildEmbeddingSummary(embedded: number, failed: number): string {
+  const parts: string[] = [];
+  if (embedded > 0) parts.push(`embedded ${embedded} chunk(s)`);
+  if (failed > 0) parts.push(`${failed} embedding failure(s)`);
+  return parts.length > 0 ? `, ${parts.join(", ")}` : "";
+}
+
 /**
  * Sync a document-source attachment: fetch the remote commit, enumerate blobs,
- * build a generation, and publish it.
+ * build a generation, embed chunk vectors (fail-soft), and publish it.
  */
 export async function syncDocumentSource(
   config: DocumentSourceAttachmentConfig,
+  ctx: ServerContext,
+  projectEmbeddingsDir: string | undefined,
 ): Promise<DocumentSyncResult> {
   const resolvedLocalPath = path.resolve(expandHomePath(config.localPath));
 
@@ -196,6 +401,56 @@ export async function syncDocumentSource(
     indexedCommit,
   );
 
+  // Override the embedding-compatibility identity so embedding-model changes
+  // invalidate the generation. `buildGenerationFromFiles` stays pure (it cannot
+  // import the embedding provider), so this happens here, before the generation
+  // is consumed.
+  const generation = getCurrentGeneration(config.attachmentId);
+  if (generation) {
+    generation.manifest.embeddingCompatibilityIdentity = buildEmbeddingCompatibilityIdentity(
+      extractor,
+      markdownChunker,
+    );
+  }
+
+  // Embed chunk vectors (fail-soft). When the embedding provider is unavailable
+  // or the project embeddings directory cannot be resolved, the generation
+  // still publishes with lexical-only coverage — the spec's line-41 contract.
+  if (generation && projectEmbeddingsDir) {
+    const chunkStorage = new ChunkEmbeddingStorage(
+      path.join(projectEmbeddingsDir, "doc-source", config.attachmentId),
+    );
+    const embedStep = await attempt("sync:doc-source-embed", async () => {
+      await chunkStorage.init();
+      const sourcePaths = Array.from(generation.documents.values(), (d) => d.sourcePath);
+      const lastModByPath = await computePerPathLastMod(
+        resolvedLocalPath,
+        indexedCommit,
+        sourcePaths,
+      );
+      await embedGenerationChunks(
+        generation,
+        ctx,
+        config.attachmentId,
+        chunkStorage,
+        lastModByPath,
+      );
+      await sweepStaleChunkEmbeddings(chunkStorage, new Set(generation.chunks.keys()));
+    });
+    if (!embedStep.ok) {
+      generation.manifest.embeddingFailures = [
+        { chunkId: "", reason: `embed-step-failed: ${getErrorMessage(embedStep.error)}` },
+      ];
+    }
+  }
+
+  const embeddingSummary = generation
+    ? buildEmbeddingSummary(
+        generation.manifest.embeddedChunkCount,
+        generation.manifest.embeddingFailures.length,
+      )
+    : "";
+
   return {
     attachmentId: config.attachmentId,
     projectSlug: config.projectSlug,
@@ -206,6 +461,6 @@ export async function syncDocumentSource(
     skippedFiles: buildResult.skippedFiles,
     errors: [],
     status: "indexed",
-    message: `Indexed ${buildResult.documentCount} documents, ${buildResult.chunkCount} chunks from ${indexedCommit.substring(0, 8)}.`,
+    message: `Indexed ${buildResult.documentCount} documents, ${buildResult.chunkCount} chunks from ${indexedCommit.substring(0, 8)}${embeddingSummary}.`,
   };
 }

--- a/src/markdown-chunker.ts
+++ b/src/markdown-chunker.ts
@@ -1,7 +1,7 @@
 import type { DocumentChunker, RetrievalChunk, DocumentId } from "./retrieval-document.js";
 import { deriveChunkId } from "./retrieval-document.js";
 import { parseBody, serializeBody } from "./markdown-ast.js";
-import type { Root, Heading, Content } from "mdast";
+import type { Root, Heading, Content, PhrasingContent } from "mdast";
 
 const MAX_CHUNK_CHARS = 4000;
 const MIN_CHUNK_CHARS = 50;
@@ -12,11 +12,42 @@ interface HeadingContext {
   occurrence: number;
 }
 
+// Extract readable text from any mdast phrasing content node.
+// Headings in API docs frequently wrap key terms in `inlineCode` (e.g.
+// `### \`MarkAsCompleted()\``), `strong`, `emphasis`, or `link` nodes. Dropping
+// those nodes left heading ancestry (and therefore chunk IDs and heading-based
+// retrieval) empty or garbled (e.g. " and ", ": Polling-Based Completion").
+function phrasingNodeText(node: PhrasingContent): string {
+  switch (node.type) {
+    case "text":
+    case "inlineCode":
+    case "html":
+      return node.value;
+    case "strong":
+    case "emphasis":
+    case "delete":
+    case "link":
+    case "linkReference":
+      return node.children.map((child) => phrasingNodeText(child)).join("");
+    case "image":
+    case "imageReference":
+      return node.alt ?? "";
+    case "footnoteReference":
+      return node.label ?? node.identifier ?? "";
+    case "break":
+      return " ";
+    default: {
+      // Exhaustiveness guard: if a future mdast release (or a remark plugin)
+      // adds a new PhrasingContent member, this assignment fails to compile,
+      // forcing a decision here rather than silently yielding empty headings.
+      const exhaustive: never = node;
+      return exhaustive;
+    }
+  }
+}
+
 function getHeadingText(node: Heading): string {
-  return node.children
-    .filter((c): c is { type: "text"; value: string } => c.type === "text")
-    .map((c) => c.value)
-    .join("");
+  return node.children.map((child) => phrasingNodeText(child)).join("");
 }
 
 function isHeadingNode(node: unknown): node is Heading {
@@ -89,7 +120,7 @@ function splitOversizedContent(
 
 export const markdownChunker: DocumentChunker = {
   chunkerId: "markdown-heading",
-  chunkerVersion: "1",
+  chunkerVersion: "2",
   chunkContentMediaType: "text/markdown",
 
   chunk(documentId: DocumentId, content: string): RetrievalChunk[] {

--- a/src/retrieval-document.ts
+++ b/src/retrieval-document.ts
@@ -1,4 +1,5 @@
 import type { Brand } from "./brands.js";
+import type { ChunkEmbeddingRecord } from "./chunk-embedding-storage.js";
 
 // Branded types for document and chunk IDs
 export type DocumentId = Brand<string, "DocumentId">;
@@ -46,7 +47,9 @@ export interface GenerationManifest {
   sourceMediaTypeCounts: Record<string, number>;
   documentCount: number;
   chunkCount: number;
+  embeddedChunkCount: number;
   skippedFiles: Array<{ path: string; reason: string }>;
+  embeddingFailures: Array<{ chunkId: string; reason: string }>;
   builtAt: string; // ISO 8601
 }
 
@@ -55,6 +58,7 @@ export interface DocumentGeneration {
   manifest: GenerationManifest;
   documents: Map<string, RetrievalDocument>; // documentId -> document
   chunks: Map<string, RetrievalChunk>; // chunkId -> chunk
+  chunkEmbeddings: Map<string, ChunkEmbeddingRecord>; // chunkId -> chunk embedding record
   sourceBytes: Map<string, Uint8Array>; // documentId -> raw source bytes
   extractedText: Map<string, string>; // documentId -> extracted text
 }

--- a/src/structured-content.ts
+++ b/src/structured-content.ts
@@ -174,6 +174,8 @@ export interface RecallResult extends Record<string, unknown> {
     documentId: string;
     score: number;
     boosted: number;
+    semanticScore?: number;
+    lexicalScore?: number;
     sourcePath: string;
     headingAncestry: Array<{ depth: number; text: string }>;
     excerpt: string;
@@ -1168,6 +1170,8 @@ export const RecallResultSchema = z.object({
         documentId: z.string().describe("Stable document identifier"),
         score: z.number().describe("Composite relevance score"),
         boosted: z.number().describe("Score after policy boosts"),
+        semanticScore: z.number().optional().describe("Semantic cosine similarity, when available"),
+        lexicalScore: z.number().optional().describe("Composite lexical score"),
         sourcePath: z.string().describe("Repository-relative source path"),
         headingAncestry: z
           .array(

--- a/src/structured-content.ts
+++ b/src/structured-content.ts
@@ -297,6 +297,8 @@ export interface GetResult extends Record<string, unknown> {
         tags: string[];
         lifecycle: NoteLifecycle;
         role?: NoteRole;
+        alwaysLoad?: boolean;
+        relatedTo?: Array<{ id: string; type: RelationshipType }>;
         vault: string;
         createdAt: string;
         updatedAt: string;
@@ -1624,6 +1626,8 @@ export const GetResultSchema = z.object({
           tags: z.array(z.string()),
           lifecycle: _NoteLifecycle,
           role: _NoteRole.optional(),
+          alwaysLoad: z.boolean().optional(),
+          relatedTo: z.array(z.object({ id: z.string(), type: _RelationshipType })).optional(),
           vault: _VaultLabel,
           createdAt: z.string(),
           updatedAt: z.string(),

--- a/src/tools/recall-helpers.ts
+++ b/src/tools/recall-helpers.ts
@@ -60,6 +60,10 @@ export function buildRecallCandidateContext(note: Note) {
 // Bounded policy priors remain smaller than meaningful multi-channel RRF agreement.
 export const PROJECT_SCOPE_BOOST = 0.005;
 export const ATTACHMENT_BOOST = PROJECT_SCOPE_BOOST / 2;
+// Document chunks fuse into the unified recall ranking with a prior smaller than
+// ATTACHMENT_BOOST so notes outrank chunks by default while documents stay visible
+// (rank just below notes; a dramatically stronger chunk can still rise).
+export const DOCUMENT_CHUNK_PRIOR = ATTACHMENT_BOOST / 2;
 
 interface LexicalCandidateOptions {
   excludeExisting: boolean;

--- a/src/tools/recall.ts
+++ b/src/tools/recall.ts
@@ -77,6 +77,7 @@ import {
   computeRecallDiversity,
   computeRecallRetrievalCoverage,
   ATTACHMENT_BOOST,
+  DOCUMENT_CHUNK_PRIOR,
 } from "./recall-helpers.js";
 import {
   collectDocumentChunkCandidates,
@@ -100,7 +101,7 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
         "- You already know the exact id; use `get`\n" +
         "- You just want to browse by tags or scope; use `list`\n\n" +
         "Returns: ranked matches (id, title, score, vault, tags, lifecycle, updatedAt), 1-hop relationship previews on top results, temporal history (mode: temporal), retrieval evidence (evidence: compact), including optional score decomposition, diagnostics: recallScopeNoteCount, diversity, retrievalCoverage, signalStrength.\n" +
-        "Document-source attachments return documentChunks (kind, chunkId, documentId, score, sourcePath, headingAncestry, excerpt, attachmentId, retrievalHandle).\n\n" +
+        "Document-source attachments return documentChunks (kind, chunkId, documentId, score, boosted, semanticScore, lexicalScore, sourcePath, headingAncestry, excerpt, attachmentId, sourceMediaType, extractionMetadata, indexedCommit, generationId, retrievalHandle); chunks rank below memories by default and render inline in the ranked list.\n\n" +
         "Typical next step:\n" +
         "- Use `get`, `update`, `relate`, or `consolidate` based on the results.",
       annotations: {
@@ -507,7 +508,12 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
         const attachmentConfigs = await ctx.configStore.getProjectAttachments(project.id);
         const docSourceAttachmentIds = getDocumentSourceAttachmentIds(attachmentConfigs);
         if (docSourceAttachmentIds.length > 0) {
-          const candidates = collectDocumentChunkCandidates(docSourceAttachmentIds, query, limit);
+          const candidates = collectDocumentChunkCandidates(
+            docSourceAttachmentIds,
+            query,
+            limit,
+            queryVec,
+          );
           for (const candidate of candidates) {
             const generation = getCurrentGeneration(candidate.attachmentId);
             const doc = generation?.documents.get(candidate.documentId);
@@ -517,6 +523,8 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
               documentId: candidate.documentId,
               score: candidate.score,
               boosted: candidate.score,
+              semanticScore: candidate.semanticScore,
+              lexicalScore: candidate.lexicalScore,
               sourcePath: doc?.sourcePath ?? candidate.sourcePath,
               headingAncestry: candidate.headingAncestry,
               excerpt: candidate.excerpt,
@@ -549,7 +557,7 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
         ? `Recall results for project **${project.name}** (scope: ${scope}):`
         : `Recall results (global):`;
 
-      const sections: string[] = [];
+      const noteEntries: Array<{ kind: "note"; score: number; sortKey: string; text: string }> = [];
       const structuredResults: Array<{
         id: string;
         title: string;
@@ -733,9 +741,12 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
             ? `\n${formatRetrievalEvidenceHint(retrievalEvidence, metadata?.role)}`
             : "";
           // Suppress raw related IDs when enriched preview is shown to avoid duplication
-          sections.push(
-            `${formatNote(note, score, relationships === undefined)}${provenanceLine}${evidenceLine}${formattedHistory}${formattedRelationships}`,
-          );
+          noteEntries.push({
+            kind: "note",
+            score: finalScore,
+            sortKey: id,
+            text: `${formatNote(note, score, relationships === undefined)}${provenanceLine}${evidenceLine}${formattedHistory}${formattedRelationships}`,
+          });
 
           structuredResults.push({
             id,
@@ -776,6 +787,44 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
         }
       }
 
+      // Fuse document chunks into the unified ranked list. Chunks get a prior
+      // smaller than ATTACHMENT_BOOST so notes outrank them by default while
+      // documents remain visible just below the notes; a dramatically stronger
+      // chunk match can still rise above weak note matches.
+      const chunkEntries: Array<{
+        kind: "document-chunk";
+        score: number;
+        sortKey: string;
+        text: string;
+      }> = [];
+      for (const dc of documentChunks) {
+        const headingStr =
+          dc.headingAncestry.length > 0
+            ? dc.headingAncestry.map((h) => `${"#".repeat(h.depth)} ${h.text}`).join(" > ")
+            : "(introduction)";
+        chunkEntries.push({
+          kind: "document-chunk",
+          score: dc.score + DOCUMENT_CHUNK_PRIOR,
+          sortKey: dc.chunkId,
+          text:
+            `- 📄 **${dc.sourcePath}** (document)\n` +
+            `  heading: ${headingStr}\n` +
+            `  ${dc.excerpt.slice(0, 150)}\n` +
+            `  \`${dc.retrievalHandle}\``,
+        });
+      }
+
+      type UnifiedEntry = (typeof noteEntries)[number] | (typeof chunkEntries)[number];
+      const unified: UnifiedEntry[] = [...noteEntries, ...chunkEntries];
+      unified.sort((a, b) => {
+        const delta = b.score - a.score;
+        if (Math.abs(delta) > 1e-9) return delta;
+        // tie-break: notes rank above chunks by default
+        if (a.kind !== b.kind) return a.kind === "note" ? -1 : 1;
+        return a.sortKey.localeCompare(b.sortKey); // deterministic
+      });
+      const unifiedText = unified.map((e) => e.text).join("\n\n---\n\n");
+
       let diversity: RecallResult["diversity"] | undefined;
       let retrievalCoverage: RecallRetrievalCoverage | undefined;
       if (structuredResults.length > 0) {
@@ -807,22 +856,7 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
       }
       const diagnosticsLine =
         diagnosticsParts.length > 0 ? `\n${diagnosticsParts.join(" | ")}` : "";
-      let textContent = `${header}${diagnosticsLine}\n\n${sections.join("\n\n---\n\n")}`;
-
-      // Add document chunk text rendering
-      if (documentChunks.length > 0) {
-        textContent += "\n\n## Document Results\n\n";
-        for (const dc of documentChunks) {
-          const headingStr =
-            dc.headingAncestry.length > 0
-              ? dc.headingAncestry.map((h) => `${"#".repeat(h.depth)} ${h.text}`).join(" > ")
-              : "(introduction)";
-          textContent += `- **${dc.sourcePath}** (${(dc.score * 100).toFixed(0)}%)\n`;
-          textContent += `  heading: ${headingStr}\n`;
-          textContent += `  ${dc.excerpt.slice(0, 150)}...\n`;
-          textContent += `  \`${dc.retrievalHandle}\`\n\n`;
-        }
-      }
+      const textContent = `${header}${diagnosticsLine}\n\n${unifiedText}`;
 
       const structuredContent: RecallResult = {
         action: "recalled",

--- a/src/tools/remove-attachment.ts
+++ b/src/tools/remove-attachment.ts
@@ -147,6 +147,19 @@ export function registerRemoveAttachmentTool(server: McpServer, ctx: ServerConte
         );
       }
 
+      // Clean up per-attachment chunk embeddings for document-source attachments
+      // (<gitRoot>/.mnemonic/embeddings/doc-source/<attachmentId>/).
+      if (removed.kind === "document-source") {
+        const projectVault = cwd ? await ctx.vaultManager.getProjectVaultIfExists(cwd) : null;
+        const embeddingsDir = projectVault?.storage.embeddingsDir;
+        if (embeddingsDir) {
+          const dir = path.join(embeddingsDir, "doc-source", removed.attachmentId);
+          await attempt("remove-attachment:clean-chunk-embeddings", () =>
+            fs.rm(dir, { recursive: true, force: true }),
+          );
+        }
+      }
+
       const updatedAttachments = currentAttachments.filter((_, i) => i !== attachmentIndex);
       await ctx.configStore.setProjectAttachments(project.id, updatedAttachments);
       ctx.vaultManager.removeAttachment(project.id, removed.projectSlug);

--- a/src/tools/sync.ts
+++ b/src/tools/sync.ts
@@ -224,9 +224,14 @@ export function registerSyncTool(server: McpServer, ctx: ServerContext): void {
           const documentSourceAttachments = attachmentConfigs.filter(
             (a): a is DocumentSourceAttachmentConfig => a.enabled && a.kind === "document-source",
           );
+          // Chunk embeddings live under the project vault's embeddings directory
+          // (.mnemonic/embeddings/doc-source/<attachmentId>/). When the project
+          // vault is missing, sync falls back to lexical-only coverage.
+          const projectVault = await ctx.vaultManager.getProjectVaultIfExists(cwd);
+          const projectEmbeddingsDir = projectVault?.storage.embeddingsDir;
           for (const docConfig of documentSourceAttachments) {
             const label = `doc-source:${docConfig.projectSlug}`;
-            const result = await syncDocumentSource(docConfig);
+            const result = await syncDocumentSource(docConfig, ctx, projectEmbeddingsDir);
             if (result.status === "indexed") {
               lines.push(`${label}: ${result.message}`);
               if (result.skippedFiles.length > 0) {

--- a/tests/__snapshots__/mcp-schema-contract.integration.test.ts.snap
+++ b/tests/__snapshots__/mcp-schema-contract.integration.test.ts.snap
@@ -4983,7 +4983,7 @@ Do not use this when:
 - You just want to browse by tags or scope; use \`list\`
 
 Returns: ranked matches (id, title, score, vault, tags, lifecycle, updatedAt), 1-hop relationship previews on top results, temporal history (mode: temporal), retrieval evidence (evidence: compact), including optional score decomposition, diagnostics: recallScopeNoteCount, diversity, retrievalCoverage, signalStrength.
-Document-source attachments return documentChunks (kind, chunkId, documentId, score, sourcePath, headingAncestry, excerpt, attachmentId, retrievalHandle).
+Document-source attachments return documentChunks (kind, chunkId, documentId, score, boosted, semanticScore, lexicalScore, sourcePath, headingAncestry, excerpt, attachmentId, sourceMediaType, extractionMetadata, indexedCommit, generationId, retrievalHandle); chunks rank below memories by default and render inline in the ranked list.
 
 Typical next step:
 - Use \`get\`, \`update\`, \`relate\`, or \`consolidate\` based on the results.",
@@ -5181,12 +5181,20 @@ Typical next step:
                 "description": "Result kind discriminator",
                 "type": "string",
               },
+              "lexicalScore": {
+                "description": "Composite lexical score",
+                "type": "number",
+              },
               "retrievalHandle": {
                 "description": "Revision-qualified handle for exact retrieval via get",
                 "type": "string",
               },
               "score": {
                 "description": "Composite relevance score",
+                "type": "number",
+              },
+              "semanticScore": {
+                "description": "Semantic cosine similarity, when available",
                 "type": "number",
               },
               "sourceMediaType": {

--- a/tests/__snapshots__/mcp-schema-contract.integration.test.ts.snap
+++ b/tests/__snapshots__/mcp-schema-contract.integration.test.ts.snap
@@ -2471,6 +2471,9 @@ Typical next step:
               {
                 "additionalProperties": false,
                 "properties": {
+                  "alwaysLoad": {
+                    "type": "boolean",
+                  },
                   "content": {
                     "type": "string",
                   },
@@ -2506,6 +2509,33 @@ Typical next step:
                       "name",
                     ],
                     "type": "object",
+                  },
+                  "relatedTo": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                        },
+                        "type": {
+                          "enum": [
+                            "related-to",
+                            "explains",
+                            "example-of",
+                            "supersedes",
+                            "derives-from",
+                            "follows",
+                          ],
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "id",
+                        "type",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
                   },
                   "relationships": {
                     "additionalProperties": false,

--- a/tests/chunk-embedding-storage.unit.test.ts
+++ b/tests/chunk-embedding-storage.unit.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, describe, expect, it } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import {
+  ChunkEmbeddingStorage,
+  validateChunkEmbeddingRecord,
+} from "../src/chunk-embedding-storage.js";
+import type { ChunkEmbeddingRecord } from "../src/chunk-embedding-storage.js";
+import {
+  embeddingCompatibilityKey,
+  embeddingDimensions,
+  embeddingMetric,
+  embeddingModelId,
+  embeddingProviderId,
+  isoDateString,
+} from "../src/brands.js";
+import { normalizePathToSlug } from "../src/retrieval-document.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+async function makeStorage(): Promise<{ dir: string; storage: ChunkEmbeddingStorage }> {
+  const base = await fs.mkdtemp(path.join(os.tmpdir(), "mnemonic-chunk-embedding-"));
+  tempDirs.push(base);
+  const dir = path.join(base, "att-1");
+  const storage = new ChunkEmbeddingStorage(dir);
+  await storage.init();
+  return { dir, storage };
+}
+
+/** Deterministic valid record for storage round-trips. */
+function makeRecord(overrides: Partial<ChunkEmbeddingRecord> = {}): ChunkEmbeddingRecord {
+  return {
+    chunkId: "att-1::docs/guide.md::Setup::0::0",
+    contentHash: "cafebabe0123",
+    model: embeddingModelId("test-model"),
+    provider: embeddingProviderId("ollama"),
+    dimensions: embeddingDimensions(3),
+    metric: embeddingMetric("cosine"),
+    compatibilityKey: embeddingCompatibilityKey(
+      "provider=ollama|model=test-model|dimensions=3|metric=cosine|inputMode=default",
+    ),
+    embedding: [1, 2, 3],
+    updatedAt: isoDateString("2026-01-01T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("ChunkEmbeddingStorage", () => {
+  it("round-trips a valid record with all fields preserved", async () => {
+    const { storage } = await makeStorage();
+    const record = makeRecord();
+
+    await storage.write(record);
+    const readBack = await storage.read(record.chunkId);
+
+    expect(readBack).not.toBeNull();
+    expect(readBack).toEqual(record);
+    expect(readBack?.chunkId).toBe(record.chunkId);
+    expect(readBack?.contentHash).toBe(record.contentHash);
+    expect(readBack?.embedding).toEqual([1, 2, 3]);
+    expect(readBack?.model).toBe("test-model");
+    expect(readBack?.updatedAt).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  it("returns null for a chunk with no persisted record", async () => {
+    const { storage } = await makeStorage();
+
+    await expect(storage.read("att-1::docs/missing.md::Intro::0::0")).resolves.toBeNull();
+  });
+
+  it("returns null for corrupt JSON and skips it in list", async () => {
+    const { dir, storage } = await makeStorage();
+    const chunkId = "att-1::docs/corrupt.md::Intro::0::0";
+    await fs.writeFile(
+      path.join(dir, `${normalizePathToSlug(chunkId)}.json`),
+      "{ not valid json",
+      "utf-8",
+    );
+
+    await expect(storage.read(chunkId)).resolves.toBeNull();
+    await expect(storage.list()).resolves.toEqual([]);
+  });
+
+  it("returns null for a well-formed file with the wrong shape and skips it in list", async () => {
+    const { dir, storage } = await makeStorage();
+    const chunkId = "att-1::docs/shape.md::Intro::0::0";
+    await fs.writeFile(
+      path.join(dir, `${normalizePathToSlug(chunkId)}.json`),
+      JSON.stringify({ chunkId, embedding: "not-an-array" }),
+      "utf-8",
+    );
+
+    await expect(storage.read(chunkId)).resolves.toBeNull();
+    await expect(storage.list()).resolves.toEqual([]);
+  });
+
+  it("lists only valid records and ignores corrupt siblings", async () => {
+    const { dir, storage } = await makeStorage();
+    const valid = makeRecord();
+    const corruptId = "att-1::docs/corrupt.md::Intro::0::0";
+    await storage.write(valid);
+    await fs.writeFile(
+      path.join(dir, `${normalizePathToSlug(corruptId)}.json`),
+      "garbage",
+      "utf-8",
+    );
+
+    const listed = await storage.list();
+
+    expect(listed).toHaveLength(1);
+    expect(listed[0]).toEqual(valid);
+  });
+
+  it("remove ignores a missing record without throwing", async () => {
+    const { storage } = await makeStorage();
+
+    await expect(
+      storage.remove("att-1::docs/never-written.md::Intro::0::0"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("removeAll deletes the directory and is idempotent on a missing directory", async () => {
+    const { dir, storage } = await makeStorage();
+    await storage.write(makeRecord());
+    expect(await storage.list()).toHaveLength(1);
+
+    await storage.removeAll();
+
+    await expect(fs.readdir(dir)).rejects.toThrow();
+    // Idempotent: removing an already-missing directory must not throw.
+    await expect(storage.removeAll()).resolves.toBeUndefined();
+    await expect(storage.removeAll()).resolves.toBeUndefined();
+  });
+
+  it("names files by the slugified chunk id", async () => {
+    const { dir, storage } = await makeStorage();
+    const chunkId = "att-1::docs/Guide.md::Setup & Config::0::0";
+    await storage.write(makeRecord({ chunkId }));
+
+    const expectedFile = path.join(dir, `${normalizePathToSlug(chunkId)}.json`);
+    await expect(fs.access(expectedFile)).resolves.toBeUndefined();
+    expect(normalizePathToSlug(chunkId)).toBe("att-1-docs-Guide-md-Setup-Config-0-0");
+    // The non-slugified chunkId must not be used verbatim as a file name.
+    const literalFile = path.join(dir, `${chunkId}.json`);
+    await expect(fs.access(literalFile)).rejects.toThrow();
+  });
+});
+
+describe("validateChunkEmbeddingRecord", () => {
+  it("accepts a fully-populated record", () => {
+    const record = makeRecord();
+    expect(validateChunkEmbeddingRecord(record)).toEqual(record);
+  });
+
+  it("accepts a minimal record without optional provider metadata", () => {
+    const minimal = makeRecord({
+      provider: undefined,
+      dimensions: undefined,
+      metric: undefined,
+      compatibilityKey: undefined,
+    });
+    const validated = validateChunkEmbeddingRecord(minimal);
+    expect(validated).not.toBeNull();
+    expect(validated?.provider).toBeUndefined();
+    expect(validated?.dimensions).toBeUndefined();
+    expect(validated?.metric).toBeUndefined();
+    expect(validated?.compatibilityKey).toBeUndefined();
+  });
+
+  it("rejects non-record values", () => {
+    expect(validateChunkEmbeddingRecord(null)).toBeNull();
+    expect(validateChunkEmbeddingRecord("nope")).toBeNull();
+    expect(validateChunkEmbeddingRecord([1, 2, 3])).toBeNull();
+  });
+
+  it("rejects an invalid updatedAt date", () => {
+    expect(
+      validateChunkEmbeddingRecord(makeRecord({ updatedAt: isoDateString("not-a-date") })),
+    ).toBeNull();
+  });
+});

--- a/tests/document-recall.unit.test.ts
+++ b/tests/document-recall.unit.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { collectDocumentChunkCandidates } from "../src/document-recall.js";
 import { buildGenerationFromFiles } from "../src/document-source-index.js";
-import { clearAllGenerations } from "../src/generation-storage.js";
+import { clearAllGenerations, getCurrentGeneration } from "../src/generation-storage.js";
 import { markdownChunker } from "../src/markdown-chunker.js";
 import { markdownExtractor } from "../src/markdown-extractor.js";
+import { embeddingModelId, isoDateString } from "../src/brands.js";
+import type { ChunkEmbeddingRecord } from "../src/chunk-embedding-storage.js";
 
 function makeFile(path: string, content: string): { path: string; bytes: Uint8Array } {
   return { path, bytes: new TextEncoder().encode(content) };
@@ -90,5 +92,70 @@ describe("collectDocumentChunkCandidates", () => {
 
     expect(results.length).toBeGreaterThan(0);
     expect(results[0]?.sourcePath).toBe("nservicebus-acceptancetesting.md");
+  });
+});
+
+describe("collectDocumentChunkCandidates semantic gating", () => {
+  beforeEach(() => {
+    clearAllGenerations();
+  });
+
+  it("does not give a semantic RRF boost to a negatively-correlated chunk", () => {
+    // A chunk with a strong lexical match but an anti-parallel embedding
+    // (cosine = -1) must not earn a semantic rank. The note path gates semantic
+    // candidates by minSimilarity; the chunk path must do the equivalent so an
+    // anti-correlated chunk cannot get a spurious RRF boost on top of its
+    // lexical match. The fused score must equal the lexical-only score.
+    const sections = Array.from(
+      { length: 6 },
+      (_, index) => `## Section ${index}\n\nThis component contains general documentation.`,
+    ).join("\n\n");
+    const files = [
+      makeFile(
+        "docs/components.md",
+        `# Components\n\n${sections}\n\n## Runner\n\nThe ComponentRunner starts the test component.`,
+      ),
+    ];
+    buildGenerationFromFiles(
+      "att-gate",
+      files,
+      ["text/markdown"],
+      markdownExtractor,
+      markdownChunker,
+      "abc123",
+    );
+
+    const gen = getCurrentGeneration("att-gate");
+    if (!gen) throw new Error("generation not published");
+    const runnerChunk = Array.from(gen.chunks.values()).find((c) =>
+      c.content.includes("ComponentRunner"),
+    );
+    if (!runnerChunk) throw new Error("runner chunk not found");
+
+    // Anti-parallel vectors: cosine similarity is exactly -1.
+    const queryVec: number[] = [1, 0, 0, 0];
+    const record: ChunkEmbeddingRecord = {
+      chunkId: runnerChunk.chunkId,
+      contentHash: "irrelevant-for-this-test",
+      model: embeddingModelId("test-model"),
+      embedding: [-1, 0, 0, 0],
+      updatedAt: isoDateString("2026-01-01T00:00:00Z"),
+    };
+    gen.chunkEmbeddings.set(runnerChunk.chunkId, record);
+
+    const withVec = collectDocumentChunkCandidates(["att-gate"], "ComponentRunner", 5, queryVec);
+    const withoutVec = collectDocumentChunkCandidates(["att-gate"], "ComponentRunner", 5, null);
+
+    const withVecTop = withVec[0];
+    const withoutVecTop = withoutVec[0];
+    if (!withVecTop || !withoutVecTop) {
+      throw new Error("expected a ranked chunk in both paths");
+    }
+
+    // The negatively-correlated semantic signal is recorded for diagnostics...
+    expect(withVecTop.semanticScore).toBe(-1);
+    // ...but it must NOT change the fused score: the chunk gets no semantic rank,
+    // so its score equals the lexical-only score.
+    expect(withVecTop.score).toBeCloseTo(withoutVecTop.score, 10);
   });
 });

--- a/tests/document-recall.unit.test.ts
+++ b/tests/document-recall.unit.test.ts
@@ -40,4 +40,55 @@ describe("collectDocumentChunkCandidates", () => {
     expect(results).toHaveLength(1);
     expect(results[0]?.excerpt).toContain("ComponentRunner");
   });
+
+  it("scores heading ancestry so navigation-style queries surface the right chunk", () => {
+    // Query terms appear in a heading wrapped in backticks, not in body prose.
+    // Without heading scoring the chunk would not match.
+    const files = [
+      makeFile(
+        "docs/api.md",
+        "# API\n\n## `MarkAsFailed()` and `MarkAsCancelled()`\n\nFailure methods for tests.",
+      ),
+    ];
+    buildGenerationFromFiles(
+      "att-2",
+      files,
+      ["text/markdown"],
+      markdownExtractor,
+      markdownChunker,
+      "abc123",
+    );
+
+    const results = collectDocumentChunkCandidates(
+      ["att-2"],
+      "MarkAsFailed MarkAsCancelled failure methods",
+      5,
+    );
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.headingAncestry.at(-1)?.text).toBe("MarkAsFailed() and MarkAsCancelled()");
+  });
+
+  it("scores source path so path-oriented queries surface the document", () => {
+    // Query terms appear only in the file path, not body or headings.
+    const files = [
+      makeFile(
+        "nservicebus-acceptancetesting.md",
+        "# Acceptance Testing\n\nGeneral overview content without the search term.",
+      ),
+    ];
+    buildGenerationFromFiles(
+      "att-3",
+      files,
+      ["text/markdown"],
+      markdownExtractor,
+      markdownChunker,
+      "abc123",
+    );
+
+    const results = collectDocumentChunkCandidates(["att-3"], "nservicebus acceptancetesting", 5);
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.sourcePath).toBe("nservicebus-acceptancetesting.md");
+  });
 });

--- a/tests/document-source.integration.test.ts
+++ b/tests/document-source.integration.test.ts
@@ -96,6 +96,74 @@ async function startFailingEmbeddingServer(): Promise<{ url: string; close: () =
   };
 }
 
+/**
+ * Deterministic 8-dim vector for arbitrary text. The moonshadow/quicksilver
+ * marker phrases below are mapped to the SAME vector by the fake server so
+ * semantically-associated texts (chunk projection vs query) get cosine 1 while
+ * everything else gets a stable unrelated vector.
+ */
+function hashVector(text: string): number[] {
+  let h1 = 2166136261;
+  let h2 = 16777619;
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i);
+    h1 = Math.imul(h1 ^ code, 16777619);
+    h2 = Math.imul(h2 + code, 2654435761);
+  }
+  const vector: number[] = [];
+  for (let i = 0; i < 8; i++) {
+    const component = ((h1 >>> (i * 4)) & 0xffff) / 65535;
+    // Keep components away from the marker vector's all-zero tail so unrelated
+    // texts never look semantically close to the marker phrase.
+    vector.push(0.05 + 0.9 * (Number.isFinite(component) ? component : 0));
+  }
+  return vector;
+}
+
+const SEMANTIC_MARKER_VECTOR = [1, 0, 0, 0, 0, 0, 0, 0] as const;
+
+/**
+ * Fake Ollama embedder with real vectors: maps the moonshadow-vault chunk
+ * marker and the quicksilver-core query marker to the same vector (semantic
+ * match) and every other text to a stable unrelated hash vector.
+ */
+async function startSemanticFakeEmbeddingServer(): Promise<{
+  url: string;
+  close: () => Promise<void>;
+}> {
+  const server = http.createServer((req, res) => {
+    if (req.method !== "POST" || req.url !== "/api/embed") {
+      res.writeHead(404).end();
+      return;
+    }
+    let raw = "";
+    req.setEncoding("utf-8");
+    req.on("data", (chunk) => {
+      raw += chunk;
+    });
+    req.on("end", () => {
+      const body = JSON.parse(raw) as { input?: string };
+      const input = body.input ?? "";
+      const vector =
+        input.includes("moonshadow-vault") || input.includes("quicksilver-core")
+          ? [...SEMANTIC_MARKER_VECTOR]
+          : hashVector(input);
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ embeddings: [vector] }));
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const addr = server.address();
+  if (!addr || typeof addr === "string") throw new Error("could not bind semantic server");
+  return {
+    url: `http://127.0.0.1:${addr.port}`,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
 describe("document-source attachment integration", () => {
   it("indexes, recalls, retrieves, and rejects mutation of document chunks end-to-end", async () => {
     const env = await setupDocSourceEnv();
@@ -222,6 +290,112 @@ describe("document-source attachment integration", () => {
     } finally {
       await session.close();
       await failing.close();
+      await rm(env.base, { recursive: true, force: true });
+    }
+  }, 60000);
+
+  it("semantic recall surfaces a chunk that lexical matching misses", async () => {
+    const env = await setupDocSourceEnv();
+    // A doc whose content, heading, and path share no tokens with the query,
+    // but whose embedding (via the fake semantic embedder) sits on the query
+    // vector: the only channel that can surface it is the semantic one.
+    await writeFile(
+      path.join(env.docsource, "docs", "moonshadow.md"),
+      `# Moonshadow Vault\n\nThe moonshadow-vault subsystem coordinates durable state transitions across worker nodes.\n`,
+    );
+    await git(env.docsource, "add", ".");
+    await git(env.docsource, "commit", "-m", "moonshadow");
+    await git(env.docsource, "fetch", "origin");
+
+    const embedding = await startSemanticFakeEmbeddingServer();
+    const session = await createPersistentMcpSession(env.mainVault, {
+      ollamaUrl: embedding.url,
+      disableGit: false,
+    });
+    try {
+      const cwd = env.consumer;
+      // remember(scope: project) creates the .mnemonic project vault so sync
+      // can persist chunk embeddings under <gitRoot>/.mnemonic/embeddings.
+      await session.callTool("remember", {
+        cwd,
+        title: "Semantic doc-source test note",
+        content: "Seed note that creates the project vault.",
+        scope: "project",
+        summary: "Create project vault for document-source embedding tests",
+      });
+
+      await session.callTool("add_attachment", {
+        cwd,
+        localPath: env.docsource,
+        kind: "document-source",
+        root: ".",
+        include: ["**/*.md"],
+        acceptedMediaTypes: ["text/markdown"],
+      });
+
+      const sync = await session.callTool("sync", { cwd });
+      expect(sync.text).toMatch(/doc-source:.*Indexed \d+ documents, \d+ chunks/);
+      // The semantic fake embedder works, so sync must not report failures.
+      expect(sync.text).not.toMatch(/embedding failure/);
+
+      const recall = await session.callTool("recall", {
+        cwd,
+        query: "quicksilver-core reconciliation",
+        limit: 10,
+        scope: "all",
+      });
+      const chunks = asArr(recall.structuredContent?.documentChunks);
+      const semanticChunk = chunks.find(
+        (c) => (c as { sourcePath?: string }).sourcePath === "docs/moonshadow.md",
+      );
+      expect(semanticChunk).toBeDefined();
+      // Cosine of the marker vector against itself is 1: a semantic-only hit.
+      expect((semanticChunk as { semanticScore?: number }).semanticScore).toBeGreaterThan(0.9);
+      // Lexical evidence is negligible (bigram noise on shared substrings), so
+      // the semantic channel is what surfaces this chunk.
+      const lexicalScore = (semanticChunk as { lexicalScore?: number }).lexicalScore ?? 0;
+      expect(lexicalScore).toBeLessThan(0.1);
+      // The semantic-only chunk outranks every lexical candidate.
+      expect((chunks[0] as { sourcePath?: string }).sourcePath).toBe("docs/moonshadow.md");
+      // The chunk is also visible in the unified text with a chunk: handle.
+      expect(recall.text).toContain("chunk:");
+      expect(recall.text).toContain("docs/moonshadow.md");
+    } finally {
+      await session.close();
+      await embedding.close();
+      await rm(env.base, { recursive: true, force: true });
+    }
+  }, 60000);
+
+  it("a second identical sync reports unchanged (isGenerationCurrent reuses the generation)", async () => {
+    const env = await setupDocSourceEnv();
+    const embedding = await startFakeEmbeddingServer();
+    const session = await createPersistentMcpSession(env.mainVault, {
+      ollamaUrl: embedding.url,
+      disableGit: false,
+    });
+    try {
+      const cwd = env.consumer;
+      await session.callTool("add_attachment", {
+        cwd,
+        localPath: env.docsource,
+        kind: "document-source",
+        root: ".",
+        include: ["**/*.md"],
+        acceptedMediaTypes: ["text/markdown"],
+      });
+
+      const first = await session.callTool("sync", { cwd });
+      expect(first.text).toMatch(/doc-source:.*Indexed \d+ documents, \d+ chunks/);
+
+      // Same commit, same extractor/chunker/embedding identity: the generation
+      // is current, so a second sync must not re-index.
+      const second = await session.callTool("sync", { cwd });
+      expect(second.text).toMatch(/doc-source:.*No changes on/);
+      expect(second.text).not.toMatch(/Indexed/);
+    } finally {
+      await session.close();
+      await embedding.close();
       await rm(env.base, { recursive: true, force: true });
     }
   }, 60000);

--- a/tests/document-sync-compat.unit.test.ts
+++ b/tests/document-sync-compat.unit.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { isGenerationCurrent } from "../src/document-sync.js";
+import { markdownExtractor } from "../src/markdown-extractor.js";
+import { markdownChunker } from "../src/markdown-chunker.js";
+
+const extractor = {
+  extractorId: markdownExtractor.extractorId,
+  extractorVersion: markdownExtractor.extractorVersion,
+};
+const chunker = {
+  chunkerId: markdownChunker.chunkerId,
+  chunkerVersion: markdownChunker.chunkerVersion,
+};
+
+function makeGeneration(
+  overrides: Partial<{
+    indexedCommit: string;
+    extractorVersion: string;
+    chunkerVersion: string;
+    embeddingCompatibilityIdentity: string;
+  }> = {},
+) {
+  return {
+    manifest: {
+      indexedCommit: overrides.indexedCommit ?? "commit-1",
+      extractorVersion: overrides.extractorVersion ?? extractor.extractorVersion,
+      chunkerVersion: overrides.chunkerVersion ?? chunker.chunkerVersion,
+      embeddingCompatibilityIdentity:
+        overrides.embeddingCompatibilityIdentity ??
+        `${extractor.extractorId}::${extractor.extractorVersion}::${chunker.chunkerId}::${chunker.chunkerVersion}`,
+    },
+  };
+}
+
+describe("isGenerationCurrent", () => {
+  it("returns true when commit and all versions match", () => {
+    expect(isGenerationCurrent(makeGeneration(), "commit-1", extractor, chunker)).toBe(true);
+  });
+
+  it("returns false when there is no generation", () => {
+    expect(isGenerationCurrent(undefined, "commit-1", extractor, chunker)).toBe(false);
+  });
+
+  it("returns false when the pinned commit changed", () => {
+    expect(isGenerationCurrent(makeGeneration(), "commit-2", extractor, chunker)).toBe(false);
+  });
+
+  it("returns false when the chunker version was bumped (re-index required)", () => {
+    const stale = makeGeneration({ chunkerVersion: "1" });
+    expect(isGenerationCurrent(stale, "commit-1", extractor, chunker)).toBe(false);
+  });
+
+  it("returns false when the extractor version changed", () => {
+    const stale = makeGeneration({ extractorVersion: "0" });
+    expect(isGenerationCurrent(stale, "commit-1", extractor, chunker)).toBe(false);
+  });
+
+  it("returns false when the embedding compatibility identity changed", () => {
+    const stale = makeGeneration({ embeddingCompatibilityIdentity: "stale::identity" });
+    expect(isGenerationCurrent(stale, "commit-1", extractor, chunker)).toBe(false);
+  });
+});

--- a/tests/document-sync-compat.unit.test.ts
+++ b/tests/document-sync-compat.unit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { isGenerationCurrent } from "../src/document-sync.js";
 import { markdownExtractor } from "../src/markdown-extractor.js";
 import { markdownChunker } from "../src/markdown-chunker.js";
+import { currentEmbeddingIdentity } from "../src/embeddings.js";
 
 const extractor = {
   extractorId: markdownExtractor.extractorId,
@@ -12,11 +13,25 @@ const chunker = {
   chunkerVersion: markdownChunker.chunkerVersion,
 };
 
+// Must mirror the production 8-part embedding-compatibility identity
+// (src/document-sync.ts buildEmbeddingCompatibilityIdentity).
+const expectedEmbeddingCompatibilityIdentity = [
+  extractor.extractorId,
+  extractor.extractorVersion,
+  chunker.chunkerId,
+  chunker.chunkerVersion,
+  currentEmbeddingIdentity.provider,
+  currentEmbeddingIdentity.model,
+  currentEmbeddingIdentity.dimensions ?? "",
+  currentEmbeddingIdentity.metric,
+].join("::");
+
 function makeGeneration(
   overrides: Partial<{
     indexedCommit: string;
     extractorVersion: string;
     chunkerVersion: string;
+    indexSchemaVersion: string;
     embeddingCompatibilityIdentity: string;
   }> = {},
 ) {
@@ -25,9 +40,9 @@ function makeGeneration(
       indexedCommit: overrides.indexedCommit ?? "commit-1",
       extractorVersion: overrides.extractorVersion ?? extractor.extractorVersion,
       chunkerVersion: overrides.chunkerVersion ?? chunker.chunkerVersion,
+      indexSchemaVersion: overrides.indexSchemaVersion ?? "2",
       embeddingCompatibilityIdentity:
-        overrides.embeddingCompatibilityIdentity ??
-        `${extractor.extractorId}::${extractor.extractorVersion}::${chunker.chunkerId}::${chunker.chunkerVersion}`,
+        overrides.embeddingCompatibilityIdentity ?? expectedEmbeddingCompatibilityIdentity,
     },
   };
 }

--- a/tests/document-sync-embeddings.unit.test.ts
+++ b/tests/document-sync-embeddings.unit.test.ts
@@ -1,0 +1,308 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import {
+  embedGenerationChunks,
+  isGenerationCurrent,
+  sweepStaleChunkEmbeddings,
+} from "../src/document-sync.js";
+import { ChunkEmbeddingStorage } from "../src/chunk-embedding-storage.js";
+import type { ChunkEmbeddingRecord } from "../src/chunk-embedding-storage.js";
+import { buildGenerationFromFiles } from "../src/document-source-index.js";
+import { clearAllGenerations, getCurrentGeneration } from "../src/generation-storage.js";
+import { markdownChunker } from "../src/markdown-chunker.js";
+import { markdownExtractor } from "../src/markdown-extractor.js";
+import type { DocumentGeneration } from "../src/retrieval-document.js";
+import {
+  embeddingCompatibilityKey,
+  embeddingDimensions,
+  embeddingMetric,
+  embeddingModelId,
+  embeddingProviderId,
+  isoDateString,
+} from "../src/brands.js";
+import type { ServerContext } from "../src/server-context.js";
+import type { EmbeddingRecord } from "../src/storage.js";
+import type { EmbeddingIdentity } from "../src/embeddings.js";
+import type {
+  EmbeddingCompatibilityKey,
+  EmbeddingDimensions,
+  EmbeddingMetric,
+  EmbeddingModelId,
+  EmbeddingProviderId,
+} from "../src/brands.js";
+
+const { embedMock, mockIdentity } = vi.hoisted(() => {
+  const embedMock = vi.fn<(text: string) => Promise<number[]>>();
+  const mockIdentity: EmbeddingIdentity = {
+    provider: "ollama" as EmbeddingProviderId,
+    model: "test-model" as EmbeddingModelId,
+    dimensions: 8 as EmbeddingDimensions,
+    metric: "cosine" as EmbeddingMetric,
+    compatibilityKey: "test-model" as EmbeddingCompatibilityKey,
+  };
+  return { embedMock, mockIdentity };
+});
+
+vi.mock("../src/embeddings.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/embeddings.js")>();
+  return {
+    ...actual,
+    embed: embedMock,
+    currentEmbeddingIdentity: mockIdentity,
+    embeddingMetadata: (
+      vector: number[],
+      identity: EmbeddingIdentity = mockIdentity,
+    ): Pick<
+      EmbeddingRecord,
+      "model" | "provider" | "dimensions" | "metric" | "inputMode" | "compatibilityKey"
+    > => ({
+      model: identity.model,
+      provider: identity.provider,
+      dimensions: vector.length as EmbeddingDimensions,
+      metric: identity.metric,
+      inputMode: identity.inputMode,
+      compatibilityKey: identity.compatibilityKey,
+    }),
+  };
+});
+
+const DEFAULT_EMBED_VECTOR = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8] as const;
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+beforeEach(() => {
+  clearAllGenerations();
+  embedMock.mockReset();
+  embedMock.mockImplementation(async () => [...DEFAULT_EMBED_VECTOR]);
+});
+
+function makeFile(filePath: string, content: string): { path: string; bytes: Uint8Array } {
+  return { path: filePath, bytes: new TextEncoder().encode(content) };
+}
+
+/** Build a real generation via buildGenerationFromFiles and return the published generation. */
+function buildGeneration(
+  attachmentId: string,
+  files: Array<{ path: string; bytes: Uint8Array }>,
+): DocumentGeneration {
+  buildGenerationFromFiles(
+    attachmentId,
+    files,
+    ["text/markdown"],
+    markdownExtractor,
+    markdownChunker,
+    "abc123",
+  );
+  const generation = getCurrentGeneration(attachmentId);
+  if (!generation) {
+    throw new Error(`generation for attachment '${attachmentId}' was not published`);
+  }
+  return generation;
+}
+
+/**
+ * Minimal ServerContext for embedGenerationChunks. The function only reads
+ * `config.reindexEmbedConcurrency`, so only that field is populated.
+ */
+function makeContext(): ServerContext {
+  return { config: { reindexEmbedConcurrency: 4 } } as unknown as ServerContext;
+}
+
+async function makeStorage(): Promise<{ dir: string; storage: ChunkEmbeddingStorage }> {
+  const base = await fs.mkdtemp(path.join(os.tmpdir(), "mnemonic-sync-embedding-"));
+  tempDirs.push(base);
+  const dir = path.join(base, "doc-source", "att-1");
+  const storage = new ChunkEmbeddingStorage(dir);
+  await storage.init();
+  return { dir, storage };
+}
+
+function makeStaleRecord(): ChunkEmbeddingRecord {
+  return {
+    chunkId: "att-1::docs/gone.md::Intro::0::0",
+    contentHash: "stale-content-hash",
+    model: embeddingModelId("test-model"),
+    provider: embeddingProviderId("ollama"),
+    dimensions: embeddingDimensions(8),
+    metric: embeddingMetric("cosine"),
+    compatibilityKey: embeddingCompatibilityKey("test-model"),
+    embedding: [0.9, 0, 0, 0, 0, 0, 0, 0],
+    updatedAt: isoDateString("2026-01-01T00:00:00.000Z"),
+  };
+}
+
+const twoChunkFiles = [
+  makeFile("docs/a.md", "# Alpha\n\nAlpha section content."),
+  makeFile("docs/b.md", "# Beta\n\nBeta section content."),
+];
+
+function isDefined(value: string | undefined): value is string {
+  return value !== undefined;
+}
+
+describe("embedGenerationChunks", () => {
+  it("embeds every chunk during sync and persists records to disk", async () => {
+    const { storage } = await makeStorage();
+    const gen = buildGeneration("att-1", twoChunkFiles);
+    expect(gen.chunks.size).toBe(2);
+
+    await embedGenerationChunks(gen, makeContext(), "att-1", storage, new Map());
+
+    expect(gen.chunkEmbeddings.size).toBe(2);
+    for (const chunk of gen.chunks.values()) {
+      expect(gen.chunkEmbeddings.get(chunk.chunkId)).toBeDefined();
+    }
+    expect(gen.manifest.embeddedChunkCount).toBe(2);
+    expect(gen.manifest.embeddingFailures).toEqual([]);
+    expect(embedMock).toHaveBeenCalledTimes(2);
+
+    const onDisk = await storage.list();
+    expect(onDisk).toHaveLength(2);
+    for (const record of onDisk) {
+      expect(record.embedding).toEqual([...DEFAULT_EMBED_VECTOR]);
+      expect(record.model).toBe("test-model");
+    }
+  });
+
+  it("fails soft when the embedding provider is unavailable", async () => {
+    embedMock.mockImplementation(async () => {
+      throw new Error("embedding service unavailable");
+    });
+    const { storage } = await makeStorage();
+    const gen = buildGeneration("att-1", twoChunkFiles);
+
+    await expect(
+      embedGenerationChunks(gen, makeContext(), "att-1", storage, new Map()),
+    ).resolves.toBeUndefined();
+
+    expect(gen.chunkEmbeddings.size).toBe(0);
+    expect(gen.manifest.embeddedChunkCount).toBe(0);
+    expect(gen.manifest.embeddingFailures).toHaveLength(2);
+    for (const failure of gen.manifest.embeddingFailures) {
+      expect(failure.reason).toContain("embedding service unavailable");
+    }
+    expect(await storage.list()).toHaveLength(0);
+  });
+
+  it("caps embedding work per sync and leaves the rest lexical-only", async () => {
+    const { storage } = await makeStorage();
+    const gen = buildGeneration("att-1", [
+      makeFile("docs/a.md", "# Alpha\n\nAlpha section content."),
+      makeFile("docs/b.md", "# Beta\n\nBeta section content."),
+      makeFile("docs/c.md", "# Gamma\n\nGamma section content."),
+    ]);
+    expect(gen.chunks.size).toBe(3);
+
+    await embedGenerationChunks(gen, makeContext(), "att-1", storage, new Map(), 1);
+
+    expect(embedMock).toHaveBeenCalledTimes(1);
+    expect(gen.chunkEmbeddings.size).toBe(1);
+    expect(gen.manifest.embeddedChunkCount).toBe(1);
+    const onDisk = await storage.list();
+    expect(onDisk).toHaveLength(1);
+    // Deterministic recency tie-break: docs/a.md sorts first.
+    expect(onDisk[0]?.chunkId).toContain("docs-a-md");
+  });
+
+  it("reuses on-disk embeddings for unchanged chunks and re-embeds only changed ones", async () => {
+    const { storage } = await makeStorage();
+    const fileA = makeFile("docs/a.md", "# Alpha\n\nAlpha section content.");
+    const fileB = makeFile("docs/b.md", "# Beta\n\nBeta section content.");
+
+    const firstGen = buildGeneration("att-1", [fileA, fileB]);
+    await embedGenerationChunks(firstGen, makeContext(), "att-1", storage, new Map());
+    expect(embedMock).toHaveBeenCalledTimes(2);
+
+    const secondGen = buildGeneration("att-1", [fileA, fileB]);
+    await embedGenerationChunks(secondGen, makeContext(), "att-1", storage, new Map());
+    expect(embedMock).toHaveBeenCalledTimes(2);
+    expect(secondGen.chunkEmbeddings.size).toBe(2);
+
+    const thirdGen = buildGeneration("att-1", [
+      fileA,
+      makeFile("docs/b.md", "# Beta\n\nBeta section content changed."),
+    ]);
+    await embedGenerationChunks(thirdGen, makeContext(), "att-1", storage, new Map());
+    expect(embedMock).toHaveBeenCalledTimes(3);
+    expect(thirdGen.chunkEmbeddings.size).toBe(2);
+    // The re-embedded chunk reflects the new content hash.
+    const changedChunkId = Array.from(thirdGen.chunks.keys()).find((id) =>
+      id.includes("docs-b-md"),
+    );
+    expect(isDefined(changedChunkId)).toBe(true);
+    if (isDefined(changedChunkId)) {
+      expect(thirdGen.chunkEmbeddings.get(changedChunkId)?.contentHash).not.toBe(
+        secondGen.chunkEmbeddings.get(changedChunkId)?.contentHash,
+      );
+    }
+  });
+
+  it("sweeps stale on-disk chunk embeddings not present in the generation", async () => {
+    const { storage } = await makeStorage();
+    const gen = buildGeneration("att-1", [
+      makeFile("docs/a.md", "# Alpha\n\nAlpha section content."),
+    ]);
+    const stale = makeStaleRecord();
+    await storage.write(stale);
+    expect(await storage.list()).toHaveLength(1);
+
+    await sweepStaleChunkEmbeddings(storage, new Set(gen.chunks.keys()));
+
+    expect(await storage.list()).toHaveLength(0);
+  });
+});
+
+describe("isGenerationCurrent with a different embedding identity", () => {
+  const extractor = {
+    extractorId: markdownExtractor.extractorId,
+    extractorVersion: markdownExtractor.extractorVersion,
+  };
+  const chunker = {
+    chunkerId: markdownChunker.chunkerId,
+    chunkerVersion: markdownChunker.chunkerVersion,
+  };
+
+  function expectedIdentityFor(model: string): string {
+    return [
+      extractor.extractorId,
+      extractor.extractorVersion,
+      chunker.chunkerId,
+      chunker.chunkerVersion,
+      mockIdentity.provider,
+      model,
+      mockIdentity.dimensions ?? "",
+      mockIdentity.metric,
+    ].join("::");
+  }
+
+  it("rejects a generation whose embedding identity predates an embedding-model change", () => {
+    const currentIdentity = expectedIdentityFor(mockIdentity.model);
+    const current = {
+      manifest: {
+        indexedCommit: "abc123",
+        extractorVersion: extractor.extractorVersion,
+        chunkerVersion: chunker.chunkerVersion,
+        indexSchemaVersion: "2",
+        embeddingCompatibilityIdentity: currentIdentity,
+      },
+    };
+    expect(isGenerationCurrent(current, "abc123", extractor, chunker)).toBe(true);
+
+    const stale = {
+      manifest: {
+        indexedCommit: "abc123",
+        extractorVersion: extractor.extractorVersion,
+        chunkerVersion: chunker.chunkerVersion,
+        indexSchemaVersion: "2",
+        embeddingCompatibilityIdentity: expectedIdentityFor("other-model"),
+      },
+    };
+    expect(isGenerationCurrent(stale, "abc123", extractor, chunker)).toBe(false);
+  });
+});

--- a/tests/markdown-chunker.unit.test.ts
+++ b/tests/markdown-chunker.unit.test.ts
@@ -10,7 +10,7 @@ describe("markdownChunker", () => {
     });
 
     it("has chunkerVersion", () => {
-      expect(markdownChunker.chunkerVersion).toBe("1");
+      expect(markdownChunker.chunkerVersion).toBe("2");
     });
 
     it("has chunkContentMediaType equal to 'text/markdown'", () => {
@@ -160,6 +160,45 @@ describe("markdownChunker", () => {
       const ids = chunks.map((c) => c.chunkId);
       const uniqueIds = new Set(ids);
       expect(uniqueIds.size).toBe(ids.length);
+    });
+  });
+
+  describe("heading text extraction", () => {
+    it("includes inline-code spans in heading ancestry (not just plain text)", () => {
+      // API docs wrap key terms in backticks. Dropping inlineCode nodes left
+      // ancestry empty or garbled (e.g. "", " and ", ": Polling-Based Completion").
+      const md =
+        "# Top\n\n## `MarkAsCompleted()`\n\nCall it.\n\n### `MarkAsFailed()` and `MarkAsCancelled()`\n\nFailure methods.\n\n#### `.Done()`: Polling-Based Completion\n\nPolling alternative.";
+      const chunks = markdownChunker.chunk(DOC_ID, md);
+
+      const completed = chunks.find((c) => c.headingAncestry.at(-1)?.text === "MarkAsCompleted()");
+      expect(completed, "expected a chunk under `MarkAsCompleted()`").toBeDefined();
+
+      const failed = chunks.find(
+        (c) => c.headingAncestry.at(-1)?.text === "MarkAsFailed() and MarkAsCancelled()",
+      );
+      expect(failed, "expected a chunk under `MarkAsFailed() and MarkAsCancelled()`").toBeDefined();
+
+      const done = chunks.find(
+        (c) => c.headingAncestry.at(-1)?.text === ".Done(): Polling-Based Completion",
+      );
+      expect(done, "expected a chunk under `.Done(): Polling-Based Completion`").toBeDefined();
+    });
+
+    it("extracts text from nested emphasis/strong/link phrasing", () => {
+      const md = "# Top\n\n## **Bold** _and_ [linked](url) term\n\nBody text here.";
+      const chunks = markdownChunker.chunk(DOC_ID, md);
+      const chunk = chunks.find((c) => c.headingAncestry.at(-1)?.text === "Bold and linked term");
+      expect(chunk).toBeDefined();
+    });
+
+    it("extracts footnote reference labels in heading ancestry", () => {
+      // A footnote reference needs a matching definition to be recognized as a
+      // FootnoteReference node rather than literal text.
+      const md = "# Top\n\n## Cited notes[^1]\n\n[^1]: Definition.\n\nBody text here.";
+      const chunks = markdownChunker.chunk(DOC_ID, md);
+      const chunk = chunks.find((c) => c.headingAncestry.at(-1)?.text === "Cited notes1");
+      expect(chunk).toBeDefined();
     });
   });
 

--- a/tests/mcp-schema-contract.integration.test.ts
+++ b/tests/mcp-schema-contract.integration.test.ts
@@ -43,6 +43,18 @@ describe("mcp schema-driven contract integration", () => {
       const results = recallResponse.structuredContent?.["results"] as
         Array<Record<string, unknown>> | undefined;
       expect(results?.some((result) => result["id"] === rememberedId)).toBe(true);
+
+      // Regression: the real `get` handler emits note items with alwaysLoad +
+      // relatedTo; the declared output schema must accept them. Handler/schema
+      // drift here previously caused an MCP -32602 structured-content error when
+      // fetching a plain memory by id.
+      const getResponse = await client.callTool("get", { ids: [rememberedId] });
+      expect(getResponse.structuredContent).toBeDefined();
+      const { GetResultSchema } = await import("../src/structured-content.js");
+      const parsedGet = GetResultSchema.parse(getResponse.structuredContent);
+      expect(
+        parsedGet.items?.some((item) => item.kind === "note" && item.id === rememberedId),
+      ).toBe(true);
     } finally {
       await client.close();
       await embeddingServer.close();
@@ -114,6 +126,20 @@ describe("mcp schema-driven contract integration", () => {
       ],
       items: [
         {
+          kind: "note" as const,
+          id: "test-note-abc",
+          title: "Test note",
+          content: "Body of the test note.",
+          tags: ["testing"],
+          lifecycle: "permanent" as const,
+          role: "decision" as const,
+          alwaysLoad: true,
+          relatedTo: [{ id: "other-note", type: "related-to" as const }],
+          vault: "main-vault",
+          createdAt: "2026-01-01T00:00:00Z",
+          updatedAt: "2026-01-01T00:00:00Z",
+        },
+        {
           kind: "document" as const,
           documentId: "doc:test-doc.md",
           sourcePath: "test-doc.md",
@@ -137,8 +163,9 @@ describe("mcp schema-driven contract integration", () => {
     expect(parsedGet.documents).toBeDefined();
     expect(parsedGet.documents).toHaveLength(1);
     expect(parsedGet.items).toBeDefined();
-    expect(parsedGet.items).toHaveLength(1);
-    expect(parsedGet.items![0].kind).toBe("document");
+    expect(parsedGet.items).toHaveLength(2);
+    expect(parsedGet.items![0].kind).toBe("note");
+    expect(parsedGet.items![1].kind).toBe("document");
     expect(parsedGet.itemErrors).toBeDefined();
     expect(parsedGet.itemErrors).toHaveLength(1);
     expect(parsedGet.itemErrors![0].code).toBe("unknown-document");


### PR DESCRIPTION
## Summary

This PR fixes the following issues:

- **Document-source chunk embeddings specified but never delivered (spec-vs-implementation gap)**
- **Document-source attachments: design, delivery, and verification (canonical)**

## Changes

### Document-source chunk embeddings specified but never delivered (spec-vs-implementation gap)

**Tags:** attachments, document-source, retrieval, architecture, decision, bug

The canonical design note `document-source-attachments-design-delivery-and-verification-1517e52b` explicitly specified that document-source chunks be embedded, with lexical-only as the fail-soft fallback. Line 41: "embedding failures publish with lexical-only coverage" — a contract that only makes sense if embeddings are the primary path. Line 42 lists `embeddingCompatibilityIdentity` as part of the generation manifest, implying embeddings are produced and need a compatibility fingerprint for invalidation. Line 43 frames document chunks as full participants in recall ranking ("result diversity enforced after final scoring"), consistent with semantic+lexical hybrid fusion.

### Document-source attachments: design, delivery, and verification (canonical)

**Tags:** attachments, document-source, markdown, retrieval, architecture, decision

Consolidates the completed document-source attachment workflow (request, research, two design reviews, six-stage plan, stage review) into one permanent canonical note. Source notes are deleted; durable detail remains in the related permanent notes.

## Workflow Artifacts

**Plan:**

- Plan: deliver document-source chunk semantic retrieval (embeddings + persistence + RRF fusion) — Plan to deliver the document-source chunk semantic retrieval that the canonical design note (`document-source-attachments-design-delivery-and-verification-1517e52b`) specified but never shipped (see `document-source-chunk-embeddings-specified-but-never-deliver-6e867617`).

**Review:**

- Document-source attachment: five bugs found and fixed via Pack D dogfooding — Dogfooding the newly added read-only markdown (document-source) attachment feature against the LOCAL build (`scripts/dogfood-document-source.mjs`, Pack D) found five defects that broke the end-to-end contract.

## Notes / References

_Detailed notes in `.mnemonic/notes/`:_

- `.mnemonic/notes/document-source-attachment-five-bugs-found-and-fixed-via-pac-24bedd4b.md` — Document-source attachment: five bugs found and fixed via Pack D dogfooding _(review)_
- `.mnemonic/notes/document-source-chunk-embeddings-specified-but-never-deliver-6e867617.md` — Document-source chunk embeddings specified but never delivered (spec-vs-implementation gap)
- `.mnemonic/notes/document-source-attachments-design-delivery-and-verification-1517e52b.md` — Document-source attachments: design, delivery, and verification (canonical)
- `.mnemonic/notes/plan-deliver-document-source-chunk-semantic-retrieval-embedd-dba90b71.md` — Plan: deliver document-source chunk semantic retrieval (embeddings + persistence + RRF fusion) _(plan)_

---

_Generated from 4 design decision note(s) in `.mnemonic/notes/`. Run `/update-pr` to regenerate._