### PR TITLE
Chunk embedding path layout: drop redundant guid prefix, lowercase filenames, reconcile on schema change

### DIFF
--- a/.mnemonic/notes/chunk-embedding-path-layout-drop-redundant-guid-prefix-lower-6b739d42.md
+++ b/.mnemonic/notes/chunk-embedding-path-layout-drop-redundant-guid-prefix-lower-6b739d42.md
@@ -9,11 +9,14 @@ tags:
   - embeddings
 lifecycle: permanent
 createdAt: '2026-08-01T22:39:23.145Z'
-updatedAt: '2026-08-01T22:39:23.145Z'
+updatedAt: '2026-08-01T22:39:42.026Z'
 role: decision
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: plan-deliver-document-source-chunk-semantic-retrieval-embedd-dba90b71
+    type: derives-from
 memoryVersion: 1
 ---
 # Chunk embedding path layout: drop redundant guid prefix, lowercase filenames, reconcile on schema change

--- a/.mnemonic/notes/chunk-embedding-path-layout-drop-redundant-guid-prefix-lower-6b739d42.md
+++ b/.mnemonic/notes/chunk-embedding-path-layout-drop-redundant-guid-prefix-lower-6b739d42.md
@@ -1,0 +1,57 @@
+---
+title: >-
+  Chunk embedding path layout: drop redundant guid prefix, lowercase filenames,
+  reconcile on schema change
+tags:
+  - decision
+  - attachments
+  - document-source
+  - embeddings
+lifecycle: permanent
+createdAt: '2026-08-01T22:39:23.145Z'
+updatedAt: '2026-08-01T22:39:23.145Z'
+role: decision
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+# Chunk embedding path layout: drop redundant guid prefix, lowercase filenames, reconcile on schema change
+
+Refined the document-source chunk embedding on-disk layout in `src/chunk-embedding-storage.ts`, `src/document-sync.ts`, and `src/document-source-index.ts`. `indexSchemaVersion` bumped 2→3 to invalidate prior caches. The authoritative chunkId format (the `::`-separated id stored in JSON) is unchanged.
+
+## Why
+
+Files lived at `.mnemonic/embeddings/doc-source/<attachmentId>/<slug(chunkId)>.json`, but `chunkId` itself is derived as `<attachmentId>::<path>::<headings>::<dup>::<ordinal>`. After slugifying (`::` → `-`) every filename redundantly carried the same guid already used as the parent folder. Measured: 2986 files in one attachment dir, ~20% shorter paths (~110 KB saved). Mixed-case also leaked from source paths (`README`) and heading text (`Azure`, `PaaS`).
+
+## Decisions
+
+1. **Strip the attachment-id prefix.** `ChunkEmbeddingStorage` now takes `(dir, attachmentId)`; `pathFor` strips the leading `<attachmentId>::` before slugifying. Safe because storage is always constructed per-attachment (`document-sync.ts`) and `remove-attachment` wipes the whole `<attachmentId>/` dir. The slug is already non-injective (`::`, `/`, and spaces all → `-`), so the filename was never a faithful chunkId encoding anyway; the authoritative chunkId lives inside the JSON.
+
+2. **Lowercase in `pathFor` only — never in the shared `normalizePathToSlug`.** `normalizePathToSlug` (`src/retrieval-document.ts`) is shared with id derivation (`deriveDocumentId`, `deriveChunkId`, `buildDocumentRef`); lowercasing it would change the `::`-separated chunkId stored in JSON and used for tie-breaks / Map keys — breaking the id contract. The `.toLowerCase()` lives only inside `ChunkEmbeddingStorage.pathFor`. Rationale: macOS APFS and Windows NTFS are case-insensitive by default (latent collision risk); Linux ext4 is case-sensitive. Lowercasing makes filenames deterministic cross-platform.
+
+3. **`pathFor` made public** so tests can target the canonical path when injecting corrupt / shape-mismatch files (tests already imported `normalizePathToSlug` for this, so it is consistent with existing test philosophy).
+
+4. **`reconcile()` unlinks by the actual on-disk path.** A version bump rebuilds and re-embeds but does NOT delete old files: reuse via `read()` misses at new canonical paths → re-embed writes new-named files alongside; `sweepStaleChunkEmbeddings` only removes files whose chunkId is gone, and legacy files carry valid chunkIds; `remove()` targets the canonical name so it can never unlink a legacy file; `list()` discards the real filename. So legacy files are unreachable orphans. `reconcile` fixes this by readdir + read + unlink-by-actual-path, removing a file when it is stale OR `basename(pathFor(chunkId)) !== file`. Fail-soft: corrupt/unreadable files are left in place (mirrors `list()`).
+
+5. **Rename-cleanup gated to schema-version change only.** Stale removal runs every sync (cheap, original behavior); rename-removal is opt-in via `removeNonCanonical`. The caller passes `schemaChanged = previousSchemaVersion !== generation.manifest.indexSchemaVersion`, so the basename comparison runs exactly once (on the migration sync) then never again.
+
+## Safety of the schemaChanged gate
+
+`previousSchemaVersion` is captured from `currentGen?.manifest.indexSchemaVersion` at the point `currentGen` is declared, before the `isGenerationCurrent` type guard narrows it (without this, TS narrows `currentGen` to `never`). `currentGen` is `const` and never reassigned (the post-publish generation is a separate `generation` variable), so it is a faithful pre-rebuild snapshot.
+
+| Scenario | previous | new | schemaChanged | reconcile effect |
+| --- | --- | --- | --- | --- |
+| first sync, empty dir | undefined | 3 | true | reads 0 files, no-op |
+| orphaned dir, no manifest | undefined | 3 | true | cleans legacy, re-embeds (self-heals) |
+| same-schema re-sync | 3 | 3 | false | stale-only, zero extra work |
+| migration 2→3 | 2 | 3 | true | one-time legacy cleanup |
+
+Two invariants guarantee safety even when schemaChanged is spuriously true: (a) freshly-written canonical files always survive, because a file's basename equals `pathFor(its chunkId)` by construction; (b) the dir always exists by then (`init()` runs before `embedGenerationChunks` before `sweepStaleChunkEmbeddings`, all inside one `attempt` block, so if `init` fails reconcile is never reached). `removeNonCanonical` can ONLY ever delete genuinely legacy-named files.
+
+## Tradeoffs / residual notes
+
+- Slug stays non-injective; hash-based names would be truly injective but lose readability — judged overkill given guid+path+heading uniqueness.
+- `pathFor` is now public API (minor filesystem-detail leak; justified by test ergonomics).
+- Migration is automatic (no manual `rm -rf`): the first sync after upgrade re-embeds at the new names and sweeps the old ones, because `schemaChanged` is true on the 2→3 boundary.
+- `reconcile` does one readdir + per-file read pass per sync (same order of cost as the original `list()`-based sweep it replaces; the rename check is a free piggyback, now gated off on non-migration syncs).

--- a/.mnemonic/notes/plan-deliver-document-source-chunk-semantic-retrieval-embedd-dba90b71.md
+++ b/.mnemonic/notes/plan-deliver-document-source-chunk-semantic-retrieval-embedd-dba90b71.md
@@ -11,13 +11,15 @@ tags:
   - architecture
 lifecycle: permanent
 createdAt: '2026-08-01T20:43:19.999Z'
-updatedAt: '2026-08-01T20:43:23.909Z'
+updatedAt: '2026-08-01T22:39:42.026Z'
 role: plan
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
   - id: document-source-chunk-embeddings-specified-but-never-deliver-6e867617
+    type: derives-from
+  - id: chunk-embedding-path-layout-drop-redundant-guid-prefix-lower-6b739d42
     type: derives-from
 memoryVersion: 1
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 
 ## [Unreleased]
 
+### Changed
+
+- Document-source chunk embedding cache files no longer duplicate the attachment id in their file name (the per-attachment folder already scopes by it) and are now lowercased for consistent behavior across macOS, Windows, and Linux filesystems. The first `sync` after upgrade rebuilds and re-embeds affected attachments once, then removes the old cache files automatically.
+
 ## [0.40.0] - 2026-08-01
 
 ### Added

--- a/src/chunk-embedding-storage.ts
+++ b/src/chunk-embedding-storage.ts
@@ -43,17 +43,29 @@ export interface ChunkEmbeddingRecord {
  *
  * Owns a single directory (the per-attachment directory resolved by the caller,
  * e.g. `.mnemonic/embeddings/doc-source/<attachmentId>/`). Files are named by
- * the slugified chunk ID: `<slug(chunkId)>.json`.
+ * the slugified, lowercased chunk-id *suffix* — the leading `<attachmentId>::`
+ * prefix is stripped because the directory already scopes by attachment id, so
+ * the prefix would be redundant on every file: `<slug(suffix)>.json`.
+ *
+ * Lowercasing is applied here ONLY (not in the shared `normalizePathToSlug`,
+ * which stays case-preserving so the `::`-separated chunkId stored in JSON is
+ * never altered). This keeps file names deterministic across case-insensitive
+ * filesystems (macOS APFS, Windows NTFS) without touching the id contract.
  */
 export class ChunkEmbeddingStorage {
-  constructor(private readonly dir: string) {}
+  constructor(
+    private readonly dir: string,
+    private readonly attachmentId: string,
+  ) {}
 
   async init(): Promise<void> {
     await fs.mkdir(this.dir, { recursive: true });
   }
 
-  private pathFor(chunkId: string): string {
-    return path.join(this.dir, normalizePathToSlug(chunkId) + ".json");
+  pathFor(chunkId: string): string {
+    const prefix = `${this.attachmentId}::`;
+    const suffix = chunkId.startsWith(prefix) ? chunkId.slice(prefix.length) : chunkId;
+    return path.join(this.dir, normalizePathToSlug(suffix).toLowerCase() + ".json");
   }
 
   async read(chunkId: string): Promise<ChunkEmbeddingRecord | null> {
@@ -93,6 +105,60 @@ export class ChunkEmbeddingStorage {
     await attempt("chunk-embedding:removeAll", () =>
       fs.rm(this.dir, { recursive: true, force: true }),
     );
+  }
+
+  /**
+   * Reconcile on-disk files against the current generation in a single pass,
+   * unlinking by the ACTUAL on-disk path.
+   *
+   * Stale removal runs every call: a file whose `chunkId` is no longer in
+   * `currentChunkIds` is deleted. Rename removal is opt-in via
+   * `removeNonCanonical` — pass it only when the caller knows the on-disk
+   * naming scheme changed (e.g. an `indexSchemaVersion` bump that dropped the
+   * attachment-id prefix or lowercased the slug), so the normal per-sync pass
+   * skips the basename comparison when there is nothing to migrate.
+   *
+   * The rename case is unreachable for `remove()`/`list()` alone: `remove`
+   * targets the canonical name, and `list()` discards the real filename — so a
+   * legacy-named file whose chunkId is still current is invisible to a plain
+   * stale sweep and would accumulate as dead weight after a rename. Fail-soft:
+   * unreadable or corrupt files are left in place, mirroring `list()`. Returns
+   * the counts removed by reason.
+   */
+  async reconcile(
+    currentChunkIds: Set<string>,
+    removeNonCanonical = false,
+  ): Promise<{ stale: number; nonCanonical: number }> {
+    const filesResult = await attempt(
+      "chunk-embedding:reconcile",
+      () => fs.readdir(this.dir),
+      [] as string[],
+    );
+    const files = filesResult.ok ? filesResult.value : [];
+    let stale = 0;
+    let nonCanonical = 0;
+    for (const file of files) {
+      if (!file.endsWith(".json")) continue;
+      const filePath = path.join(this.dir, file);
+      const raw = await attempt("chunk-embedding:reconcile", () => fs.readFile(filePath, "utf-8"));
+      if (!raw.ok) continue;
+      const parsed = await attempt("chunk-embedding:reconcile", (): unknown =>
+        JSON.parse(raw.value),
+      );
+      if (!parsed.ok) continue;
+      const record = validateChunkEmbeddingRecord(parsed.value);
+      if (!record) continue;
+      if (!currentChunkIds.has(record.chunkId)) {
+        const r = await attempt("chunk-embedding:reconcile", () => fs.unlink(filePath));
+        if (r.ok) stale++;
+        continue;
+      }
+      if (removeNonCanonical && path.basename(this.pathFor(record.chunkId)) !== file) {
+        const r = await attempt("chunk-embedding:reconcile", () => fs.unlink(filePath));
+        if (r.ok) nonCanonical++;
+      }
+    }
+    return { stale, nonCanonical };
   }
 }
 

--- a/src/document-source-index.ts
+++ b/src/document-source-index.ts
@@ -106,7 +106,7 @@ export function buildGenerationFromFiles(
     chunkerVersion: chunker.chunkerVersion,
     chunkerOptionsHash: "default",
     projectionSchemaVersion: "1",
-    indexSchemaVersion: "2",
+    indexSchemaVersion: "3",
     embeddingCompatibilityIdentity: `${extractor.extractorId}::${extractor.extractorVersion}::${chunker.chunkerId}::${chunker.chunkerVersion}`,
     sourceMediaTypeCounts: { [extractor.sourceMediaType]: documents.size },
     documentCount: documents.size,

--- a/src/document-sync.ts
+++ b/src/document-sync.ts
@@ -86,7 +86,7 @@ export function isGenerationCurrent(
     generation.manifest.indexedCommit === indexedCommit &&
     generation.manifest.extractorVersion === extractor.extractorVersion &&
     generation.manifest.chunkerVersion === chunker.chunkerVersion &&
-    generation.manifest.indexSchemaVersion === "2" &&
+    generation.manifest.indexSchemaVersion === "3" &&
     generation.manifest.embeddingCompatibilityIdentity === expectedCompatibilityIdentity
   );
 }
@@ -234,19 +234,20 @@ export async function embedGenerationChunks(
 }
 
 /**
- * Delete on-disk chunk embeddings whose chunkId no longer exists in the current
- * generation (mirrors `removeStaleEmbeddings` for note embeddings).
+ * Reconcile on-disk chunk embeddings against the current generation. Stale
+ * removal (chunkId no longer present) runs every sync; rename removal is
+ * opt-in via `removeNonCanonical` — the caller enables it only when the naming
+ * scheme changed (e.g. an `indexSchemaVersion` bump), so legacy-named files
+ * get cleaned up exactly once instead of re-checking every sync. Delegates to
+ * `ChunkEmbeddingStorage.reconcile`, which unlinks by the actual on-disk path
+ * in a single pass (mirrors `removeStaleEmbeddings` for note embeddings).
  */
 export async function sweepStaleChunkEmbeddings(
   storage: ChunkEmbeddingStorage,
   currentChunkIds: Set<string>,
+  removeNonCanonical = false,
 ): Promise<void> {
-  const onDisk = await storage.list();
-  for (const record of onDisk) {
-    if (!currentChunkIds.has(record.chunkId)) {
-      await storage.remove(record.chunkId);
-    }
-  }
+  await storage.reconcile(currentChunkIds, removeNonCanonical);
 }
 
 function buildEmbeddingSummary(embedded: number, failed: number): string {
@@ -327,6 +328,11 @@ export async function syncDocumentSource(
     };
   }
   const currentGen = getCurrentGeneration(config.attachmentId) ?? undefined;
+  // Capture the pre-rebuild schema version before the `isGenerationCurrent`
+  // type guard narrows `currentGen`. Used later to decide whether the on-disk
+  // embedding naming scheme might have changed (and thus whether the more
+  // expensive rename-cleanup pass should run). `currentGen` is never reassigned.
+  const previousSchemaVersion = currentGen?.manifest.indexSchemaVersion;
   if (isGenerationCurrent(currentGen, indexedCommit, extractor, markdownChunker)) {
     return {
       attachmentId: config.attachmentId,
@@ -419,6 +425,7 @@ export async function syncDocumentSource(
   if (generation && projectEmbeddingsDir) {
     const chunkStorage = new ChunkEmbeddingStorage(
       path.join(projectEmbeddingsDir, "doc-source", config.attachmentId),
+      config.attachmentId,
     );
     const embedStep = await attempt("sync:doc-source-embed", async () => {
       await chunkStorage.init();
@@ -435,7 +442,15 @@ export async function syncDocumentSource(
         chunkStorage,
         lastModByPath,
       );
-      await sweepStaleChunkEmbeddings(chunkStorage, new Set(generation.chunks.keys()));
+      // Only pay for rename-cleanup when the on-disk naming scheme actually
+      // changed (previous manifest's schema version differs from this one);
+      // stale-chunkId removal still runs every sync.
+      const schemaChanged = previousSchemaVersion !== generation.manifest.indexSchemaVersion;
+      await sweepStaleChunkEmbeddings(
+        chunkStorage,
+        new Set(generation.chunks.keys()),
+        schemaChanged,
+      );
     });
     if (!embedStep.ok) {
       generation.manifest.embeddingFailures = [

--- a/tests/chunk-embedding-storage.unit.test.ts
+++ b/tests/chunk-embedding-storage.unit.test.ts
@@ -15,7 +15,6 @@ import {
   embeddingProviderId,
   isoDateString,
 } from "../src/brands.js";
-import { normalizePathToSlug } from "../src/retrieval-document.js";
 
 const tempDirs: string[] = [];
 
@@ -27,7 +26,7 @@ async function makeStorage(): Promise<{ dir: string; storage: ChunkEmbeddingStor
   const base = await fs.mkdtemp(path.join(os.tmpdir(), "mnemonic-chunk-embedding-"));
   tempDirs.push(base);
   const dir = path.join(base, "att-1");
-  const storage = new ChunkEmbeddingStorage(dir);
+  const storage = new ChunkEmbeddingStorage(dir, "att-1");
   await storage.init();
   return { dir, storage };
 }
@@ -76,11 +75,7 @@ describe("ChunkEmbeddingStorage", () => {
   it("returns null for corrupt JSON and skips it in list", async () => {
     const { dir, storage } = await makeStorage();
     const chunkId = "att-1::docs/corrupt.md::Intro::0::0";
-    await fs.writeFile(
-      path.join(dir, `${normalizePathToSlug(chunkId)}.json`),
-      "{ not valid json",
-      "utf-8",
-    );
+    await fs.writeFile(storage.pathFor(chunkId), "{ not valid json", "utf-8");
 
     await expect(storage.read(chunkId)).resolves.toBeNull();
     await expect(storage.list()).resolves.toEqual([]);
@@ -90,7 +85,7 @@ describe("ChunkEmbeddingStorage", () => {
     const { dir, storage } = await makeStorage();
     const chunkId = "att-1::docs/shape.md::Intro::0::0";
     await fs.writeFile(
-      path.join(dir, `${normalizePathToSlug(chunkId)}.json`),
+      storage.pathFor(chunkId),
       JSON.stringify({ chunkId, embedding: "not-an-array" }),
       "utf-8",
     );
@@ -104,11 +99,7 @@ describe("ChunkEmbeddingStorage", () => {
     const valid = makeRecord();
     const corruptId = "att-1::docs/corrupt.md::Intro::0::0";
     await storage.write(valid);
-    await fs.writeFile(
-      path.join(dir, `${normalizePathToSlug(corruptId)}.json`),
-      "garbage",
-      "utf-8",
-    );
+    await fs.writeFile(storage.pathFor(corruptId), "garbage", "utf-8");
 
     const listed = await storage.list();
 
@@ -137,17 +128,62 @@ describe("ChunkEmbeddingStorage", () => {
     await expect(storage.removeAll()).resolves.toBeUndefined();
   });
 
-  it("names files by the slugified chunk id", async () => {
+  it("names files by the slugified, lowercased chunk-id suffix (attachment id stripped)", async () => {
     const { dir, storage } = await makeStorage();
     const chunkId = "att-1::docs/Guide.md::Setup & Config::0::0";
     await storage.write(makeRecord({ chunkId }));
 
-    const expectedFile = path.join(dir, `${normalizePathToSlug(chunkId)}.json`);
+    // The attachment-id prefix is dropped (the directory already scopes by it)
+    // and the remaining suffix is slugified + lowercased for cross-filesystem
+    // safety. The shared `normalizePathToSlug` stays case-preserving; only the
+    // file-name path lowercases.
+    const expectedFile = path.join(dir, "docs-guide-md-setup-config-0-0.json");
     await expect(fs.access(expectedFile)).resolves.toBeUndefined();
-    expect(normalizePathToSlug(chunkId)).toBe("att-1-docs-Guide-md-Setup-Config-0-0");
-    // The non-slugified chunkId must not be used verbatim as a file name.
-    const literalFile = path.join(dir, `${chunkId}.json`);
-    await expect(fs.access(literalFile)).rejects.toThrow();
+
+    // The authoritative chunkId round-trips intact from the JSON payload.
+    const readBack = await storage.read(chunkId);
+    expect(readBack?.chunkId).toBe(chunkId);
+
+    // Neither the verbatim chunkId nor an attachment-id-prefixed name is used.
+    await expect(fs.access(path.join(dir, `${chunkId}.json`))).rejects.toThrow();
+    await expect(
+      fs.access(path.join(dir, "att-1-docs-guide-md-setup-config-0-0.json")),
+    ).rejects.toThrow();
+  });
+
+  it("reconcile removes stale chunks every call but legacy-named files only when opted in", async () => {
+    const { dir, storage } = await makeStorage();
+    const currentId = "att-1::docs/keep.md::Intro::0::0";
+    const staleId = "att-1::docs/gone.md::Intro::0::0";
+    await storage.write(makeRecord({ chunkId: currentId }));
+    await storage.write(makeRecord({ chunkId: staleId }));
+
+    // Simulate a pre-rename legacy file: same chunkId as `currentId` but stored
+    // at the OLD naming scheme (attachment-id prefix, mixed case). This file is
+    // invisible to `list()`/`remove()` (which target the canonical name) yet
+    // still carries a valid chunkId, so plain sweep would spare it.
+    const legacyPath = path.join(dir, "att-1-docs-keep-md-Intro-0-0.json");
+    await fs.writeFile(
+      legacyPath,
+      JSON.stringify(makeRecord({ chunkId: currentId }), null, 2),
+      "utf-8",
+    );
+
+    // Default pass: stale removal only; the legacy file is left in place so the
+    // per-sync path skips the basename comparison when nothing changed.
+    const defaultResult = await storage.reconcile(new Set([currentId]));
+    expect(defaultResult.stale).toBe(1);
+    expect(defaultResult.nonCanonical).toBe(0);
+    await expect(fs.access(legacyPath)).resolves.toBeUndefined();
+
+    // Opt-in pass (schema-version change): now the legacy file is removed too.
+    const optInResult = await storage.reconcile(new Set([currentId]), true);
+    expect(optInResult.stale).toBe(0);
+    expect(optInResult.nonCanonical).toBe(1);
+    // The canonical current file survives; the legacy file is gone.
+    expect(await storage.list()).toHaveLength(1);
+    expect(await storage.read(currentId)).not.toBeNull();
+    await expect(fs.access(legacyPath)).rejects.toThrow();
   });
 });
 

--- a/tests/document-sync-compat.unit.test.ts
+++ b/tests/document-sync-compat.unit.test.ts
@@ -40,7 +40,7 @@ function makeGeneration(
       indexedCommit: overrides.indexedCommit ?? "commit-1",
       extractorVersion: overrides.extractorVersion ?? extractor.extractorVersion,
       chunkerVersion: overrides.chunkerVersion ?? chunker.chunkerVersion,
-      indexSchemaVersion: overrides.indexSchemaVersion ?? "2",
+      indexSchemaVersion: overrides.indexSchemaVersion ?? "3",
       embeddingCompatibilityIdentity:
         overrides.embeddingCompatibilityIdentity ?? expectedEmbeddingCompatibilityIdentity,
     },

--- a/tests/document-sync-embeddings.unit.test.ts
+++ b/tests/document-sync-embeddings.unit.test.ts
@@ -118,7 +118,7 @@ async function makeStorage(): Promise<{ dir: string; storage: ChunkEmbeddingStor
   const base = await fs.mkdtemp(path.join(os.tmpdir(), "mnemonic-sync-embedding-"));
   tempDirs.push(base);
   const dir = path.join(base, "doc-source", "att-1");
-  const storage = new ChunkEmbeddingStorage(dir);
+  const storage = new ChunkEmbeddingStorage(dir, "att-1");
   await storage.init();
   return { dir, storage };
 }
@@ -288,7 +288,7 @@ describe("isGenerationCurrent with a different embedding identity", () => {
         indexedCommit: "abc123",
         extractorVersion: extractor.extractorVersion,
         chunkerVersion: chunker.chunkerVersion,
-        indexSchemaVersion: "2",
+        indexSchemaVersion: "3",
         embeddingCompatibilityIdentity: currentIdentity,
       },
     };
@@ -299,7 +299,7 @@ describe("isGenerationCurrent with a different embedding identity", () => {
         indexedCommit: "abc123",
         extractorVersion: extractor.extractorVersion,
         chunkerVersion: chunker.chunkerVersion,
-        indexSchemaVersion: "2",
+        indexSchemaVersion: "3",
         embeddingCompatibilityIdentity: expectedIdentityFor("other-model"),
       },
     };


### PR DESCRIPTION
## Summary

This PR captures the following design decisions:

- **Chunk embedding path layout: drop redundant guid prefix, lowercase filenames, reconcile on schema change**

## Changes

### Chunk embedding path layout: drop redundant guid prefix, lowercase filenames, reconcile on schema change

**Tags:** decision, attachments, document-source, embeddings

Refined the document-source chunk embedding on-disk layout in `src/chunk-embedding-storage.ts`, `src/document-sync.ts`, and `src/document-source-index.ts`. `indexSchemaVersion` bumped 2→3 to invalidate prior caches. The authoritative chunkId format (the `::`-separated id stored in JSON) is unchanged.

## Workflow Artifacts

**Plan:**

- Plan: deliver document-source chunk semantic retrieval (embeddings + persistence + RRF fusion) — Plan to deliver the document-source chunk semantic retrieval that the canonical design note (`document-source-attachments-design-delivery-and-verification-1517e52b`) specified but never shipped (see `document-source-chunk-embeddings-specified-but-never-deliver-6e867617`).

## Notes / References

_Detailed notes in `.mnemonic/notes/`:_

- `.mnemonic/notes/chunk-embedding-path-layout-drop-redundant-guid-prefix-lower-6b739d42.md` — Chunk embedding path layout: drop redundant guid prefix, lowercase filenames, reconcile on schema change
- `.mnemonic/notes/plan-deliver-document-source-chunk-semantic-retrieval-embedd-dba90b71.md` — Plan: deliver document-source chunk semantic retrieval (embeddings + persistence + RRF fusion) _(plan)_

---

_Generated from 2 design decision note(s) in `.mnemonic/notes/`. Run `/update-pr` to regenerate._