### PR TITLE
Chunk embedding path layout: drop redundant guid prefix, lowercase filenames, reconcile on schema change

### DIFF
--- a/.mnemonic/notes/chunk-embedding-path-layout-drop-redundant-guid-prefix-lower-6b739d42.md
+++ b/.mnemonic/notes/chunk-embedding-path-layout-drop-redundant-guid-prefix-lower-6b739d42.md
@@ -9,13 +9,15 @@ tags:
   - embeddings
 lifecycle: permanent
 createdAt: '2026-08-01T22:39:23.145Z'
-updatedAt: '2026-08-01T22:39:42.026Z'
+updatedAt: '2026-08-02T06:16:01.222Z'
 role: decision
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
   - id: plan-deliver-document-source-chunk-semantic-retrieval-embedd-dba90b71
+    type: derives-from
+  - id: document-source-chunk-embeddings-use-xxh128-for-filenames-an-e3e988b8
     type: derives-from
 memoryVersion: 1
 ---

--- a/.mnemonic/notes/document-source-chunk-embeddings-use-xxh128-for-filenames-an-e3e988b8.md
+++ b/.mnemonic/notes/document-source-chunk-embeddings-use-xxh128-for-filenames-an-e3e988b8.md
@@ -7,7 +7,7 @@ tags:
   - attachments
 lifecycle: permanent
 createdAt: '2026-08-02T06:15:43.841Z'
-updatedAt: '2026-08-02T06:16:01.222Z'
+updatedAt: '2026-08-02T06:24:14.893Z'
 role: decision
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -33,13 +33,15 @@ Retrieval is unaffected by either change: `collectDocumentChunkCandidates` keys 
 
 2. **Content hash = `xxh128(projectionText)`**, replacing SHA-256. Unifies both sites under one deliberate non-cryptographic hash.
 
-3. **128-bit, not 64-bit.** xxh64 was considered and rejected: at `maxTotalChunks: 50000` a 64-bit hash has birthday-collision probability ~7×10⁻¹¹. For filenames a collision silently clobbers one chunk's embedding (retrieval degrades to lexical-only for that chunk; reconcile cannot detect it). For content a collision causes a false cache-hit (wrong vector reused for a changed chunk). 128-bit removes both concerns entirely.
+3. **128-bit, not 64-bit.** xxh64 was considered and rejected: at `maxTotalChunks: 50000` a 64-bit hash has birthday-collision probability \~7×10⁻¹¹. For filenames a collision silently clobbers one chunk's embedding (retrieval degrades to lexical-only for that chunk; reconcile cannot detect it). For content a collision causes a false cache-hit (wrong vector reused for a changed chunk). 128-bit removes both concerns entirely.
 
 4. **xxh128 over SHA-256** because SHA-256's prior use was arbitrary and xxh128 is the purpose-built tool for content addressing at this scale. xxh128 over xxh64 for the collision-proofing above.
 
-5. **Dependency: `xxhash-wasm`.** `node:crypto` has no xxhash (confirmed on Node 25.2.1). Hashing speed is not the bottleneck — the embed loop's per-chunk sequential `storage.read()` I/O dominates — but using the right tool is worth a tiny dep.
+5. **Dependency: `hash-wasm`.** `node:crypto` ships no non-cryptographic 128-bit hash (confirmed on Node 25.2.1). `xxhash-wasm` was tried first but its v1.x exposes only 32/64-bit variants, so `hash-wasm` (real XXH3-128 via `xxhash128`) is used instead. Hashing speed is not the bottleneck — the embed loop's per-chunk sequential `storage.read()` I/O dominates — but using the right tool is worth a tiny dep.
 
 ## Implementation consequences
+
+- **`pathFor` is now async** (`Promise<string>`): `hash-wasm`'s `xxhash128` lazily compiles its WASM on first use, so the hash is a `Promise`. Every caller (`read`, `write`, `remove`, `reconcile`) was already async, so this is a contained change; the few tests that called `pathFor` synchronously now `await` it.
 
 - **`list()` must read files directly** instead of round-tripping the basename through `read()`/`pathFor()`. The slug was idempotent (`slug(slug(x)) === slug(x)`), so the old round-trip worked by coincidence; a hash is NOT idempotent (`hash(hash(x)) !== hash(x)`), so the round-trip would hash the hex filename again and miss the file. `read(chunkId)` (takes the real chunkId) and `reconcile()` (already reads directly) keep working unchanged. The fix mirrors `reconcile`'s direct-read approach.
 
@@ -49,7 +51,8 @@ Retrieval is unaffected by either change: `collectDocumentChunkCandidates` keys 
 
 ## What changes
 
-- `src/chunk-embedding-storage.ts`: `pathFor` uses `xxh128(suffix)`; `list()` reads files directly; contentHash comment updated (no longer "hex sha256").
-- `src/document-sync.ts`: content hash at `:169` uses `xxh128`.
-- New `xxhash-wasm` dependency + a small shared hash helper.
-- Tests updated: filename assertion becomes the xxh128 digest; reconcile legacy-file test still valid (v2 slug names are the legacy).
+- `src/hashing.ts` (new): shared `xxh128(input)` wrapper over `hash-wasm`'s `xxhash128`.
+- `src/chunk-embedding-storage.ts`: `pathFor` is async and uses `xxh128(suffix)`; `read`/`write`/`remove`/`reconcile` `await` it; `list()` reads files directly (not via `pathFor`); contentHash comment updated (no longer "hex sha256").
+- `src/document-sync.ts`: content hash at `:169` uses `await xxh128(...)`; `createHash` import dropped.
+- New `hash-wasm` dependency.
+- Tests updated: filename assertion becomes the xxh128 digest; `pathFor` calls awaited; reconcile legacy-file test still valid (v2 slug names are the legacy).

--- a/.mnemonic/notes/document-source-chunk-embeddings-use-xxh128-for-filenames-an-e3e988b8.md
+++ b/.mnemonic/notes/document-source-chunk-embeddings-use-xxh128-for-filenames-an-e3e988b8.md
@@ -7,11 +7,14 @@ tags:
   - attachments
 lifecycle: permanent
 createdAt: '2026-08-02T06:15:43.841Z'
-updatedAt: '2026-08-02T06:15:43.841Z'
+updatedAt: '2026-08-02T06:16:01.222Z'
 role: decision
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: chunk-embedding-path-layout-drop-redundant-guid-prefix-lower-6b739d42
+    type: derives-from
 memoryVersion: 1
 ---
 Document-source chunk embedding cache files are now named by an **xxh128 digest** of the chunkId suffix, and the per-chunk **content hash is also xxh128**. Both sites had been slug-based / SHA-256 by accident; this makes one deliberate non-cryptographic hash the single source of truth. Reverses the "hash-based names judged overkill" residual in `chunk-embedding-path-layout-drop-redundant-guid-prefix-lower-6b739d42`.

--- a/.mnemonic/notes/document-source-chunk-embeddings-use-xxh128-for-filenames-an-e3e988b8.md
+++ b/.mnemonic/notes/document-source-chunk-embeddings-use-xxh128-for-filenames-an-e3e988b8.md
@@ -1,0 +1,52 @@
+---
+title: Document-source chunk embeddings use xxh128 for filenames and content hashes
+tags:
+  - document-source
+  - embeddings
+  - retrieval
+  - attachments
+lifecycle: permanent
+createdAt: '2026-08-02T06:15:43.841Z'
+updatedAt: '2026-08-02T06:15:43.841Z'
+role: decision
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+Document-source chunk embedding cache files are now named by an **xxh128 digest** of the chunkId suffix, and the per-chunk **content hash is also xxh128**. Both sites had been slug-based / SHA-256 by accident; this makes one deliberate non-cryptographic hash the single source of truth. Reverses the "hash-based names judged overkill" residual in `chunk-embedding-path-layout-drop-redundant-guid-prefix-lower-6b739d42`.
+
+## Why
+
+The slug filename was unbounded: a chunkId is `<attachmentId>::<path>::<headings>::<dup>::<ordinal>`, and after slugifying the whole thing collapses into **one filename component**. Document-source markdown lives in arbitrarily deep paths with long heading ancestry, so that single component can blow past the 255-byte limit shared by APFS/ext4/NTFS (and NTFS caps total path at 260). This is unique to document sources — note-embedding filenames are short GUIDs. f87b0a6c's prefix-strip + lowercase reduced length but never bounded it.
+
+The SHA-256 content hash (`document-sync.ts:169`) was an arbitrary default, never a deliberate choice. "It's already imported" is not a justification when the prior choice was itself accidental.
+
+Retrieval is unaffected by either change: `collectDocumentChunkCandidates` keys on the in-memory `chunkEmbeddings` Map by the **chunkId stored in the JSON payload** — never the filename. As long as the filename is a deterministic function of the chunkId, slug, hash, or anything else works.
+
+## Decisions
+
+1. **Filename = `xxh128(chunkIdSuffix)`** (32 hex chars, fixed length → path-limit-safe regardless of source depth or heading ancestry). The `<attachmentId>::` prefix is still stripped before hashing, consistent with v3's per-attachment-directory scoping. `ChunkEmbeddingStorage` keeps its `(dir, attachmentId)` constructor.
+
+2. **Content hash = `xxh128(projectionText)`**, replacing SHA-256. Unifies both sites under one deliberate non-cryptographic hash.
+
+3. **128-bit, not 64-bit.** xxh64 was considered and rejected: at `maxTotalChunks: 50000` a 64-bit hash has birthday-collision probability ~7×10⁻¹¹. For filenames a collision silently clobbers one chunk's embedding (retrieval degrades to lexical-only for that chunk; reconcile cannot detect it). For content a collision causes a false cache-hit (wrong vector reused for a changed chunk). 128-bit removes both concerns entirely.
+
+4. **xxh128 over SHA-256** because SHA-256's prior use was arbitrary and xxh128 is the purpose-built tool for content addressing at this scale. xxh128 over xxh64 for the collision-proofing above.
+
+5. **Dependency: `xxhash-wasm`.** `node:crypto` has no xxhash (confirmed on Node 25.2.1). Hashing speed is not the bottleneck — the embed loop's per-chunk sequential `storage.read()` I/O dominates — but using the right tool is worth a tiny dep.
+
+## Implementation consequences
+
+- **`list()` must read files directly** instead of round-tripping the basename through `read()`/`pathFor()`. The slug was idempotent (`slug(slug(x)) === slug(x)`), so the old round-trip worked by coincidence; a hash is NOT idempotent (`hash(hash(x)) !== hash(x)`), so the round-trip would hash the hex filename again and miss the file. `read(chunkId)` (takes the real chunkId) and `reconcile()` (already reads directly) keep working unchanged. The fix mirrors `reconcile`'s direct-read approach.
+
+- **`reconcile(removeNonCanonical)` stays.** It is NOT moot pre-ship: v2 slug-named files DID ship in 0.40.0, so upgrading users have v2 files to clean up. Whether v3 names them slug or xxh128, the v2→v3 migration needs the basename-mismatch cleanup. The re-embed is already forced by the filename change (`storage.read` computes the new path, file sits at the old v2 name → read misses → `existing` null → re-embed), so folding the contentHash switch into the same release costs nothing extra — users re-embed once, and the new xxh128 content hash is written during that same pass.
+
+- **No separate `indexSchemaVersion` bump** for the contentHash change; it rides the existing v2→v3 bump from f87b0a6c.
+
+## What changes
+
+- `src/chunk-embedding-storage.ts`: `pathFor` uses `xxh128(suffix)`; `list()` reads files directly; contentHash comment updated (no longer "hex sha256").
+- `src/document-sync.ts`: content hash at `:169` uses `xxh128`.
+- New `xxhash-wasm` dependency + a small shared hash helper.
+- Tests updated: filename assertion becomes the xxh128 digest; reconcile legacy-file test still valid (v2 slug names are the legacy).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 
 ### Changed
 
-- Document-source chunk embedding cache files no longer duplicate the attachment id in their file name (the per-attachment folder already scopes by it) and are now lowercased for consistent behavior across macOS, Windows, and Linux filesystems. The first `sync` after upgrade rebuilds and re-embeds affected attachments once, then removes the old cache files automatically.
+- Document-source chunk embedding cache files are now named by an xxh128 digest of the chunk id (a fixed 32-character name) instead of a slugified path. Slug names were unbounded, so a document in a deeply nested path with long heading ancestry could exceed the 255-character single-filename limit shared by macOS, Windows, and Linux — a problem unique to document sources, since note embeddings are keyed by short ids. The per-chunk content hash (used to reuse embeddings across syncs) also switched from SHA-256 to xxh128, unifying both sites under one deliberate non-cryptographic hash. The first `sync` after upgrade rebuilds and re-embeds affected attachments once (the cache-reuse check changes), then removes the old cache files automatically.
 
 ## [0.40.0] - 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 ### Changed
 
 - Document-source chunk embedding cache files are now named by an xxh128 digest of the chunk id (a fixed 32-character name) instead of a slugified path. Slug names were unbounded, so a document in a deeply nested path with long heading ancestry could exceed the 255-character single-filename limit shared by macOS, Windows, and Linux — a problem unique to document sources, since note embeddings are keyed by short ids. The per-chunk content hash (used to reuse embeddings across syncs) also switched from SHA-256 to xxh128, unifying both sites under one deliberate non-cryptographic hash. The first `sync` after upgrade rebuilds and re-embeds affected attachments once (the cache-reuse check changes), then removes the old cache files automatically.
+- Re-syncing a large unchanged document-source attachment is faster: cached chunk embeddings are now read concurrently instead of one at a time, reducing serialized disk I/O without changing results.
 
 ## [0.40.0] - 2026-08-01
 

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ User-tunable fields:
 
 | Field                     | Default       | Description                                                          |
 | ------------------------- | ------------- | -------------------------------------------------------------------- |
-| `reindexEmbedConcurrency` | `4`           | Parallel embedding requests during `sync` (capped from 1 to 16)     |
+| `reindexEmbedConcurrency` | `4`           | Parallel embedding and cache reads during `sync` (capped 1 to 16)   |
 | `mutationPushMode`        | `"main-only"` | When to auto-push after a write: `"all"`, `"main-only"`, or `"none"` |
 
 `projectMemoryPolicies` and `projectIdentityOverrides` are written automatically by `set_project_memory_policy` and `set_project_identity`. You do not need to edit them by hand.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1978,7 +1978,7 @@ VAULT_PATH = <span class="str">"/Users/you/mnemonic-vault"</span></pre>
           <tr>
             <td><code>reindexEmbedConcurrency</code></td>
             <td class="default">4</td>
-            <td>Parallel embedding requests during <code>sync</code> (capped from 1 to 16)</td>
+            <td>Parallel embedding and cache reads during <code>sync</code> (capped 1 to 16)</td>
           </tr>
           <tr>
             <td><code>mutationPushMode</code></td>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@modelcontextprotocol/server": "^2.0.0",
         "gray-matter": "^4.0.3",
+        "hash-wasm": "^4.12.0",
         "markdownlint": "^0.41.0",
         "remark-gfm": "^4.0.1",
         "remark-parse": "^11.0.0",
@@ -2477,6 +2478,12 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/hash-wasm": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/hash-wasm/-/hash-wasm-4.12.0.tgz",
+      "integrity": "sha512-+/2B2rYLb48I/evdOIhP+K/DD2ca2fgBjp6O+GBEnCDk2e4rpeXIK8GvIyRPjTezgmWn9gmKwkQjjx6BtqDHVQ==",
+      "license": "MIT"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4849,7 +4856,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "dependencies": {
     "@modelcontextprotocol/server": "^2.0.0",
     "gray-matter": "^4.0.3",
+    "hash-wasm": "^4.12.0",
     "markdownlint": "^0.41.0",
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",

--- a/src/chunk-embedding-storage.ts
+++ b/src/chunk-embedding-storage.ts
@@ -17,7 +17,7 @@ import {
   isValidIsoDateString,
 } from "./brands.js";
 import { attempt } from "./error-utils.js";
-import { normalizePathToSlug } from "./retrieval-document.js";
+import { xxh128 } from "./hashing.js";
 
 /**
  * A persisted embedding record for a single retrieval chunk.
@@ -28,7 +28,7 @@ import { normalizePathToSlug } from "./retrieval-document.js";
  */
 export interface ChunkEmbeddingRecord {
   chunkId: string; // the ChunkId (branded string) serialized as plain string
-  contentHash: string; // hex sha256 of the chunk's projection text (set by Stage 2)
+  contentHash: string; // 32-hex-char xxh128 of the chunk's projection text (set by Stage 2)
   model: EmbeddingModelId;
   provider?: EmbeddingProviderId;
   dimensions?: EmbeddingDimensions;
@@ -43,14 +43,22 @@ export interface ChunkEmbeddingRecord {
  *
  * Owns a single directory (the per-attachment directory resolved by the caller,
  * e.g. `.mnemonic/embeddings/doc-source/<attachmentId>/`). Files are named by
- * the slugified, lowercased chunk-id *suffix* — the leading `<attachmentId>::`
- * prefix is stripped because the directory already scopes by attachment id, so
- * the prefix would be redundant on every file: `<slug(suffix)>.json`.
+ * the xxh128 digest of the chunk-id *suffix* — the leading `<attachmentId>::`
+ * prefix is stripped first because the directory already scopes by attachment
+ * id, so it would be redundant in the hash input: `<xxh128(suffix)>.json`
+ * (32 lowercase hex chars, fixed length regardless of source-path depth or
+ * heading ancestry).
  *
- * Lowercasing is applied here ONLY (not in the shared `normalizePathToSlug`,
- * which stays case-preserving so the `::`-separated chunkId stored in JSON is
- * never altered). This keeps file names deterministic across case-insensitive
- * filesystems (macOS APFS, Windows NTFS) without touching the id contract.
+ * xxh128 (XXH3-128, non-cryptographic) bounds the filename to a fixed length so
+ * document sources with arbitrarily deep paths and long heading ancestry never
+ * hit the 255-byte single-component limit shared by APFS/ext4/NTFS — a problem
+ * unique to document sources, since note-embedding files are named by short
+ * GUIDs. 128 bits removes any practical collision concern at the
+ * document-source scale (`maxTotalChunks` = 50 000). The authoritative
+ * `::`-separated chunkId lives inside the JSON payload and is never derived
+ * from or altered by the filename; retrieval keys on that id, not the file
+ * name. `pathFor` is async because hash-wasm lazily compiles its WASM on first
+ * use. See the `document-source-chunk-embeddings-use-xxh128-...` decision note.
  */
 export class ChunkEmbeddingStorage {
   constructor(
@@ -62,16 +70,15 @@ export class ChunkEmbeddingStorage {
     await fs.mkdir(this.dir, { recursive: true });
   }
 
-  pathFor(chunkId: string): string {
+  async pathFor(chunkId: string): Promise<string> {
     const prefix = `${this.attachmentId}::`;
     const suffix = chunkId.startsWith(prefix) ? chunkId.slice(prefix.length) : chunkId;
-    return path.join(this.dir, normalizePathToSlug(suffix).toLowerCase() + ".json");
+    return path.join(this.dir, (await xxh128(suffix)) + ".json");
   }
 
   async read(chunkId: string): Promise<ChunkEmbeddingRecord | null> {
-    const raw = await attempt("chunk-embedding:read", () =>
-      fs.readFile(this.pathFor(chunkId), "utf-8"),
-    );
+    const filePath = await this.pathFor(chunkId);
+    const raw = await attempt("chunk-embedding:read", () => fs.readFile(filePath, "utf-8"));
     if (!raw.ok) return null;
     const parsed = await attempt("chunk-embedding:read", (): unknown => JSON.parse(raw.value));
     if (!parsed.ok) return null;
@@ -80,7 +87,8 @@ export class ChunkEmbeddingStorage {
 
   async write(record: ChunkEmbeddingRecord): Promise<void> {
     await fs.mkdir(this.dir, { recursive: true });
-    await fs.writeFile(this.pathFor(record.chunkId), JSON.stringify(record, null, 2), "utf-8");
+    const filePath = await this.pathFor(record.chunkId);
+    await fs.writeFile(filePath, JSON.stringify(record, null, 2), "utf-8");
   }
 
   async list(): Promise<ChunkEmbeddingRecord[]> {
@@ -90,15 +98,32 @@ export class ChunkEmbeddingStorage {
       [] as string[],
     );
     const files = filesResult.ok ? filesResult.value : [];
-    const chunkIds = files
-      .filter((file) => file.endsWith(".json"))
-      .map((file) => file.replace(/\.json$/, ""));
-    const records = await Promise.all(chunkIds.map((id) => this.read(id)));
+    // Read files directly rather than round-tripping the basename through
+    // read()/pathFor(). The old slug scheme was idempotent (slug(slug(x)) ===
+    // slug(x)), so the round-trip worked by coincidence; the xxh128 name is NOT
+    // idempotent (hash(hash(x)) !== hash(x)), so pathFor(basename) would
+    // re-hash the hex and miss every file. Mirrors reconcile()'s direct read.
+    const records = await Promise.all(
+      files
+        .filter((file) => file.endsWith(".json"))
+        .map(async (file) => {
+          const raw = await attempt("chunk-embedding:list", () =>
+            fs.readFile(path.join(this.dir, file), "utf-8"),
+          );
+          if (!raw.ok) return null;
+          const parsed = await attempt("chunk-embedding:list", (): unknown =>
+            JSON.parse(raw.value),
+          );
+          if (!parsed.ok) return null;
+          return validateChunkEmbeddingRecord(parsed.value);
+        }),
+    );
     return records.filter((record): record is ChunkEmbeddingRecord => record !== null);
   }
 
   async remove(chunkId: string): Promise<void> {
-    await attempt("chunk-embedding:remove", () => fs.unlink(this.pathFor(chunkId)));
+    const filePath = await this.pathFor(chunkId);
+    await attempt("chunk-embedding:remove", () => fs.unlink(filePath));
   }
 
   async removeAll(): Promise<void> {
@@ -153,7 +178,7 @@ export class ChunkEmbeddingStorage {
         if (r.ok) stale++;
         continue;
       }
-      if (removeNonCanonical && path.basename(this.pathFor(record.chunkId)) !== file) {
+      if (removeNonCanonical && path.basename(await this.pathFor(record.chunkId)) !== file) {
         const r = await attempt("chunk-embedding:reconcile", () => fs.unlink(filePath));
         if (r.ok) nonCanonical++;
       }

--- a/src/chunk-embedding-storage.ts
+++ b/src/chunk-embedding-storage.ts
@@ -82,7 +82,12 @@ export class ChunkEmbeddingStorage {
     if (!raw.ok) return null;
     const parsed = await attempt("chunk-embedding:read", (): unknown => JSON.parse(raw.value));
     if (!parsed.ok) return null;
-    return validateChunkEmbeddingRecord(parsed.value);
+    const record = validateChunkEmbeddingRecord(parsed.value);
+    // A canonical file lives at pathFor(chunkId) and carries that same chunkId
+    // in its payload. A mismatch means the file is corrupt or misplaced; treat
+    // it as unreadable so callers re-embed rather than reuse a record keyed
+    // under the wrong id.
+    return record && record.chunkId === chunkId ? record : null;
   }
 
   async write(record: ChunkEmbeddingRecord): Promise<void> {

--- a/src/document-sync.ts
+++ b/src/document-sync.ts
@@ -1,6 +1,6 @@
 import { simpleGit } from "simple-git";
 import path from "path";
-import { createHash } from "node:crypto";
+import { xxh128 } from "./hashing.js";
 import { expandHomePath } from "./paths.js";
 import { getExtractor } from "./document-extractor.js";
 import { markdownChunker } from "./markdown-chunker.js";
@@ -166,7 +166,7 @@ export async function embedGenerationChunks(
   for (const chunk of gen.chunks.values()) {
     const sourcePath = gen.documents.get(chunk.documentId)?.sourcePath ?? chunk.documentId;
     const projectionText = `${chunk.content}\n${joinHeadingAncestry(chunk.headingAncestry)}\n${sourcePath}`;
-    const contentHash = createHash("sha256").update(projectionText, "utf-8").digest("hex");
+    const contentHash = await xxh128(projectionText);
 
     const existing = await storage.read(chunk.chunkId);
     if (

--- a/src/document-sync.ts
+++ b/src/document-sync.ts
@@ -163,23 +163,41 @@ export async function embedGenerationChunks(
 ): Promise<void> {
   const toEmbed: ChunkEmbeddingWorkItem[] = [];
 
-  for (const chunk of gen.chunks.values()) {
-    const sourcePath = gen.documents.get(chunk.documentId)?.sourcePath ?? chunk.documentId;
-    const projectionText = `${chunk.content}\n${joinHeadingAncestry(chunk.headingAncestry)}\n${sourcePath}`;
-    const contentHash = await xxh128(projectionText);
+  // Read existing on-disk embeddings and compute each chunk's content hash
+  // concurrently. On a re-sync of a large unchanged attachment every chunk hits
+  // the reuse branch, so this read/decide loop is the whole cost — serializing
+  // it makes re-syncs slow for no benefit. Bounded by `reindexEmbedConcurrency`
+  // (same knob as the embed workers below). Workers share no mutable state:
+  // each chunk reads a distinct file and sets a distinct chunk-id key
+  // (`Map.set` / `Array.push` are atomic between awaits), and `toEmbed` is
+  // sorted next, so gathering order doesn't matter. `xxh128` is concurrency-
+  // safe — its WASM executes synchronously between awaits (stress-checked).
+  const chunks = [...gen.chunks.values()];
+  let readIndex = 0;
+  const readWorkerCount = Math.min(ctx.config.reindexEmbedConcurrency, Math.max(chunks.length, 1));
+  const readWorkers = Array.from({ length: readWorkerCount }, async () => {
+    while (true) {
+      const chunk = chunks[readIndex++];
+      if (!chunk) return;
 
-    const existing = await storage.read(chunk.chunkId);
-    if (
-      existing &&
-      existing.contentHash === contentHash &&
-      checkEmbeddingCompatibility(existing, currentEmbeddingIdentity).status === "compatible"
-    ) {
-      gen.chunkEmbeddings.set(chunk.chunkId, existing);
-      continue;
+      const sourcePath = gen.documents.get(chunk.documentId)?.sourcePath ?? chunk.documentId;
+      const projectionText = `${chunk.content}\n${joinHeadingAncestry(chunk.headingAncestry)}\n${sourcePath}`;
+      const contentHash = await xxh128(projectionText);
+
+      const existing = await storage.read(chunk.chunkId);
+      if (
+        existing &&
+        existing.contentHash === contentHash &&
+        checkEmbeddingCompatibility(existing, currentEmbeddingIdentity).status === "compatible"
+      ) {
+        gen.chunkEmbeddings.set(chunk.chunkId, existing);
+        continue;
+      }
+
+      toEmbed.push({ chunk, projectionText, contentHash, sourcePath });
     }
-
-    toEmbed.push({ chunk, projectionText, contentHash, sourcePath });
-  }
+  });
+  await Promise.all(readWorkers);
 
   // Recency-priority ordering: newest last-modified first, tie-break by source
   // path for determinism. ISO dates compare lexicographically = chronologically.

--- a/src/document-sync.ts
+++ b/src/document-sync.ts
@@ -199,15 +199,23 @@ export async function embedGenerationChunks(
   });
   await Promise.all(readWorkers);
 
-  // Recency-priority ordering: newest last-modified first, tie-break by source
-  // path for determinism. ISO dates compare lexicographically = chronologically.
+  // Recency-priority ordering: newest last-modified first, then source path,
+  // then chunkId. The chunkId tie-break makes this a TOTAL ordering so cap
+  // selection is deterministic regardless of the (now concurrent) read
+  // completion order — without it, same-document chunks tie on recency and
+  // source path, and a stable sort would preserve the nondeterministic push
+  // order, letting slice(maxEmbeddingWork) pick different chunks across runs.
+  // ISO dates compare lexicographically = chronologically.
   toEmbed.sort((a, b) => {
     const aLastMod = lastModByPath.get(a.sourcePath) ?? "";
     const bLastMod = lastModByPath.get(b.sourcePath) ?? "";
     if (aLastMod !== bLastMod) {
       return aLastMod < bLastMod ? 1 : -1;
     }
-    return a.sourcePath.localeCompare(b.sourcePath);
+    if (a.sourcePath !== b.sourcePath) {
+      return a.sourcePath.localeCompare(b.sourcePath);
+    }
+    return a.chunk.chunkId.localeCompare(b.chunk.chunkId);
   });
 
   const capped = toEmbed.slice(0, maxEmbeddingWork);

--- a/src/hashing.ts
+++ b/src/hashing.ts
@@ -1,0 +1,24 @@
+import { xxhash128 } from "hash-wasm";
+
+/**
+ * 128-bit xxHash (XXH3-128) of a UTF-8 string as 32 lowercase hex chars.
+ *
+ * Non-cryptographic, deterministic, fixed-length. Used for document-source
+ * chunk embedding file names (bounded regardless of source-path depth or
+ * heading ancestry, so deeply nested docs never hit the 255-byte
+ * single-component filename limit) and per-chunk content hashes (embedding
+ * cache-reuse). 128 bits removes any practical collision concern at the
+ * document-source scale (`DOCUMENT_SOURCE_LIMITS.maxTotalChunks` = 50 000).
+ *
+ * `node:crypto` ships no non-cryptographic 128-bit hash, so this wraps
+ * `hash-wasm`. The function is async only because the WASM is lazily compiled
+ * on first use and cached thereafter; subsequent calls are cheap and the
+ * compile cost is paid exactly once per process.
+ *
+ * See the `document-source-chunk-embeddings-use-xxh128-...` decision note for
+ * the rationale (xxh128 over xxh64 for collision-proofing; over the arbitrary
+ * SHA-256 content hash it replaces).
+ */
+export function xxh128(input: string): Promise<string> {
+  return xxhash128(input);
+}

--- a/tests/chunk-embedding-storage.unit.test.ts
+++ b/tests/chunk-embedding-storage.unit.test.ts
@@ -7,6 +7,7 @@ import {
   validateChunkEmbeddingRecord,
 } from "../src/chunk-embedding-storage.js";
 import type { ChunkEmbeddingRecord } from "../src/chunk-embedding-storage.js";
+import { xxh128 } from "../src/hashing.js";
 import {
   embeddingCompatibilityKey,
   embeddingDimensions,
@@ -75,7 +76,7 @@ describe("ChunkEmbeddingStorage", () => {
   it("returns null for corrupt JSON and skips it in list", async () => {
     const { dir, storage } = await makeStorage();
     const chunkId = "att-1::docs/corrupt.md::Intro::0::0";
-    await fs.writeFile(storage.pathFor(chunkId), "{ not valid json", "utf-8");
+    await fs.writeFile(await storage.pathFor(chunkId), "{ not valid json", "utf-8");
 
     await expect(storage.read(chunkId)).resolves.toBeNull();
     await expect(storage.list()).resolves.toEqual([]);
@@ -85,7 +86,7 @@ describe("ChunkEmbeddingStorage", () => {
     const { dir, storage } = await makeStorage();
     const chunkId = "att-1::docs/shape.md::Intro::0::0";
     await fs.writeFile(
-      storage.pathFor(chunkId),
+      await storage.pathFor(chunkId),
       JSON.stringify({ chunkId, embedding: "not-an-array" }),
       "utf-8",
     );
@@ -99,7 +100,7 @@ describe("ChunkEmbeddingStorage", () => {
     const valid = makeRecord();
     const corruptId = "att-1::docs/corrupt.md::Intro::0::0";
     await storage.write(valid);
-    await fs.writeFile(storage.pathFor(corruptId), "garbage", "utf-8");
+    await fs.writeFile(await storage.pathFor(corruptId), "garbage", "utf-8");
 
     const listed = await storage.list();
 
@@ -128,23 +129,25 @@ describe("ChunkEmbeddingStorage", () => {
     await expect(storage.removeAll()).resolves.toBeUndefined();
   });
 
-  it("names files by the slugified, lowercased chunk-id suffix (attachment id stripped)", async () => {
+  it("names files by the xxh128 digest of the chunk-id suffix (attachment id stripped)", async () => {
     const { dir, storage } = await makeStorage();
     const chunkId = "att-1::docs/Guide.md::Setup & Config::0::0";
     await storage.write(makeRecord({ chunkId }));
 
     // The attachment-id prefix is dropped (the directory already scopes by it)
-    // and the remaining suffix is slugified + lowercased for cross-filesystem
-    // safety. The shared `normalizePathToSlug` stays case-preserving; only the
-    // file-name path lowercases.
-    const expectedFile = path.join(dir, "docs-guide-md-setup-config-0-0.json");
+    // and the remaining suffix is hashed with xxh128 to a fixed 32-hex-char
+    // name, so source-path depth and heading-ancestry length can never exceed
+    // the filesystem's single-component limit.
+    const suffix = "docs/Guide.md::Setup & Config::0::0";
+    const expectedFile = path.join(dir, `${await xxh128(suffix)}.json`);
     await expect(fs.access(expectedFile)).resolves.toBeUndefined();
+    expect(path.basename(expectedFile)).toMatch(/^[0-9a-f]{32}\.json$/);
 
     // The authoritative chunkId round-trips intact from the JSON payload.
     const readBack = await storage.read(chunkId);
     expect(readBack?.chunkId).toBe(chunkId);
 
-    // Neither the verbatim chunkId nor an attachment-id-prefixed name is used.
+    // Neither the verbatim chunkId nor an attachment-id-prefixed slug is used.
     await expect(fs.access(path.join(dir, `${chunkId}.json`))).rejects.toThrow();
     await expect(
       fs.access(path.join(dir, "att-1-docs-guide-md-setup-config-0-0.json")),

--- a/tests/chunk-embedding-storage.unit.test.ts
+++ b/tests/chunk-embedding-storage.unit.test.ts
@@ -95,6 +95,22 @@ describe("ChunkEmbeddingStorage", () => {
     await expect(storage.list()).resolves.toEqual([]);
   });
 
+  it("returns null for a record whose payload chunkId differs from the requested one", async () => {
+    const { storage } = await makeStorage();
+    const requestedId = "att-1::docs/requested.md::Intro::0::0";
+    const mismatchedId = "att-1::docs/other.md::Intro::0::0";
+    // A well-formed record for `mismatchedId` placed at the path for
+    // `requestedId` — simulating a corrupt/misplaced file. read must reject it
+    // so a caller can't reuse a record keyed under the wrong id.
+    await fs.writeFile(
+      await storage.pathFor(requestedId),
+      JSON.stringify(makeRecord({ chunkId: mismatchedId })),
+      "utf-8",
+    );
+
+    await expect(storage.read(requestedId)).resolves.toBeNull();
+  });
+
   it("lists only valid records and ignores corrupt siblings", async () => {
     const { dir, storage } = await makeStorage();
     const valid = makeRecord();

--- a/tests/chunk-embedding-storage.unit.test.ts
+++ b/tests/chunk-embedding-storage.unit.test.ts
@@ -74,7 +74,7 @@ describe("ChunkEmbeddingStorage", () => {
   });
 
   it("returns null for corrupt JSON and skips it in list", async () => {
-    const { dir, storage } = await makeStorage();
+    const { storage } = await makeStorage();
     const chunkId = "att-1::docs/corrupt.md::Intro::0::0";
     await fs.writeFile(await storage.pathFor(chunkId), "{ not valid json", "utf-8");
 
@@ -83,7 +83,7 @@ describe("ChunkEmbeddingStorage", () => {
   });
 
   it("returns null for a well-formed file with the wrong shape and skips it in list", async () => {
-    const { dir, storage } = await makeStorage();
+    const { storage } = await makeStorage();
     const chunkId = "att-1::docs/shape.md::Intro::0::0";
     await fs.writeFile(
       await storage.pathFor(chunkId),
@@ -112,7 +112,7 @@ describe("ChunkEmbeddingStorage", () => {
   });
 
   it("lists only valid records and ignores corrupt siblings", async () => {
-    const { dir, storage } = await makeStorage();
+    const { storage } = await makeStorage();
     const valid = makeRecord();
     const corruptId = "att-1::docs/corrupt.md::Intro::0::0";
     await storage.write(valid);

--- a/tests/document-sync-embeddings.unit.test.ts
+++ b/tests/document-sync-embeddings.unit.test.ts
@@ -146,6 +146,28 @@ function isDefined(value: string | undefined): value is string {
   return value !== undefined;
 }
 
+/**
+ * Storage wrapper that delays `read` for a chosen set of chunk ids, used to
+ * force a deterministic read-completion order in the cap-selection test below.
+ */
+class DelayedReadStorage extends ChunkEmbeddingStorage {
+  constructor(
+    dir: string,
+    attachmentId: string,
+    private readonly delayed: Set<string>,
+    private readonly delayMs: number,
+  ) {
+    super(dir, attachmentId);
+  }
+
+  override async read(chunkId: string): Promise<ChunkEmbeddingRecord | null> {
+    if (this.delayed.has(chunkId)) {
+      await new Promise((resolve) => setTimeout(resolve, this.delayMs));
+    }
+    return super.read(chunkId);
+  }
+}
+
 describe("embedGenerationChunks", () => {
   it("embeds every chunk during sync and persists records to disk", async () => {
     const { storage } = await makeStorage();
@@ -208,6 +230,45 @@ describe("embedGenerationChunks", () => {
     expect(onDisk).toHaveLength(1);
     // Deterministic recency tie-break: docs/a.md sorts first.
     expect(onDisk[0]?.chunkId).toContain("docs-a-md");
+  });
+
+  it("breaks recency/source-path ties by chunkId so cap selection is deterministic regardless of read completion order", async () => {
+    // One document with two H1 sections -> two chunks that share sourcePath and
+    // recency, so they tie on every sort key except chunkId. Document order
+    // (Sierra then Alpha) deliberately differs from chunkId order (Alpha first),
+    // so a completion-order sort would select Sierra while a chunkId tie-break
+    // selects Alpha.
+    const gen = buildGeneration("att-1", [
+      makeFile(
+        "docs/two.md",
+        "# Sierra\n\nSierra section body content goes here.\n\n# Alpha\n\nAlpha section body content goes here.",
+      ),
+    ]);
+    expect(gen.chunks.size).toBe(2);
+    const sortedIds = [...gen.chunks.keys()].sort((a, b) => a.localeCompare(b));
+    expect(sortedIds).toHaveLength(2);
+    const winner = sortedIds[0];
+    if (winner === undefined) throw new Error("expected two chunks");
+
+    // Delay the winner's read so it completes LAST. Both chunks are new, so
+    // read returns null either way; the delay only changes when each lands in
+    // toEmbed. A sort that preserved completion order would then pick the
+    // faster (non-winner) chunk; the chunkId tie-break must pick the winner.
+    const base = await fs.mkdtemp(path.join(os.tmpdir(), "mnemonic-sync-embedding-"));
+    tempDirs.push(base);
+    const storage = new DelayedReadStorage(
+      path.join(base, "doc-source", "att-1"),
+      "att-1",
+      new Set([winner]),
+      30,
+    );
+    await storage.init();
+
+    await embedGenerationChunks(gen, makeContext(), "att-1", storage, new Map(), 1);
+
+    expect(embedMock).toHaveBeenCalledTimes(1);
+    expect(gen.chunkEmbeddings.size).toBe(1);
+    expect([...gen.chunkEmbeddings.keys()]).toEqual([winner]);
   });
 
   it("reuses on-disk embeddings for unchanged chunks and re-embeds only changed ones", async () => {

--- a/tests/hashing.unit.test.ts
+++ b/tests/hashing.unit.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { xxh128 } from "../src/hashing.js";
+
+describe("xxh128", () => {
+  // Known-answer pins guard against accidental algorithm substitution: if the
+  // underlying hash ever changes (or the wrapper is repointed), these hardcoded
+  // digests won't match. Values are XXH3-128 (hash-wasm `xxhash128`), captured
+  // independently of the wrapper under test so a swap is caught here rather
+  // than only via downstream filenames.
+  it("matches pinned XXH3-128 digests for known inputs", async () => {
+    const cases: Array<[string, string]> = [
+      ["", "99aa06d3014798d86001c324468d497f"],
+      ["hello", "b5e9c1ad071b3e7fc779cfaa5e523818"],
+      ["abc", "06b05ab6733a618578af5f94892f3950"],
+      ["docs/Guide.md::Setup & Config::0::0", "62769fa1bd2985ba587602465f2b7925"],
+      ["The quick brown fox jumps over the lazy dog", "ddd650205ca3e7fa24a1cc2e3a8a7651"],
+    ];
+    for (const [input, expected] of cases) {
+      expect(await xxh128(input)).toBe(expected);
+    }
+  });
+
+  it("is deterministic and emits 32 lowercase hex chars", async () => {
+    const a = await xxh128("repeated-input");
+    const b = await xxh128("repeated-input");
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{32}$/);
+  });
+});


### PR DESCRIPTION
## Summary

This PR captures the following design decisions:

- **Chunk embedding path layout: drop redundant guid prefix, lowercase filenames, reconcile on schema change**
- **Document-source chunk embeddings use xxh128 for filenames and content hashes**

## Changes

### Chunk embedding path layout: drop redundant guid prefix, lowercase filenames, reconcile on schema change

**Tags:** decision, attachments, document-source, embeddings

Refined the document-source chunk embedding on-disk layout in `src/chunk-embedding-storage.ts`, `src/document-sync.ts`, and `src/document-source-index.ts`. `indexSchemaVersion` bumped 2→3 to invalidate prior caches. The authoritative chunkId format (the `::`-separated id stored in JSON) is unchanged.

### Document-source chunk embeddings use xxh128 for filenames and content hashes

**Tags:** document-source, embeddings, retrieval, attachments

Document-source chunk embedding cache files are now named by an **xxh128 digest** of the chunkId suffix, and the per-chunk **content hash is also xxh128**. Both sites had been slug-based / SHA-256 by accident; this makes one deliberate non-cryptographic hash the single source of truth. Reverses the "hash-based names judged overkill" residual in `chunk-embedding-path-layout-drop-redundant-guid-prefix-lower-6b739d42`.

## Notes / References

_Detailed notes in `.mnemonic/notes/`:_

- `.mnemonic/notes/chunk-embedding-path-layout-drop-redundant-guid-prefix-lower-6b739d42.md` — Chunk embedding path layout: drop redundant guid prefix, lowercase filenames, reconcile on schema change
- `.mnemonic/notes/document-source-chunk-embeddings-use-xxh128-for-filenames-an-e3e988b8.md` — Document-source chunk embeddings use xxh128 for filenames and content hashes

---

_Generated from 2 design decision note(s) in `.mnemonic/notes/`. Run `/update-pr` to regenerate._