### PR TITLE
Lazy generation loading for document-sources

### DIFF
--- a/.mnemonic/notes/document-source-attachments-design-delivery-and-verification-1517e52b.md
+++ b/.mnemonic/notes/document-source-attachments-design-delivery-and-verification-1517e52b.md
@@ -9,7 +9,7 @@ tags:
   - decision
 lifecycle: permanent
 createdAt: '2026-08-01T09:26:59.248Z'
-updatedAt: '2026-08-01T20:43:23.908Z'
+updatedAt: '2026-08-03T09:57:46.881Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
@@ -23,6 +23,8 @@ relatedTo:
     type: explains
   - id: plan-deliver-document-source-chunk-semantic-retrieval-embedd-dba90b71
     type: follows
+  - id: document-source-embeddings-for-global-policy-projects-main-v-ff2954f1
+    type: related-to
 memoryVersion: 1
 ---
 Consolidates the completed document-source attachment workflow (request, research, two design reviews, six-stage plan, stage review) into one permanent canonical note. Source notes are deleted; durable detail remains in the related permanent notes.

--- a/.mnemonic/notes/document-source-chunk-embeddings-specified-but-never-deliver-6e867617.md
+++ b/.mnemonic/notes/document-source-chunk-embeddings-specified-but-never-deliver-6e867617.md
@@ -11,7 +11,7 @@ tags:
   - bug
 lifecycle: permanent
 createdAt: '2026-08-01T20:35:12.274Z'
-updatedAt: '2026-08-01T20:43:23.909Z'
+updatedAt: '2026-08-03T09:57:46.882Z'
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
@@ -20,6 +20,8 @@ relatedTo:
     type: related-to
   - id: plan-deliver-document-source-chunk-semantic-retrieval-embedd-dba90b71
     type: derives-from
+  - id: document-source-embeddings-for-global-policy-projects-main-v-ff2954f1
+    type: related-to
 memoryVersion: 1
 ---
 The canonical design note `document-source-attachments-design-delivery-and-verification-1517e52b` explicitly specified that document-source chunks be embedded, with lexical-only as the fail-soft fallback. Line 41: "embedding failures publish with lexical-only coverage" — a contract that only makes sense if embeddings are the primary path. Line 42 lists `embeddingCompatibilityIdentity` as part of the generation manifest, implying embeddings are produced and need a compatibility fingerprint for invalidation. Line 43 frames document chunks as full participants in recall ranking ("result diversity enforced after final scoring"), consistent with semantic+lexical hybrid fusion.

--- a/.mnemonic/notes/document-source-embeddings-for-global-policy-projects-main-v-ff2954f1.md
+++ b/.mnemonic/notes/document-source-embeddings-for-global-policy-projects-main-v-ff2954f1.md
@@ -1,0 +1,118 @@
+---
+title: >-
+  Document-source embeddings for global-policy projects: main-vault fallback and
+  lazy generation loading
+tags:
+  - attachments
+  - document-source
+  - embeddings
+  - storage
+  - global-policy
+  - design
+  - decision
+lifecycle: permanent
+createdAt: '2026-08-03T09:57:33.038Z'
+updatedAt: '2026-08-03T09:57:33.038Z'
+role: decision
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+# Document-source embeddings for global-policy projects: main-vault fallback and lazy generation loading
+
+## Problem
+
+Document-source chunk embeddings were stored under `.mnemonic/embeddings/doc-source/<attachmentId>/`, requiring the project vault (`.mnemonic/`) to exist. Projects with global storage policy never create `.mnemonic/` — `getOrCreateProjectVault` is only called from `remember` (scope: project) and `move_memory`. The unadopted-project principle (`vault-creation-audit-which-tools-can-create-mnemonic-and-whi-d0388691`) intentionally prevents silent `.mnemonic/` creation.
+
+Result: for global-policy projects, `syncDocumentSource` received `projectEmbeddingsDir = undefined` (from `getProjectVaultIfExists` returning null), so the embedding block was skipped entirely. Document sources were limited to lexical-only retrieval — the fail-soft fallback the spec described, not the intended primary path (`document-source-chunk-embeddings-specified-but-never-deliver-6e867617`).
+
+A second problem compounded the first: `DocumentGeneration` is in-memory only (module-level `Map` in `generation-storage.ts`). After every MCP server restart, generations vanish and recall returns no document chunks until the user manually runs `sync` to rebuild them.
+
+## Decision 1: Main-vault fallback for chunk embeddings (implemented, committed 034f6c8)
+
+When the project vault doesn't exist, store document-source chunk embeddings in the main vault, namespaced by project ID:
+
+```text
+~/mnemonic-vault/embeddings/doc-source/<projectId>/<attachmentId>/
+```
+
+The `syncDocumentSource` parameter was renamed `projectEmbeddingsDir` → `docSourceBase` to clarify it's the full doc-source embeddings base directory (including the `doc-source` segment and optional project-ID namespacing), not the raw vault embeddings directory. The caller (`sync.ts`) constructs the path:
+
+- Project vault exists: `path.join(projectVault.storage.embeddingsDir, "doc-source")`
+- Project vault missing: `path.join(mainVault.storage.embeddingsDir, "doc-source", project.id)`
+
+`remove-attachment` tries both locations (project vault + main vault fallback) for cleanup — `fs.rm` with `force: true` is a no-op for non-existent paths, so this also handles the edge case where storage policy changed between when embeddings were stored and when the attachment is removed.
+
+### Alternatives considered for Decision 1
+
+1. **Create a minimal `.mnemonic/embeddings/` without full vault** — rejected because `.mnemonic/` existence is the adoption signal for `resolveWriteScope()`. Creating it would cause `remember` to default to "project" instead of "ask", violating the unadopted-project principle.
+2. **Separate per-project embeddings cache** (e.g., `~/mnemonic-vault/embeddings/projects/<projectId>/doc-source/<attachmentId>/`) — rejected as more complex than necessary; the simpler namespacing by project ID directly under `doc-source/` achieves the same isolation.
+3. **Make sync create the project vault on-demand for document sources** — rejected for the same reason as alternative 1.
+
+### Tradeoffs
+
+- Main vault grows with document-source embeddings (gitignored, re-computable — same as note embeddings)
+- Embeddings not co-located with the project (acceptable: embeddings are derived state, never committed)
+- Need namespacing by project ID to avoid collisions between projects (handled by the path construction)
+
+## Decision 2: Lazy generation loading via persisted manifest (not yet implemented)
+
+The ephemeral generation issue (`DocumentGeneration` is in-memory only, lost on restart) was analyzed extensively. Multiple approaches were considered and rejected before arriving at the chosen design.
+
+### Alternatives considered for Decision 2
+
+1. **`autoSync` as a per-project setting, triggering full `sync` on recall** — rejected for two reasons:
+   - **Naming inconsistency**: `sync` is a generic capability covering vaults, mnemonic-vault attachments, and document sources. An `autoSync` setting that only covers document sources is confusing — users would expect it to sync everything.
+   - **Not really sync**: If `autoSync` only rebuilds the in-memory generation from the last known commit (no `git fetch`, no network), it's not "sync" — it's just loading data that should have been persisted. Calling it "sync" misrepresents what it does.
+
+2. **`autoSync` as a general setting triggering full `sync` (including git fetch) on recall** — rejected because:
+   - Network I/O on recall could add seconds of latency
+   - Requires timeout handling to prevent recall from blocking indefinitely
+   - Users opted into document sources, not into network I/O on every recall
+
+3. **Persist the full `DocumentGeneration` to disk** (e.g., `generation.json` containing chunks, documents, content) — rejected because it would duplicate all markdown content locally. The source files already exist in the git repo. Copying them into a generation file defeats the purpose of document sources being a lightweight, non-copying retrieval layer.
+
+4. **Require manual `sync` after every restart** (status quo) — rejected as poor UX. Users expect recall to work without manual intervention, especially after the main-vault fallback makes embeddings available for global-policy projects.
+
+### Chosen approach: Persist a tiny manifest, rebuild from git on demand
+
+At the end of a successful `syncDocumentSource`, write a small manifest file alongside the chunk embeddings:
+
+```text
+<embeddingsDir>/doc-source/<attachmentId>/manifest.json
+```
+
+Contents: `indexedCommit`, `indexSchemaVersion`, `embeddingCompatibilityIdentity`, `documentCount`, `chunkCount`. A few hundred bytes — not content.
+
+On recall, when `getCurrentGeneration(attachmentId)` returns null:
+
+1. Read the manifest from disk (one tiny file)
+2. Rebuild the generation from git at the known commit — `git ls-tree` + `git show` per file (local only, no network)
+3. Load chunk embeddings from existing disk files (content-hash reuse, no re-embedding)
+4. Assemble and publish the in-memory `DocumentGeneration`
+5. Proceed with recall
+
+If no manifest exists (never synced, or cleaned up): skip — no chunks for that attachment. User runs `sync` first.
+
+### Why this works
+
+- **No content duplication**: content stays in the git repo. The manifest is a bookmark, not a copy.
+- **No network I/O**: we read from the local git repo at the known commit. No `git fetch`.
+- **No new user-facing setting**: no `autoSync` in `ProjectMemoryPolicy`, no naming problem. It's just lazy loading from the source on first access — the same pattern as loading notes from `.md` files.
+- **No timeout concern**: the operation is bounded local I/O. For a moderate repo (~100 files), ~200ms-500ms. For a large repo (~1000 files), ~1-2s. Once per session; subsequent recalls are O(1).
+- **Existing cleanup covers it**: `remove-attachment` already `fs.rm`s the entire `<attachmentId>/` directory — the manifest lives there.
+- **Manual sync still needed for new commits**: lazy loading rebuilds at the last known commit, not HEAD. Staying up-to-date with remote requires manual `sync` (which does `git fetch`). This is acceptable — the problem was the ephemeral generation, not stale content.
+
+### Relationship to the plan note
+
+The plan note (`plan-deliver-document-source-chunk-semantic-retrieval-embedd-dba90b71`) explicitly chose "DocumentGeneration stays in-memory; chunk embeddings persist to disk separately." This decision didn't account for the restart scenario. The manifest approach doesn't violate that decision — the generation is still in-memory for the session, and the chunks are still rebuilt from the git repo (not persisted as a copy). The manifest is just enough persisted state to know *which commit* to rebuild from, not the generation itself.
+
+## Implementation status
+
+- Decision 1 (main-vault fallback): implemented and committed (034f6c8). Tests pass (1415 tests, typecheck, lint clean).
+- Decision 2 (lazy generation loading): not yet implemented. Design agreed. Implementation requires:
+  1. Write manifest file at end of `syncDocumentSource`
+  2. Loader function: read manifest + rebuild generation from git + load embeddings from disk
+  3. `recall.ts`: call loader when `getCurrentGeneration()` returns null
+  4. Tests: verify recall works after simulated restart (clear in-memory generations, recall, verify chunks returned)

--- a/.mnemonic/notes/document-source-embeddings-for-global-policy-projects-main-v-ff2954f1.md
+++ b/.mnemonic/notes/document-source-embeddings-for-global-policy-projects-main-v-ff2954f1.md
@@ -12,11 +12,14 @@ tags:
   - decision
 lifecycle: permanent
 createdAt: '2026-08-03T09:57:33.038Z'
-updatedAt: '2026-08-03T09:57:33.038Z'
+updatedAt: '2026-08-03T09:57:46.884Z'
 role: decision
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: vault-creation-audit-which-tools-can-create-mnemonic-and-whi-d0388691
+    type: related-to
 memoryVersion: 1
 ---
 # Document-source embeddings for global-policy projects: main-vault fallback and lazy generation loading

--- a/.mnemonic/notes/document-source-embeddings-for-global-policy-projects-main-v-ff2954f1.md
+++ b/.mnemonic/notes/document-source-embeddings-for-global-policy-projects-main-v-ff2954f1.md
@@ -12,7 +12,7 @@ tags:
   - decision
 lifecycle: permanent
 createdAt: '2026-08-03T09:57:33.038Z'
-updatedAt: '2026-08-03T09:57:46.884Z'
+updatedAt: '2026-08-03T10:08:13.894Z'
 role: decision
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -20,6 +20,8 @@ projectName: mnemonic
 relatedTo:
   - id: vault-creation-audit-which-tools-can-create-mnemonic-and-whi-d0388691
     type: related-to
+  - id: review-lazy-document-generation-loading-needs-concurrency-an-b49cd0cd
+    type: follows
 memoryVersion: 1
 ---
 # Document-source embeddings for global-policy projects: main-vault fallback and lazy generation loading

--- a/.mnemonic/notes/plan-deliver-document-source-chunk-semantic-retrieval-embedd-dba90b71.md
+++ b/.mnemonic/notes/plan-deliver-document-source-chunk-semantic-retrieval-embedd-dba90b71.md
@@ -11,7 +11,7 @@ tags:
   - architecture
 lifecycle: permanent
 createdAt: '2026-08-01T20:43:19.999Z'
-updatedAt: '2026-08-01T22:39:42.026Z'
+updatedAt: '2026-08-03T09:57:46.882Z'
 role: plan
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -21,6 +21,8 @@ relatedTo:
     type: derives-from
   - id: chunk-embedding-path-layout-drop-redundant-guid-prefix-lower-6b739d42
     type: derives-from
+  - id: document-source-embeddings-for-global-policy-projects-main-v-ff2954f1
+    type: related-to
 memoryVersion: 1
 ---
 Plan to deliver the document-source chunk semantic retrieval that the canonical design note (`document-source-attachments-design-delivery-and-verification-1517e52b`) specified but never shipped (see `document-source-chunk-embeddings-specified-but-never-deliver-6e867617`). Today document chunks are lexical-only and render in a trailing `## Document Results` section never fused into the note RRF ranking. This plan makes embeddings the primary channel with lexical as the fail-soft fallback (the spec's line-41 contract), fuses chunks into the unified ranking below notes, and persists chunk embeddings to disk for cheap re-syncs.

--- a/.mnemonic/notes/project-memory-policy-defaults-storage-location-f563f634.md
+++ b/.mnemonic/notes/project-memory-policy-defaults-storage-location-f563f634.md
@@ -8,7 +8,7 @@ tags:
   - unadopted
 lifecycle: permanent
 createdAt: '2026-03-07T19:25:37.785Z'
-updatedAt: '2026-05-09T21:16:14.023Z'
+updatedAt: '2026-08-03T09:57:46.883Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
@@ -17,6 +17,8 @@ relatedTo:
   - id: vault-creation-audit-which-tools-can-create-mnemonic-and-whi-d0388691
     type: related-to
   - id: mutation-push-mode-defaults-for-project-vault-writes-ab095db1
+    type: related-to
+  - id: document-source-embeddings-for-global-policy-projects-main-v-ff2954f1
     type: related-to
 memoryVersion: 1
 ---

--- a/.mnemonic/notes/review-lazy-document-generation-loading-needs-concurrency-an-b49cd0cd.md
+++ b/.mnemonic/notes/review-lazy-document-generation-loading-needs-concurrency-an-b49cd0cd.md
@@ -12,11 +12,14 @@ tags:
   - design
 lifecycle: permanent
 createdAt: '2026-08-03T10:08:07.644Z'
-updatedAt: '2026-08-03T10:08:07.644Z'
+updatedAt: '2026-08-03T10:08:13.894Z'
 role: review
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: document-source-embeddings-for-global-policy-projects-main-v-ff2954f1
+    type: follows
 memoryVersion: 1
 ---
 ## Verdict

--- a/.mnemonic/notes/review-lazy-document-generation-loading-needs-concurrency-an-b49cd0cd.md
+++ b/.mnemonic/notes/review-lazy-document-generation-loading-needs-concurrency-an-b49cd0cd.md
@@ -1,0 +1,47 @@
+---
+title: >-
+  Review: lazy document-generation loading needs concurrency and routing
+  hardening
+tags:
+  - global-policy
+  - document-source
+  - storage
+  - attachments
+  - embeddings
+  - review
+  - design
+lifecycle: permanent
+createdAt: '2026-08-03T10:08:07.644Z'
+updatedAt: '2026-08-03T10:08:07.644Z'
+role: review
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+## Verdict
+
+Decision 1 (main-vault fallback for global-policy projects) is sound and already works. Decision 2's core direction—persist a small derived-state manifest and lazily rebuild from the pinned local git commit without fetching—is sound, but the current plan is **not implementation-ready**. It needs concurrency, routing, compatibility, and failure-semantics changes before implementation.
+
+## Must-fix design gaps
+
+1. **Atomic construction and single-flight coordination.** `buildGenerationFromFiles()` currently publishes immediately, then `syncDocumentSource()` mutates the manifest and fills embeddings asynchronously. A recall can observe partial state. A cold lazy load can also publish an older manifest commit after a concurrent sync, regressing the current pointer. Refactor construction to return a complete unpublished generation; coordinate sync and load with a project+attachment keyed single-flight/mutex; publish once with compare-and-swap/epoch protection. Write manifests with temp-file + atomic rename only after reconciliation.
+
+2. **Project-scoped generation routing and lifecycle eviction.** `generation-storage.ts` is keyed only by attachment ID. `get(doc:/chunk:)` does not verify that the attachment belongs to the resolved project or remains enabled. Removal/disable/replacement does not evict an in-memory generation. Key state by `{consumerProjectId, attachmentId}`, authorize enabled config before use, share the loader between recall and get, and add explicit eviction on remove, disable, and replacement.
+
+3. **Dual cache-location resolution.** Storage can move from main fallback to project vault when `.mnemonic/` later appears. Recall must probe both locations deterministically or migrations will make previously synced manifests invisible. Centralize path resolution. A strong alternative is to make `~/mnemonic-vault/embeddings/doc-source/<projectId>/<attachmentId>/` canonical for all document-source derived state and dual-read old project paths during migration.
+
+4. **Versioned, validated manifest.** The proposed fields are insufficient. Persist project/attachment binding, generation ID, indexed commit, normalized attachment-config hash (`localPath`/repo identity, root, include, exclude, accepted media types), separate extractor/chunker/projection/index identities, separate embedding compatibility identity, counts including embedded chunks, and build time. Validate the schema and full commit object ID and verify the object exists. Index incompatibility should require sync; embedding-only incompatibility should still allow lexical reconstruction while ignoring vectors.
+
+5. **Capped embedding backfill.** `isGenerationCurrent()` returns unchanged for a compatible commit even if the first sync embedded only `maxEmbeddingWork` chunks. Therefore large sources can remain permanently partially embedded. Treat index currency and embedding completeness separately; unchanged syncs should load/reconcile and embed the next bounded batch. Repair a missing manifest on the unchanged path.
+
+## Important refinements
+
+- Replace sequential `git show` per file with `git cat-file --batch`/bounded blob reads; enforce file limits before blob hydration; benchmark at 1k/5k files before claiming 1–2 second cold-load latency.
+- Bound embedding-file reads; avoid an unbounded `Promise.all` over up to 50k records.
+- Fail soft per attachment but surface `local index unavailable; run sync` diagnostics instead of conflating failures with no matches.
+- Test a true process restart, not only `clearAllGenerations()`: sync, stop MCP, restart with the same vault/config and embedding provider unavailable, then recall and direct get. Also cover both storage routes, route switching, concurrent recall/sync, corrupt manifest, missing commit, identity mismatch, capped backfill, disable/removal/replacement.
+
+## Alternatives assessment
+
+Rejected automatic network sync on recall and full-generation content duplication remain correctly rejected. The main missed alternatives are (a) one canonical main-vault cache location for all document-source derived state, and (b) a compact persisted retrieval index with lazy top-result hydration if cold rebuild benchmarks prove too slow. The latter should remain a measured fallback, not the initial implementation.

--- a/.mnemonic/notes/vault-creation-audit-which-tools-can-create-mnemonic-and-whi-d0388691.md
+++ b/.mnemonic/notes/vault-creation-audit-which-tools-can-create-mnemonic-and-whi-d0388691.md
@@ -8,11 +8,13 @@ tags:
   - testing
 lifecycle: permanent
 createdAt: '2026-03-12T15:41:29.294Z'
-updatedAt: '2026-03-14T00:24:21.751Z'
+updatedAt: '2026-08-03T09:57:46.884Z'
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
   - id: project-memory-policy-defaults-storage-location-f563f634
+    type: related-to
+  - id: document-source-embeddings-for-global-policy-projects-main-v-ff2954f1
     type: related-to
 memoryVersion: 1
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 
 ## [Unreleased]
 
+### Added
+
+- Document-source chunks are now available in recall after an MCP server restart without manually running `sync` first. A small manifest persisted during sync lets the generation be lazily rebuilt from git on the first recall or `get` that needs it — all local I/O, no network fetch.
+
 ### Changed
 
 - Document-source attachments now store chunk embeddings in the main vault (namespaced by project ID) when the project has no `.mnemonic/` directory, so projects with global storage policy get full semantic retrieval instead of falling back to lexical-only. Previously, embeddings were silently skipped when the project vault didn't exist.
+- Removing or disabling a document-source attachment now immediately clears its in-memory index, so recall no longer returns stale chunks from a detached or disabled source.
 
 ### Fixed
 

--- a/src/chunk-embedding-storage.ts
+++ b/src/chunk-embedding-storage.ts
@@ -103,15 +103,24 @@ export class ChunkEmbeddingStorage {
       [] as string[],
     );
     const files = filesResult.ok ? filesResult.value : [];
+    // The per-attachment directory also holds the lazy-load manifest; it is not
+    // a chunk embedding file and must be excluded from the scan.
+    const jsonFiles = files.filter((file) => file.endsWith(".json") && file !== "manifest.json");
     // Read files directly rather than round-tripping the basename through
     // read()/pathFor(). The old slug scheme was idempotent (slug(slug(x)) ===
     // slug(x)), so the round-trip worked by coincidence; the xxh128 name is NOT
     // idempotent (hash(hash(x)) !== hash(x)), so pathFor(basename) would
     // re-hash the hex and miss every file. Mirrors reconcile()'s direct read.
-    const records = await Promise.all(
-      files
-        .filter((file) => file.endsWith(".json"))
-        .map(async (file) => {
+    //
+    // Bound concurrency: up to 50k chunks would otherwise open 50k file
+    // descriptors at once via Promise.all. Process in fixed-size batches so the
+    // lazy loader and reconcile sweeps stay within file-descriptor limits.
+    const BATCH_SIZE = 100;
+    const records: ChunkEmbeddingRecord[] = [];
+    for (let i = 0; i < jsonFiles.length; i += BATCH_SIZE) {
+      const batch = jsonFiles.slice(i, i + BATCH_SIZE);
+      const batchRecords = await Promise.all(
+        batch.map(async (file) => {
           const raw = await attempt("chunk-embedding:list", () =>
             fs.readFile(path.join(this.dir, file), "utf-8"),
           );
@@ -122,8 +131,12 @@ export class ChunkEmbeddingStorage {
           if (!parsed.ok) return null;
           return validateChunkEmbeddingRecord(parsed.value);
         }),
-    );
-    return records.filter((record): record is ChunkEmbeddingRecord => record !== null);
+      );
+      for (const record of batchRecords) {
+        if (record !== null) records.push(record);
+      }
+    }
+    return records;
   }
 
   async remove(chunkId: string): Promise<void> {

--- a/src/document-lazy-load.ts
+++ b/src/document-lazy-load.ts
@@ -1,4 +1,4 @@
-import { execFile } from "child_process";
+import { execFile, spawn } from "child_process";
 import { promisify } from "util";
 import path from "path";
 import type { DocumentGeneration } from "./retrieval-document.js";
@@ -12,7 +12,7 @@ import {
 import { getExtractor } from "./document-extractor.js";
 import { markdownChunker } from "./markdown-chunker.js";
 import { ChunkEmbeddingStorage } from "./chunk-embedding-storage.js";
-import { attempt } from "./error-utils.js";
+import { attempt, getErrorMessage } from "./error-utils.js";
 import { expandHomePath } from "./paths.js";
 import { matchAnyGlob } from "./glob-match.js";
 import type { DocumentSourceAttachmentConfig } from "./vault.js";
@@ -27,6 +27,10 @@ const MAX_LAZY_LOAD_FILES = 5000;
  * Enumerate and read the files at a given git commit, applying the attachment's
  * include/exclude globs relative to `config.root`. Mirrors the enumeration in
  * `syncDocumentSource`. Fail-soft: any git failure returns `null`.
+ *
+ * Blob content is hydrated with a single `git cat-file --batch` subprocess
+ * rather than one `git show` call per file; the old sequential path is kept as
+ * a fallback if the batch subprocess fails.
  */
 async function enumerateFilesAtCommit(
   resolvedLocalPath: string,
@@ -42,7 +46,12 @@ async function enumerateFilesAtCommit(
   const lsTreeResult = await attempt("lazy-load:ls-tree", () =>
     run(["ls-tree", "-r", "--name-only", indexedCommit]),
   );
-  if (!lsTreeResult.ok) return null;
+  if (!lsTreeResult.ok) {
+    console.error(
+      `[lazy-load] ls-tree failed for ${indexedCommit}: ${getErrorMessage(lsTreeResult.error)}`,
+    );
+    return null;
+  }
 
   const allFiles = lsTreeResult.value.trim().split("\n").filter(Boolean);
   const root = config.root || ".";
@@ -58,18 +67,146 @@ async function enumerateFilesAtCommit(
     return true;
   });
 
+  // Enforce the file cap BEFORE blob hydration so a huge repo cannot flood the
+  // subprocess with an unbounded number of paths.
   const boundedFiles = matchedFiles.slice(0, MAX_LAZY_LOAD_FILES);
 
+  if (boundedFiles.length === 0) return [];
+
+  // Single subprocess reads all matching blobs.
+  const batchResult = await attempt("lazy-load:cat-file", () =>
+    readBlobsBatch(resolvedLocalPath, indexedCommit, boundedFiles),
+  );
+  if (batchResult.ok) return batchResult.value;
+  console.error(
+    `[lazy-load] git cat-file --batch failed for ${boundedFiles.length} files; falling back to sequential git show: ${getErrorMessage(batchResult.error)}`,
+  );
+
+  // Fallback: sequential `git show` per file (kept for robustness when the
+  // batch subprocess is unavailable, e.g. exotic git wrappers).
   const files: Array<{ path: string; bytes: Uint8Array }> = [];
   for (const filePath of boundedFiles) {
     const showResult = await attempt("lazy-load:show", () =>
       run(["show", `${indexedCommit}:${filePath}`]),
     );
-    if (!showResult.ok) return null;
+    if (!showResult.ok) {
+      console.error(
+        `[lazy-load] git show failed for ${filePath}: ${getErrorMessage(showResult.error)}`,
+      );
+      return null;
+    }
     files.push({ path: filePath, bytes: new TextEncoder().encode(showResult.value) });
   }
 
   return files;
+}
+
+/**
+ * Read a set of file blobs from a commit in a single `git cat-file --batch`
+ * subprocess.
+ *
+ * Each input line `<commit>:<path>` resolves to the file's blob; output is a
+ * `<oid> <type> <size>\n<content>\n` block per requested object. `missing`
+ * blobs are skipped (fail-soft). Resolves with the byte contents in the same
+ * order as `filePaths`, omitting any `missing` entries.
+ *
+ * The parser accumulates stdout in a buffer and only emits an entry once both
+ * the header line and the full `<size>` bytes (plus the trailing newline) are
+ * available, so header/content splits across `data` chunks are handled
+ * correctly. Rejects if the subprocess exits before every requested blob is
+ * read or if a header is malformed.
+ */
+function readBlobsBatch(
+  resolvedLocalPath: string,
+  indexedCommit: string,
+  filePaths: string[],
+): Promise<Array<{ path: string; bytes: Uint8Array }>> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("git", ["cat-file", "--batch"], {
+      cwd: resolvedLocalPath,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    if (!proc.stdout || !proc.stdin) {
+      return Promise.reject(new Error("git cat-file --batch: stdio not available"));
+    }
+    const stdout = proc.stdout;
+    const stdin = proc.stdin;
+    const files: Array<{ path: string; bytes: Uint8Array }> = [];
+    let stdoutBuf = Buffer.alloc(0);
+    let fileIdx = 0;
+
+    stdout.on("data", (chunk: Buffer) => {
+      stdoutBuf = Buffer.concat([stdoutBuf, chunk]);
+      while (fileIdx < filePaths.length) {
+        const newlineIdx = stdoutBuf.indexOf(0x0a);
+        if (newlineIdx === -1) break; // header line incomplete; wait for more data
+        const header = stdoutBuf.subarray(0, newlineIdx).toString("utf-8");
+        // Consume the header line including its trailing newline.
+        stdoutBuf = stdoutBuf.subarray(newlineIdx + 1);
+
+        const parts = header.split(" ");
+        const type = parts[1];
+        if (type === "missing") {
+          fileIdx++;
+          continue;
+        }
+        const oid = parts[0];
+        const sizeStr = parts[2];
+        if (!oid || !sizeStr) {
+          proc.kill();
+          reject(new Error(`unexpected git cat-file --batch header: "${header}"`));
+          return;
+        }
+        const size = parseInt(sizeStr, 10);
+        if (Number.isNaN(size) || size < 0) {
+          proc.kill();
+          reject(new Error(`invalid blob size in header: "${header}"`));
+          return;
+        }
+        // Content is followed by a trailing newline; need at least size+1 bytes.
+        if (stdoutBuf.length < size + 1) {
+          // Not enough data yet; restore the header so we re-parse when more
+          // arrives, and wait for the next data chunk.
+          stdoutBuf = Buffer.concat([Buffer.from(header + "\n"), stdoutBuf]);
+          break;
+        }
+        const content = stdoutBuf.subarray(0, size);
+        // Skip the content plus its trailing newline.
+        stdoutBuf = stdoutBuf.subarray(size + 1);
+        const fp = filePaths[fileIdx];
+        if (!fp) break;
+        files.push({ path: fp, bytes: new Uint8Array(content) });
+        fileIdx++;
+      }
+    });
+
+    proc.on("close", (code) => {
+      if (fileIdx < filePaths.length) {
+        reject(
+          new Error(
+            `git cat-file --batch closed (code ${code}) before all ${filePaths.length} blobs were read (got ${fileIdx})`,
+          ),
+        );
+      } else {
+        resolve(files);
+      }
+    });
+
+    proc.on("error", reject);
+
+    void (async () => {
+      const writeResult = await attempt("lazy-load:batch-write", () => {
+        for (const fp of filePaths) {
+          stdin.write(`${indexedCommit}:${fp}\n`);
+        }
+        stdin.end();
+      });
+      if (!writeResult.ok) {
+        proc.kill();
+        reject(writeResult.error);
+      }
+    })();
+  });
 }
 
 /**
@@ -99,7 +236,12 @@ export async function lazyLoadGeneration(
   _ctx: ServerContext,
   docSourceBase: string | undefined,
 ): Promise<DocumentGeneration | null> {
-  if (!docSourceBase) return null;
+  if (!docSourceBase) {
+    console.error(
+      `[lazy-load] no doc-source base for ${attachmentId} — run sync to index document sources`,
+    );
+    return null;
+  }
   const attachmentDir = path.join(docSourceBase, attachmentId);
 
   return withGenerationLock(projectId, attachmentId, async () => {
@@ -110,28 +252,47 @@ export async function lazyLoadGeneration(
 
     const manifestResult = await attempt("lazy-load:manifest", () => readManifest(attachmentDir));
     const manifest = manifestResult.ok ? manifestResult.value : null;
-    if (!manifest) return null;
+    if (!manifest) {
+      console.error(
+        `[lazy-load] no manifest for ${attachmentId} — run sync to index document sources`,
+      );
+      return null;
+    }
 
     // Validate manifest identity against function parameters and current config.
     // A mismatch means the manifest is stale (config changed, or the file was
     // copied from another project/attachment) — force a re-sync by returning null.
     if (manifest.projectId !== projectId || manifest.attachmentId !== attachmentId) {
+      console.error(
+        `[lazy-load] manifest binding mismatch for ${attachmentId} — run sync to index document sources`,
+      );
       return null;
     }
     const currentConfigHash = await computeAttachmentConfigHash(config);
-    if (currentConfigHash !== manifest.attachmentConfigHash) return null;
+    if (currentConfigHash !== manifest.attachmentConfigHash) {
+      console.error(
+        `[lazy-load] manifest config hash mismatch for ${attachmentId} — run sync to update`,
+      );
+      return null;
+    }
 
     // Validate extractor/chunker identity — a version drift means the manifest
     // was built with different derivation logic and should not be reused.
     const mediaType = config.acceptedMediaTypes[0] || "text/markdown";
     const extractor = getExtractor(mediaType);
-    if (!extractor) return null;
+    if (!extractor) {
+      console.error(`[lazy-load] no extractor for media type ${mediaType}`);
+      return null;
+    }
     if (
       manifest.extractorId !== extractor.extractorId ||
       manifest.extractorVersion !== extractor.extractorVersion ||
       manifest.chunkerId !== markdownChunker.chunkerId ||
       manifest.chunkerVersion !== markdownChunker.chunkerVersion
     ) {
+      console.error(
+        `[lazy-load] extractor/chunker version mismatch for ${attachmentId} — run sync to reindex`,
+      );
       return null;
     }
 
@@ -140,7 +301,18 @@ export async function lazyLoadGeneration(
       enumerateFilesAtCommit(resolvedLocalPath, config, manifest.indexedCommit),
     );
     const files = filesResult.ok ? filesResult.value : null;
-    if (!files || files.length === 0) return null;
+    if (!files) {
+      console.error(
+        `[lazy-load] git rebuild failed for ${attachmentId}: ${filesResult.ok ? "ls-tree/read failed" : getErrorMessage(filesResult.error)}`,
+      );
+      return null;
+    }
+    if (files.length === 0) {
+      console.error(
+        `[lazy-load] no matching files at commit ${manifest.indexedCommit} for ${attachmentId}`,
+      );
+      return null;
+    }
 
     // buildGenerationFromFiles RETURNS the generation now; it does not publish.
     const generation = buildGenerationFromFiles(

--- a/src/document-lazy-load.ts
+++ b/src/document-lazy-load.ts
@@ -1,0 +1,175 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+import path from "path";
+import type { DocumentGeneration } from "./retrieval-document.js";
+import { readManifest, computeAttachmentConfigHash } from "./document-manifest.js";
+import { buildGenerationFromFiles } from "./document-source-index.js";
+import {
+  getCurrentGeneration,
+  publishGeneration,
+  withGenerationLock,
+} from "./generation-storage.js";
+import { getExtractor } from "./document-extractor.js";
+import { markdownChunker } from "./markdown-chunker.js";
+import { ChunkEmbeddingStorage } from "./chunk-embedding-storage.js";
+import { attempt } from "./error-utils.js";
+import { expandHomePath } from "./paths.js";
+import { matchAnyGlob } from "./glob-match.js";
+import type { DocumentSourceAttachmentConfig } from "./vault.js";
+import type { ServerContext } from "./server-context.js";
+
+const execFileAsync = promisify(execFile);
+
+/** Cap git blob reads per lazy load so a huge repository cannot stall recall. */
+const MAX_LAZY_LOAD_FILES = 5000;
+
+/**
+ * Enumerate and read the files at a given git commit, applying the attachment's
+ * include/exclude globs relative to `config.root`. Mirrors the enumeration in
+ * `syncDocumentSource`. Fail-soft: any git failure returns `null`.
+ */
+async function enumerateFilesAtCommit(
+  resolvedLocalPath: string,
+  config: Pick<DocumentSourceAttachmentConfig, "root" | "include" | "exclude">,
+  indexedCommit: string,
+): Promise<Array<{ path: string; bytes: Uint8Array }> | null> {
+  const run = (args: string[]): Promise<string> =>
+    execFileAsync("git", args, {
+      cwd: resolvedLocalPath,
+      maxBuffer: 64 * 1024 * 1024,
+    }).then((result) => result.stdout);
+
+  const lsTreeResult = await attempt("lazy-load:ls-tree", () =>
+    run(["ls-tree", "-r", "--name-only", indexedCommit]),
+  );
+  if (!lsTreeResult.ok) return null;
+
+  const allFiles = lsTreeResult.value.trim().split("\n").filter(Boolean);
+  const root = config.root || ".";
+  const includePatterns = config.include.length > 0 ? config.include : ["**/*.md"];
+  const excludePatterns = config.exclude || [];
+  const rootPrefix = root === "." ? "" : root + "/";
+
+  const matchedFiles = allFiles.filter((file) => {
+    if (rootPrefix && !file.startsWith(rootPrefix)) return false;
+    const rel = rootPrefix ? file.slice(rootPrefix.length) : file;
+    if (!matchAnyGlob(includePatterns, rel)) return false;
+    if (matchAnyGlob(excludePatterns, rel)) return false;
+    return true;
+  });
+
+  const boundedFiles = matchedFiles.slice(0, MAX_LAZY_LOAD_FILES);
+
+  const files: Array<{ path: string; bytes: Uint8Array }> = [];
+  for (const filePath of boundedFiles) {
+    const showResult = await attempt("lazy-load:show", () =>
+      run(["show", `${indexedCommit}:${filePath}`]),
+    );
+    if (!showResult.ok) return null;
+    files.push({ path: filePath, bytes: new TextEncoder().encode(showResult.value) });
+  }
+
+  return files;
+}
+
+/**
+ * Lazily rebuild a `DocumentGeneration` from persisted state after an MCP
+ * server restart cleared the in-memory generation store.
+ *
+ * Called from recall when `getCurrentGeneration(projectId, attachmentId)`
+ * returns null. Steps:
+ * 1. Read the persisted manifest at `<docSourceBase>/<attachmentId>/manifest.json`.
+ * 2. If no valid manifest → return null (the user must run `sync` first).
+ * 3. Rebuild the generation from git at `manifest.indexedCommit` via
+ *    `buildGenerationFromFiles` (which now RETURNS the generation and does NOT
+ *    publish it).
+ * 4. Load persisted chunk embeddings from disk into the generation.
+ * 5. Publish the generation so subsequent recall hits the in-memory store.
+ *
+ * The rebuild happens inside `withGenerationLock` so concurrent recalls
+ * single-flight the git work; inside the lock it double-checks the in-memory
+ * state (another caller may have loaded it first). Fail-soft throughout: any
+ * error (git failure, missing commit, corrupt manifest) returns null so recall
+ * still works without document chunks rather than throwing.
+ */
+export async function lazyLoadGeneration(
+  projectId: string,
+  attachmentId: string,
+  config: DocumentSourceAttachmentConfig,
+  _ctx: ServerContext,
+  docSourceBase: string | undefined,
+): Promise<DocumentGeneration | null> {
+  if (!docSourceBase) return null;
+  const attachmentDir = path.join(docSourceBase, attachmentId);
+
+  return withGenerationLock(projectId, attachmentId, async () => {
+    // Another caller may have loaded the generation while we waited for the
+    // lock — if so, use it instead of re-deriving from git.
+    const existing = getCurrentGeneration(projectId, attachmentId);
+    if (existing) return existing;
+
+    const manifestResult = await attempt("lazy-load:manifest", () => readManifest(attachmentDir));
+    const manifest = manifestResult.ok ? manifestResult.value : null;
+    if (!manifest) return null;
+
+    // Validate manifest identity against function parameters and current config.
+    // A mismatch means the manifest is stale (config changed, or the file was
+    // copied from another project/attachment) — force a re-sync by returning null.
+    if (manifest.projectId !== projectId || manifest.attachmentId !== attachmentId) {
+      return null;
+    }
+    const currentConfigHash = await computeAttachmentConfigHash(config);
+    if (currentConfigHash !== manifest.attachmentConfigHash) return null;
+
+    // Validate extractor/chunker identity — a version drift means the manifest
+    // was built with different derivation logic and should not be reused.
+    const mediaType = config.acceptedMediaTypes[0] || "text/markdown";
+    const extractor = getExtractor(mediaType);
+    if (!extractor) return null;
+    if (
+      manifest.extractorId !== extractor.extractorId ||
+      manifest.extractorVersion !== extractor.extractorVersion ||
+      manifest.chunkerId !== markdownChunker.chunkerId ||
+      manifest.chunkerVersion !== markdownChunker.chunkerVersion
+    ) {
+      return null;
+    }
+
+    const resolvedLocalPath = path.resolve(expandHomePath(config.localPath));
+    const filesResult = await attempt("lazy-load:enumerate", () =>
+      enumerateFilesAtCommit(resolvedLocalPath, config, manifest.indexedCommit),
+    );
+    const files = filesResult.ok ? filesResult.value : null;
+    if (!files || files.length === 0) return null;
+
+    // buildGenerationFromFiles RETURNS the generation now; it does not publish.
+    const generation = buildGenerationFromFiles(
+      attachmentId,
+      files,
+      config.acceptedMediaTypes,
+      extractor,
+      markdownChunker,
+      manifest.indexedCommit,
+    );
+
+    // Restore the authoritative embedding-compatibility identity recorded at
+    // sync time. buildGenerationFromFiles derives a chunker/extractor-only
+    // identity; the persisted manifest carries the full identity (including the
+    // embedding model), so a later isGenerationCurrent check stays accurate.
+    generation.manifest.embeddingCompatibilityIdentity = manifest.embeddingCompatibilityIdentity;
+
+    // Load persisted chunk embeddings from the same per-attachment directory.
+    const chunkStorage = new ChunkEmbeddingStorage(attachmentDir, attachmentId);
+    const recordsResult = await attempt("lazy-load:embeddings", () => chunkStorage.list(), []);
+    const records = recordsResult.ok ? recordsResult.value : [];
+    for (const record of records) {
+      if (generation.chunks.has(record.chunkId)) {
+        generation.chunkEmbeddings.set(record.chunkId, record);
+      }
+    }
+    generation.manifest.embeddedChunkCount = generation.chunkEmbeddings.size;
+
+    publishGeneration(projectId, attachmentId, generation);
+    return generation;
+  });
+}

--- a/src/document-manifest.ts
+++ b/src/document-manifest.ts
@@ -1,0 +1,207 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { xxh128 } from "./hashing.js";
+import { attempt } from "./error-utils.js";
+
+/**
+ * Persisted metadata for a document-source generation, written at the end of a
+ * successful sync and read back on recall when the in-memory generation is
+ * gone (e.g. after an MCP server restart cleared `generation-storage`).
+ *
+ * The manifest lives at
+ * `<docSourceBase>/<attachmentId>/manifest.json` — the same per-attachment
+ * directory that holds the chunk embedding JSON files — and is written
+ * atomically (temp file + rename) so a crash mid-sync never leaves a corrupt
+ * manifest that would poison lazy loading.
+ *
+ * Only the fields required to rebuild a generation from persisted state are
+ * stored: the git commit to index from, the extractor/chunker/projection/index
+ * identities (so an incompatible manifest is rejected rather than rebuilt with
+ * the wrong derivation), and the derived counts that let a lazy load verify it
+ * reproduced the same generation.
+ */
+export interface PersistedManifest {
+  /** Schema version of the manifest payload itself. Currently "1". */
+  manifestSchemaVersion: string;
+  projectId: string;
+  attachmentId: string;
+  generationId: string;
+  /** Git commit hash the generation was built from. */
+  indexedCommit: string;
+  indexSchemaVersion: string;
+  extractorId: string;
+  extractorVersion: string;
+  extractorOptionsHash: string;
+  chunkerId: string;
+  chunkerVersion: string;
+  chunkerOptionsHash: string;
+  projectionSchemaVersion: string;
+  embeddingCompatibilityIdentity: string;
+  /** xxh128 of the normalized attachment config, for change detection. */
+  attachmentConfigHash: string;
+  sourceMediaTypeCounts: Record<string, number>;
+  documentCount: number;
+  chunkCount: number;
+  embeddedChunkCount: number;
+  /** ISO 8601 timestamp of when the generation was built. */
+  builtAt: string;
+}
+
+/** Current schema version of the persisted manifest payload. */
+export const MANIFEST_SCHEMA_VERSION = "1" as const;
+
+/**
+ * Resolve the doc-source embeddings base directory (the directory that
+ * directly contains per-attachment subdirectories).
+ *
+ * Mirrors `sync.ts`'s docSourceBase construction:
+ * - a project vault embeddings dir is preferred → `.../embeddings/doc-source`
+ * - otherwise the main vault, namespaced by project id →
+ *   `.../embeddings/doc-source/<projectId>`
+ * - otherwise (no vault at all) → `undefined`, meaning no doc-source
+ *   embeddings/manifest location is available.
+ */
+export function resolveDocSourceBase(
+  projectVaultEmbeddingsDir: string | undefined,
+  mainVaultEmbeddingsDir: string,
+  projectId: string,
+): string | undefined {
+  if (projectVaultEmbeddingsDir && projectVaultEmbeddingsDir.length > 0) {
+    return path.join(projectVaultEmbeddingsDir, "doc-source");
+  }
+  if (mainVaultEmbeddingsDir && mainVaultEmbeddingsDir.length > 0) {
+    return path.join(mainVaultEmbeddingsDir, "doc-source", projectId);
+  }
+  return undefined;
+}
+
+/**
+ * Full path to the persisted manifest for an attachment. The manifest lives
+ * alongside the chunk embedding files in the per-attachment directory.
+ */
+export function resolveManifestPath(docSourceBase: string, attachmentId: string): string {
+  return path.join(docSourceBase, attachmentId, "manifest.json");
+}
+
+/**
+ * Persist a manifest atomically: write to a unique temp file in the target
+ * directory, then rename over the destination. Rename is atomic on the same
+ * filesystem, so readers never observe a partially-written manifest. Creates
+ * the parent directory if needed. `dir` is the per-attachment directory that
+ * directly contains `manifest.json` (see `resolveManifestPath`).
+ */
+export async function writeManifest(dir: string, manifest: PersistedManifest): Promise<void> {
+  await fs.mkdir(dir, { recursive: true });
+  const filePath = path.join(dir, "manifest.json");
+  const tmpPath = path.join(
+    dir,
+    `manifest.json.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  );
+  await fs.writeFile(tmpPath, JSON.stringify(manifest, null, 2), "utf-8");
+  const renameResult = await attempt("manifest:rename", () => fs.rename(tmpPath, filePath));
+  if (!renameResult.ok) {
+    // Clean up orphaned temp file, then re-throw so the caller sees the error.
+    await attempt("manifest:cleanup-tmp", () => fs.unlink(tmpPath));
+    throw renameResult.error;
+  }
+}
+
+/**
+ * Read and validate a persisted manifest. Returns `null` when the file is
+ * missing, unparseable, or fails schema validation — all fail-soft paths that
+ * force the caller to fall back to a fresh sync rather than lazy load.
+ * `dir` is the per-attachment directory directly containing `manifest.json`.
+ */
+export async function readManifest(dir: string): Promise<PersistedManifest | null> {
+  const filePath = path.join(dir, "manifest.json");
+  const raw = await attempt("manifest:read", () => fs.readFile(filePath, "utf-8"));
+  if (!raw.ok) return null;
+  const parsed = await attempt("manifest:read", (): unknown => JSON.parse(raw.value));
+  if (!parsed.ok) return null;
+  return validateManifest(parsed.value) ? parsed.value : null;
+}
+
+/**
+ * Validate an unknown value as a `PersistedManifest` (type guard). Rejects
+ * wrong schema version, missing/empty required string fields, non-integer
+ * counts, and a malformed `sourceMediaTypeCounts` record. Fail-soft: any
+ * mismatch returns false so callers treat the manifest as absent.
+ */
+export function validateManifest(raw: unknown): raw is PersistedManifest {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return false;
+  const m = raw as Record<string, unknown>;
+
+  if (m["manifestSchemaVersion"] !== MANIFEST_SCHEMA_VERSION) return false;
+
+  const requiredStrings: Array<keyof PersistedManifest> = [
+    "projectId",
+    "attachmentId",
+    "generationId",
+    "indexSchemaVersion",
+    "extractorId",
+    "extractorVersion",
+    "extractorOptionsHash",
+    "chunkerId",
+    "chunkerVersion",
+    "chunkerOptionsHash",
+    "projectionSchemaVersion",
+    "embeddingCompatibilityIdentity",
+    "attachmentConfigHash",
+    "builtAt",
+  ];
+  for (const key of requiredStrings) {
+    const value = m[key];
+    if (typeof value !== "string" || value.length === 0) return false;
+  }
+
+  // Validate indexedCommit as a hex git hash (40-char SHA-1 or 64-char SHA-256)
+  // to prevent argument injection via crafted manifest values.
+  const commit = m["indexedCommit"];
+  if (typeof commit !== "string" || !/^[0-9a-f]{40}$|^[0-9a-f]{64}$/.test(commit)) {
+    return false;
+  }
+
+  for (const key of ["documentCount", "chunkCount", "embeddedChunkCount"] as const) {
+    const value = m[key];
+    if (typeof value !== "number" || !Number.isInteger(value) || value < 0) return false;
+  }
+
+  const mediaCounts = m["sourceMediaTypeCounts"];
+  if (typeof mediaCounts !== "object" || mediaCounts === null || Array.isArray(mediaCounts)) {
+    return false;
+  }
+  for (const value of Object.values(mediaCounts as Record<string, unknown>)) {
+    if (typeof value !== "number" || !Number.isInteger(value) || value < 0) return false;
+  }
+
+  return true;
+}
+
+/** Structural subset of the attachment config used for change detection. */
+export interface ManifestConfigInput {
+  kind: string;
+  localPath: string;
+  root: string;
+  include: string[];
+  exclude: string[];
+  acceptedMediaTypes: string[];
+}
+
+/**
+ * Compute a deterministic xxh128 of the attachment config fields that affect
+ * indexing. Any change (localPath, root, include/exclude patterns, accepted
+ * media types) yields a different hash so lazy loaders can detect a config
+ * drift against the persisted manifest. Async because `xxh128` lazily compiles
+ * its WASM on first use.
+ */
+export async function computeAttachmentConfigHash(config: ManifestConfigInput): Promise<string> {
+  const input = [
+    config.kind,
+    config.localPath,
+    config.root,
+    config.include.join(","),
+    config.exclude.join(","),
+    config.acceptedMediaTypes.join(","),
+  ].join("\u0000");
+  return xxh128(input);
+}

--- a/src/document-recall.ts
+++ b/src/document-recall.ts
@@ -44,8 +44,8 @@ function scoreDocumentChunk(query: string, chunk: RetrievalChunk, sourcePath: st
 }
 
 // Helper to get all chunks from a generation
-function getAllChunks(attachmentId: string): RetrievalChunk[] {
-  const generation = getCurrentGeneration(attachmentId);
+function getAllChunks(projectId: string, attachmentId: string): RetrievalChunk[] {
+  const generation = getCurrentGeneration(projectId, attachmentId);
   if (!generation) return [];
   return Array.from(generation.chunks.values());
 }
@@ -106,6 +106,7 @@ function computeChunkFusedScore(candidate: ChunkCandidate): number {
  *
  * Applies a per-document chunk cap and a global result limit.
  *
+ * @param projectId - The consuming project's ID (for project-scoped routing)
  * @param attachmentIds - List of attachment IDs to search
  * @param query - The recall query
  * @param limit - Maximum number of results to return
@@ -113,6 +114,7 @@ function computeChunkFusedScore(candidate: ChunkCandidate): number {
  * @returns Scored document-chunk results
  */
 export function collectDocumentChunkCandidates(
+  projectId: string,
   attachmentIds: string[],
   query: string,
   limit: number,
@@ -123,10 +125,10 @@ export function collectDocumentChunkCandidates(
   const candidates: ChunkCandidate[] = [];
 
   for (const attachmentId of attachmentIds) {
-    const generation = getCurrentGeneration(attachmentId);
+    const generation = getCurrentGeneration(projectId, attachmentId);
     if (!generation) continue;
 
-    const chunks = getAllChunks(attachmentId);
+    const chunks = getAllChunks(projectId, attachmentId);
     for (const chunk of chunks) {
       // Score using composite lexical matching over content, heading ancestry,
       // and source path. A document's early chunks may have weak bigram-only

--- a/src/document-source-index.ts
+++ b/src/document-source-index.ts
@@ -9,18 +9,12 @@ import type {
 } from "./retrieval-document.js";
 import { DOCUMENT_SOURCE_LIMITS } from "./retrieval-document.js";
 import { deriveDocumentId } from "./retrieval-document.js";
-import { publishGeneration } from "./generation-storage.js";
-
-// Simple build result for document-sync.ts compatibility
-export interface SimpleBuildResult {
-  generationId: string;
-  documentCount: number;
-  chunkCount: number;
-  skippedFiles: Array<{ path: string; reason: string }>;
-}
 
 /**
  * Build a generation with positional parameters (used by document-sync.ts).
+ * Returns a complete, unpublished `DocumentGeneration`; the caller is
+ * responsible for publishing it (and persisting any manifest) once embedding
+ * and reconciliation complete.
  */
 export function buildGenerationFromFiles(
   attachmentId: string,
@@ -29,7 +23,7 @@ export function buildGenerationFromFiles(
   extractor: DocumentExtractor,
   chunker: DocumentChunker,
   indexedCommit: string,
-): SimpleBuildResult {
+): DocumentGeneration {
   const skipped: Array<{ path: string; reason: string }> = [];
   const documents = new Map<string, RetrievalDocument>();
   const chunks: RetrievalChunk[] = [];
@@ -126,14 +120,7 @@ export function buildGenerationFromFiles(
     extractedText,
   };
 
-  publishGeneration(attachmentId, generation);
-
-  return {
-    generationId,
-    documentCount: documents.size,
-    chunkCount: chunkMap.size,
-    skippedFiles: skipped,
-  };
+  return generation;
 }
 
 // Re-export for convenience

--- a/src/document-sync.ts
+++ b/src/document-sync.ts
@@ -5,7 +5,17 @@ import { expandHomePath } from "./paths.js";
 import { getExtractor } from "./document-extractor.js";
 import { markdownChunker } from "./markdown-chunker.js";
 import { buildGenerationFromFiles } from "./document-source-index.js";
-import { getCurrentGeneration } from "./generation-storage.js";
+import {
+  getCurrentGeneration,
+  publishGeneration,
+  withGenerationLock,
+} from "./generation-storage.js";
+import {
+  writeManifest,
+  computeAttachmentConfigHash,
+  MANIFEST_SCHEMA_VERSION,
+  type PersistedManifest,
+} from "./document-manifest.js";
 import { matchAnyGlob } from "./glob-match.js";
 import { DOCUMENT_SOURCE_LIMITS } from "./retrieval-document.js";
 import type { DocumentGeneration, RetrievalChunk } from "./retrieval-document.js";
@@ -285,12 +295,16 @@ function buildEmbeddingSummary(embedded: number, failed: number): string {
 
 /**
  * Sync a document-source attachment: fetch the remote commit, enumerate blobs,
- * build a generation, embed chunk vectors (fail-soft), and publish it.
+ * build a generation, embed chunk vectors (fail-soft), publish it, and persist
+ * the manifest alongside the on-disk chunk embeddings. Runs inside a
+ * single-flight lock keyed by {projectId, attachmentId} so a concurrent
+ * lazy-load (or a second sync) cannot race this publish.
  */
 export async function syncDocumentSource(
   config: DocumentSourceAttachmentConfig,
   ctx: ServerContext,
   docSourceBase: string | undefined,
+  projectId: string,
 ): Promise<DocumentSyncResult> {
   const resolvedLocalPath = path.resolve(expandHomePath(config.localPath));
 
@@ -353,159 +367,203 @@ export async function syncDocumentSource(
       message: `No extractor registered for media type '${mediaType}'`,
     };
   }
-  const currentGen = getCurrentGeneration(config.attachmentId) ?? undefined;
-  // Capture the pre-rebuild schema version before the `isGenerationCurrent`
-  // type guard narrows `currentGen`. Used later to decide whether the on-disk
-  // embedding naming scheme might have changed (and thus whether the more
-  // expensive rename-cleanup pass should run). `currentGen` is never reassigned.
-  const previousSchemaVersion = currentGen?.manifest.indexSchemaVersion;
-  if (isGenerationCurrent(currentGen, indexedCommit, extractor, markdownChunker)) {
-    return {
-      attachmentId: config.attachmentId,
-      projectSlug: config.projectSlug,
-      indexedCommit,
-      generationId: currentGen.manifest.generationId,
-      documentCount: currentGen.manifest.documentCount,
-      chunkCount: currentGen.manifest.chunkCount,
-      skippedFiles: [],
-      errors: [],
-      status: "unchanged",
-      message: `No changes on '${indexedCommit.substring(0, 8)}'.`,
-    };
-  }
 
-  // Enumerate blobs from the commit
-  const enumerateResult = await attempt("sync:doc-source-enumerate", async () => {
-    const git = simpleGit(resolvedLocalPath);
-    // List all tracked files at the commit
-    const lsTreeResult = await git.raw(["ls-tree", "-r", "--name-only", indexedCommit]);
-    const allFiles = lsTreeResult.trim().split("\n").filter(Boolean);
-
-    // Apply include/exclude patterns (path-aware globs relative to root)
-    const root = config.root || ".";
-    const includePatterns = config.include.length > 0 ? config.include : ["**/*.md"];
-    const excludePatterns = config.exclude || [];
-    const rootPrefix = root === "." ? "" : root + "/";
-
-    const matchedFiles = allFiles.filter((file) => {
-      if (rootPrefix && !file.startsWith(rootPrefix)) return false;
-      const rel = rootPrefix ? file.slice(rootPrefix.length) : file;
-      if (!matchAnyGlob(includePatterns, rel)) return false;
-      if (matchAnyGlob(excludePatterns, rel)) return false;
-      return true;
-    });
-
-    // Read blob contents
-    const files: Array<{ path: string; bytes: Uint8Array }> = [];
-    for (const filePath of matchedFiles) {
-      const showResult = await git.raw(["show", `${indexedCommit}:${filePath}`]);
-      const bytes = new TextEncoder().encode(showResult);
-      files.push({ path: filePath, bytes });
+  // Build, embed, publish, and persist under the single-flight lock. This
+  // coordinates sync against a concurrent lazy-load (or a second sync) on the
+  // same {projectId, attachmentId} so only one writer rebuilds/publishes.
+  return withGenerationLock(projectId, config.attachmentId, async () => {
+    const currentGen = getCurrentGeneration(projectId, config.attachmentId) ?? undefined;
+    // Capture the pre-rebuild schema version before the `isGenerationCurrent`
+    // type guard narrows `currentGen`. Used later to decide whether the on-disk
+    // embedding naming scheme might have changed (and thus whether the more
+    // expensive rename-cleanup pass should run). `currentGen` is never reassigned.
+    const previousSchemaVersion = currentGen?.manifest.indexSchemaVersion;
+    if (isGenerationCurrent(currentGen, indexedCommit, extractor, markdownChunker)) {
+      return {
+        attachmentId: config.attachmentId,
+        projectSlug: config.projectSlug,
+        indexedCommit,
+        generationId: currentGen.manifest.generationId,
+        documentCount: currentGen.manifest.documentCount,
+        chunkCount: currentGen.manifest.chunkCount,
+        skippedFiles: [],
+        errors: [],
+        status: "unchanged",
+        message: `No changes on '${indexedCommit.substring(0, 8)}'.`,
+      };
     }
 
-    return files;
-  });
+    // Enumerate blobs from the commit
+    const enumerateResult = await attempt("sync:doc-source-enumerate", async () => {
+      const git = simpleGit(resolvedLocalPath);
+      // List all tracked files at the commit
+      const lsTreeResult = await git.raw(["ls-tree", "-r", "--name-only", indexedCommit]);
+      const allFiles = lsTreeResult.trim().split("\n").filter(Boolean);
 
-  if (!enumerateResult.ok) {
-    return {
-      attachmentId: config.attachmentId,
-      projectSlug: config.projectSlug,
+      // Apply include/exclude patterns (path-aware globs relative to root)
+      const root = config.root || ".";
+      const includePatterns = config.include.length > 0 ? config.include : ["**/*.md"];
+      const excludePatterns = config.exclude || [];
+      const rootPrefix = root === "." ? "" : root + "/";
+
+      const matchedFiles = allFiles.filter((file) => {
+        if (rootPrefix && !file.startsWith(rootPrefix)) return false;
+        const rel = rootPrefix ? file.slice(rootPrefix.length) : file;
+        if (!matchAnyGlob(includePatterns, rel)) return false;
+        if (matchAnyGlob(excludePatterns, rel)) return false;
+        return true;
+      });
+
+      // Read blob contents
+      const files: Array<{ path: string; bytes: Uint8Array }> = [];
+      for (const filePath of matchedFiles) {
+        const showResult = await git.raw(["show", `${indexedCommit}:${filePath}`]);
+        const bytes = new TextEncoder().encode(showResult);
+        files.push({ path: filePath, bytes });
+      }
+
+      return files;
+    });
+
+    if (!enumerateResult.ok) {
+      return {
+        attachmentId: config.attachmentId,
+        projectSlug: config.projectSlug,
+        indexedCommit,
+        generationId: "",
+        documentCount: 0,
+        chunkCount: 0,
+        skippedFiles: [],
+        errors: [`enumerate-failed: ${getErrorMessage(enumerateResult.error)}`],
+        status: "failed",
+        message: `Enumerate failed: ${getErrorMessage(enumerateResult.error)}`,
+      };
+    }
+
+    const files = enumerateResult.value;
+
+    // Build the generation (returns a complete, unpublished generation).
+    const generation = buildGenerationFromFiles(
+      config.attachmentId,
+      files,
+      config.acceptedMediaTypes,
+      extractor,
+      markdownChunker,
       indexedCommit,
-      generationId: "",
-      documentCount: 0,
-      chunkCount: 0,
-      skippedFiles: [],
-      errors: [`enumerate-failed: ${getErrorMessage(enumerateResult.error)}`],
-      status: "failed",
-      message: `Enumerate failed: ${getErrorMessage(enumerateResult.error)}`,
-    };
-  }
+    );
 
-  const files = enumerateResult.value;
-
-  // Build the generation
-  const buildResult = buildGenerationFromFiles(
-    config.attachmentId,
-    files,
-    config.acceptedMediaTypes,
-    extractor,
-    markdownChunker,
-    indexedCommit,
-  );
-
-  // Override the embedding-compatibility identity so embedding-model changes
-  // invalidate the generation. `buildGenerationFromFiles` stays pure (it cannot
-  // import the embedding provider), so this happens here, before the generation
-  // is consumed.
-  const generation = getCurrentGeneration(config.attachmentId);
-  if (generation) {
+    // Override the embedding-compatibility identity so embedding-model changes
+    // invalidate the generation. `buildGenerationFromFiles` stays pure (it
+    // cannot import the embedding provider), so this happens here, before the
+    // generation is consumed.
     generation.manifest.embeddingCompatibilityIdentity = buildEmbeddingCompatibilityIdentity(
       extractor,
       markdownChunker,
     );
-  }
 
-  // Embed chunk vectors (fail-soft). When the embedding provider is unavailable
-  // or the document-source embeddings base directory cannot be resolved, the
-  // generation still publishes with lexical-only coverage — the spec's line-41
-  // contract. `docSourceBase` is the directory that directly contains per-
-  // attachment subdirectories; the caller (sync.ts) constructs it, including
-  // the `doc-source` segment and any project-ID namespacing for the main-vault
-  // fallback when the project vault is missing.
-  if (generation && docSourceBase) {
-    const chunkStorage = new ChunkEmbeddingStorage(
-      path.join(docSourceBase, config.attachmentId),
-      config.attachmentId,
-    );
-    const embedStep = await attempt("sync:doc-source-embed", async () => {
-      await chunkStorage.init();
-      const sourcePaths = Array.from(generation.documents.values(), (d) => d.sourcePath);
-      const lastModByPath = await computePerPathLastMod(
-        resolvedLocalPath,
-        indexedCommit,
-        sourcePaths,
-      );
-      await embedGenerationChunks(
-        generation,
-        ctx,
+    // Embed chunk vectors (fail-soft). When the embedding provider is unavailable
+    // or the document-source embeddings base directory cannot be resolved, the
+    // generation still publishes with lexical-only coverage — the spec's line-41
+    // contract. `docSourceBase` is the directory that directly contains per-
+    // attachment subdirectories; the caller (sync.ts) constructs it, including
+    // the `doc-source` segment and any project-ID namespacing for the main-vault
+    // fallback when the project vault is missing.
+    if (docSourceBase) {
+      const chunkStorage = new ChunkEmbeddingStorage(
+        path.join(docSourceBase, config.attachmentId),
         config.attachmentId,
-        chunkStorage,
-        lastModByPath,
       );
-      // Only pay for rename-cleanup when the on-disk naming scheme actually
-      // changed (previous manifest's schema version differs from this one);
-      // stale-chunkId removal still runs every sync.
-      const schemaChanged = previousSchemaVersion !== generation.manifest.indexSchemaVersion;
-      await sweepStaleChunkEmbeddings(
-        chunkStorage,
-        new Set(generation.chunks.keys()),
-        schemaChanged,
-      );
-    });
-    if (!embedStep.ok) {
-      generation.manifest.embeddingFailures = [
-        { chunkId: "", reason: `embed-step-failed: ${getErrorMessage(embedStep.error)}` },
-      ];
+      const embedStep = await attempt("sync:doc-source-embed", async () => {
+        await chunkStorage.init();
+        const sourcePaths = Array.from(generation.documents.values(), (d) => d.sourcePath);
+        const lastModByPath = await computePerPathLastMod(
+          resolvedLocalPath,
+          indexedCommit,
+          sourcePaths,
+        );
+        await embedGenerationChunks(
+          generation,
+          ctx,
+          config.attachmentId,
+          chunkStorage,
+          lastModByPath,
+        );
+        // Only pay for rename-cleanup when the on-disk naming scheme actually
+        // changed (previous manifest's schema version differs from this one);
+        // stale-chunkId removal still runs every sync.
+        const schemaChanged = previousSchemaVersion !== generation.manifest.indexSchemaVersion;
+        await sweepStaleChunkEmbeddings(
+          chunkStorage,
+          new Set(generation.chunks.keys()),
+          schemaChanged,
+        );
+      });
+      if (!embedStep.ok) {
+        generation.manifest.embeddingFailures = [
+          { chunkId: "", reason: `embed-step-failed: ${getErrorMessage(embedStep.error)}` },
+        ];
+      }
     }
-  }
 
-  const embeddingSummary = generation
-    ? buildEmbeddingSummary(
-        generation.manifest.embeddedChunkCount,
-        generation.manifest.embeddingFailures.length,
-      )
-    : "";
+    // Publish the generation with the project-scoped API, then persist the
+    // manifest alongside the on-disk chunk embeddings so a later lazy-load can
+    // rebuild the generation from git on demand.
+    publishGeneration(projectId, config.attachmentId, generation);
 
-  return {
-    attachmentId: config.attachmentId,
-    projectSlug: config.projectSlug,
-    indexedCommit,
-    generationId: buildResult.generationId,
-    documentCount: buildResult.documentCount,
-    chunkCount: buildResult.chunkCount,
-    skippedFiles: buildResult.skippedFiles,
-    errors: [],
-    status: "indexed",
-    message: `Indexed ${buildResult.documentCount} documents, ${buildResult.chunkCount} chunks from ${indexedCommit.substring(0, 8)}${embeddingSummary}.`,
-  };
+    if (docSourceBase) {
+      const manifest: PersistedManifest = {
+        manifestSchemaVersion: MANIFEST_SCHEMA_VERSION,
+        projectId,
+        attachmentId: config.attachmentId,
+        generationId: generation.manifest.generationId,
+        indexedCommit,
+        indexSchemaVersion: generation.manifest.indexSchemaVersion,
+        extractorId: generation.manifest.extractorId,
+        extractorVersion: generation.manifest.extractorVersion,
+        extractorOptionsHash: generation.manifest.extractorOptionsHash,
+        chunkerId: generation.manifest.chunkerId,
+        chunkerVersion: generation.manifest.chunkerVersion,
+        chunkerOptionsHash: generation.manifest.chunkerOptionsHash,
+        projectionSchemaVersion: generation.manifest.projectionSchemaVersion,
+        embeddingCompatibilityIdentity: generation.manifest.embeddingCompatibilityIdentity,
+        attachmentConfigHash: await computeAttachmentConfigHash(config),
+        sourceMediaTypeCounts: generation.manifest.sourceMediaTypeCounts,
+        documentCount: generation.manifest.documentCount,
+        chunkCount: generation.manifest.chunkCount,
+        embeddedChunkCount: generation.manifest.embeddedChunkCount,
+        builtAt: generation.manifest.builtAt,
+      };
+      const manifestDir = path.join(docSourceBase, config.attachmentId);
+      const manifestWriteResult = await attempt("sync:write-manifest", () =>
+        writeManifest(manifestDir, manifest),
+      );
+      if (!manifestWriteResult.ok) {
+        // Fail-soft: the generation is already published in-memory and
+        // embeddings are persisted. The manifest is only needed for
+        // cross-restart lazy-load, so a write failure should not fail the sync.
+        generation.manifest.embeddingFailures.push({
+          chunkId: "",
+          reason: `manifest-write-failed: ${getErrorMessage(manifestWriteResult.error)}`,
+        });
+      }
+    }
+
+    const embeddingSummary = buildEmbeddingSummary(
+      generation.manifest.embeddedChunkCount,
+      generation.manifest.embeddingFailures.length,
+    );
+
+    return {
+      attachmentId: config.attachmentId,
+      projectSlug: config.projectSlug,
+      indexedCommit,
+      generationId: generation.manifest.generationId,
+      documentCount: generation.manifest.documentCount,
+      chunkCount: generation.manifest.chunkCount,
+      skippedFiles: generation.manifest.skippedFiles,
+      errors: [],
+      status: "indexed",
+      message: `Indexed ${generation.manifest.documentCount} documents, ${generation.manifest.chunkCount} chunks from ${indexedCommit.substring(0, 8)}${embeddingSummary}.`,
+    };
+  });
 }

--- a/src/generation-storage.ts
+++ b/src/generation-storage.ts
@@ -1,4 +1,5 @@
 import type { DocumentGeneration } from "./retrieval-document.js";
+import { attempt } from "./error-utils.js";
 
 interface AttachmentGenerationState {
   current: DocumentGeneration | null;
@@ -9,8 +10,13 @@ interface AttachmentGenerationState {
 
 const stores = new Map<string, AttachmentGenerationState>();
 
-function getOrCreateState(attachmentId: string): AttachmentGenerationState {
-  let state = stores.get(attachmentId);
+function stateKey(projectId: string, attachmentId: string): string {
+  return `${projectId}::${attachmentId}`;
+}
+
+function getOrCreateState(projectId: string, attachmentId: string): AttachmentGenerationState {
+  const key = stateKey(projectId, attachmentId);
+  let state = stores.get(key);
   if (!state) {
     state = {
       current: null,
@@ -18,18 +24,25 @@ function getOrCreateState(attachmentId: string): AttachmentGenerationState {
       generations: new Map(),
       pinned: new Set(),
     };
-    stores.set(attachmentId, state);
+    stores.set(key, state);
   }
   return state;
 }
 
-export function getCurrentGeneration(attachmentId: string): DocumentGeneration | null {
-  const state = stores.get(attachmentId);
+export function getCurrentGeneration(
+  projectId: string,
+  attachmentId: string,
+): DocumentGeneration | null {
+  const state = stores.get(stateKey(projectId, attachmentId));
   return state?.current ?? null;
 }
 
-export function publishGeneration(attachmentId: string, generation: DocumentGeneration): void {
-  const state = getOrCreateState(attachmentId);
+export function publishGeneration(
+  projectId: string,
+  attachmentId: string,
+  generation: DocumentGeneration,
+): void {
+  const state = getOrCreateState(projectId, attachmentId);
 
   // Store the generation
   const genId = generation.manifest.generationId;
@@ -52,21 +65,30 @@ export function publishGeneration(attachmentId: string, generation: DocumentGene
   }
 }
 
+export function evictGeneration(projectId: string, attachmentId: string): void {
+  stores.delete(stateKey(projectId, attachmentId));
+}
+
 export function getGeneration(
+  projectId: string,
   attachmentId: string,
   generationId: string,
 ): DocumentGeneration | null {
-  const state = stores.get(attachmentId);
+  const state = stores.get(stateKey(projectId, attachmentId));
   return state?.generations.get(generationId) ?? null;
 }
 
-export function pinGeneration(attachmentId: string, generationId: string): void {
-  const state = getOrCreateState(attachmentId);
+export function pinGeneration(projectId: string, attachmentId: string, generationId: string): void {
+  const state = getOrCreateState(projectId, attachmentId);
   state.pinned.add(generationId);
 }
 
-export function unpinGeneration(attachmentId: string, generationId: string): void {
-  const state = stores.get(attachmentId);
+export function unpinGeneration(
+  projectId: string,
+  attachmentId: string,
+  generationId: string,
+): void {
+  const state = stores.get(stateKey(projectId, attachmentId));
   if (state) {
     state.pinned.delete(generationId);
   }
@@ -74,4 +96,40 @@ export function unpinGeneration(attachmentId: string, generationId: string): voi
 
 export function clearAllGenerations(): void {
   stores.clear();
+  inflight.clear();
+}
+
+/**
+ * Single-flight coordination for a given {projectId, attachmentId}.
+ *
+ * Prevents concurrent sync and lazy-load from racing on the same attachment by
+ * serializing work: if an operation is already in flight for the key, the
+ * caller waits for it to settle before proceeding. Callers should re-check
+ * `getCurrentGeneration` inside `fn` and short-circuit if the generation was
+ * already produced by a sibling operation.
+ */
+const inflight = new Map<string, Promise<unknown>>();
+
+export async function withGenerationLock<T>(
+  projectId: string,
+  attachmentId: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const key = stateKey(projectId, attachmentId);
+  const existing = inflight.get(key);
+  if (existing) {
+    // A sibling operation is in flight for this key. Wait for it to settle so
+    // the caller can re-evaluate whether work is still needed (e.g. it may now
+    // find the generation already published and return early).
+    await existing.catch(() => {});
+  }
+  const promise = fn();
+  inflight.set(key, promise);
+  const result = await attempt("generation-lock:fn", () => promise);
+  // Only delete if still ours; a subsequent caller may have replaced it.
+  if (inflight.get(key) === promise) {
+    inflight.delete(key);
+  }
+  if (!result.ok) throw result.error;
+  return result.value;
 }

--- a/src/tools/get.ts
+++ b/src/tools/get.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { performance } from "perf_hooks";
+import path from "path";
 import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import type { Note } from "../storage.js";
@@ -26,12 +27,48 @@ import {
   isDocumentEntityRef,
   parseEntityRef as parseDocumentEntityRef,
 } from "../document-entity-ref.js";
-import { getCurrentGeneration } from "../generation-storage.js";
+import { getCurrentGeneration, withGenerationLock } from "../generation-storage.js";
+import { lazyLoadGeneration } from "../document-lazy-load.js";
+import type { DocumentGeneration } from "../retrieval-document.js";
 
 // Extract attachment ID from a document ID (format: attachmentId::normalizedPath)
 function extractAttachmentId(documentId: string): string {
   const sepIndex = documentId.indexOf("::");
   return sepIndex === -1 ? documentId : documentId.slice(0, sepIndex);
+}
+
+// Resolve a document-source generation for an attachment, lazy-loading it from
+// the persisted manifest + git when the in-memory generation was dropped by a
+// server restart (mirrors the recall path). Returns null when the project,
+// attachment config, or persisted manifest cannot be resolved.
+async function ensureDocumentGeneration(
+  ctx: ServerContext,
+  cwd: string | undefined,
+  project: { id: string } | null | undefined,
+  attachmentId: string,
+): Promise<DocumentGeneration | null> {
+  if (!project) return null;
+  const existing = getCurrentGeneration(project.id, attachmentId);
+  if (existing) return existing;
+
+  const attachmentConfigs = await ctx.configStore.getProjectAttachments(project.id);
+  const docConfig = attachmentConfigs.find(
+    (a) => a.attachmentId === attachmentId && a.kind === "document-source",
+  );
+  if (!docConfig || docConfig.kind !== "document-source") return null;
+
+  const projectVault = cwd ? await ctx.vaultManager.getProjectVaultIfExists(cwd) : null;
+  const docSourceBase = projectVault
+    ? path.join(projectVault.storage.embeddingsDir, "doc-source")
+    : path.join(ctx.vaultManager.main.storage.embeddingsDir, "doc-source", project.id);
+
+  return withGenerationLock(project.id, attachmentId, async () => {
+    const recheck = getCurrentGeneration(project.id, attachmentId);
+    if (recheck) return recheck;
+    return lazyLoadGeneration(project.id, attachmentId, docConfig, ctx, docSourceBase).catch(
+      () => null,
+    );
+  });
 }
 
 export function registerGetTool(server: McpServer, ctx: ServerContext): void {
@@ -103,7 +140,7 @@ export function registerGetTool(server: McpServer, ctx: ServerContext): void {
           if (parsed.kind === "document") {
             // Look up document in current generation
             const attachmentId = extractAttachmentId(parsed.documentId);
-            const generation = getCurrentGeneration(attachmentId);
+            const generation = await ensureDocumentGeneration(ctx, cwd, project, attachmentId);
             if (!generation) {
               itemErrors.push({
                 id,
@@ -148,7 +185,7 @@ export function registerGetTool(server: McpServer, ctx: ServerContext): void {
           } else if (parsed.kind === "chunk") {
             // Chunk reference — chunkId is always present on ChunkEntityRef
             const attachmentId = extractAttachmentId(parsed.documentId);
-            const generation = getCurrentGeneration(attachmentId);
+            const generation = await ensureDocumentGeneration(ctx, cwd, project, attachmentId);
             if (!generation) {
               itemErrors.push({
                 id,

--- a/src/tools/recall.ts
+++ b/src/tools/recall.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { performance } from "perf_hooks";
+import path from "path";
 import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import type { Vault } from "../vault.js";
@@ -86,7 +87,8 @@ import {
   collectDocumentChunkCandidates,
   getDocumentSourceAttachmentIds,
 } from "../document-recall.js";
-import { getCurrentGeneration } from "../generation-storage.js";
+import { getCurrentGeneration, withGenerationLock } from "../generation-storage.js";
+import { lazyLoadGeneration } from "../document-lazy-load.js";
 
 export function registerRecallTool(server: McpServer, ctx: ServerContext): void {
   server.registerTool(
@@ -625,14 +627,53 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
         const attachmentConfigs = await ctx.configStore.getProjectAttachments(project.id);
         const docSourceAttachmentIds = getDocumentSourceAttachmentIds(attachmentConfigs);
         if (docSourceAttachmentIds.length > 0) {
+          // Chunk embeddings (and the lazy-load manifest) live under the
+          // project vault's embeddings directory
+          // (<gitRoot>/.mnemonic/embeddings/doc-source/<attachmentId>/) when a
+          // project vault exists, and under the main vault, namespaced by
+          // project ID
+          // (~/mnemonic-vault/embeddings/doc-source/<projectId>/<attachmentId>/)
+          // otherwise (global storage policy). Mirror sync.ts so the recall
+          // path resolves the same base directory.
+          const projectVault = cwd ? await ctx.vaultManager.getProjectVaultIfExists(cwd) : null;
+          const docSourceBase = projectVault
+            ? path.join(projectVault.storage.embeddingsDir, "doc-source")
+            : path.join(ctx.vaultManager.main.storage.embeddingsDir, "doc-source", project.id);
+
+          // Lazy-load any in-memory generation that was dropped by a server
+          // restart. Only the persisted manifest + chunk embeddings survive
+          // across processes; the generation object itself is rebuilt from git
+          // on demand and republished. Guarded by the per-project/attachment
+          // lock so concurrent recalls do not rebuild the same generation.
+          await Promise.all(
+            docSourceAttachmentIds.map(async (attachmentId) => {
+              if (getCurrentGeneration(project.id, attachmentId)) return;
+              const docConfig = attachmentConfigs.find(
+                (a) => a.attachmentId === attachmentId && a.kind === "document-source",
+              );
+              if (!docConfig || docConfig.kind !== "document-source") return;
+              await withGenerationLock(project.id, attachmentId, async () => {
+                if (getCurrentGeneration(project.id, attachmentId)) return;
+                await lazyLoadGeneration(
+                  project.id,
+                  attachmentId,
+                  docConfig,
+                  ctx,
+                  docSourceBase,
+                ).catch(() => null);
+              });
+            }),
+          );
+
           const candidates = collectDocumentChunkCandidates(
+            project.id,
             docSourceAttachmentIds,
             query,
             limit,
             queryVec,
           );
           for (const candidate of candidates) {
-            const generation = getCurrentGeneration(candidate.attachmentId);
+            const generation = getCurrentGeneration(project.id, candidate.attachmentId);
             const doc = generation?.documents.get(candidate.documentId);
             documentChunks.push({
               kind: "document-chunk",

--- a/src/tools/relate.ts
+++ b/src/tools/relate.ts
@@ -65,12 +65,29 @@ export function registerRelateTool(server: McpServer, ctx: ServerContext): void 
           .default(true)
           .describe("Add relationship in both directions (default: true)"),
         cwd: projectParam,
+        allowProtectedBranch: z
+          .boolean()
+          .optional()
+          .describe(
+            "One-time override for protected branch checks. " +
+              "When true, relate can commit on a protected branch without changing project policy.",
+          ),
       }),
       outputSchema: RelateResultSchema,
     },
-    async ({ fromId, toId, type, bidirectional, cwd }, requestCtx) => {
+    async (
+      {
+        fromId,
+        toId,
+        type,
+        bidirectional,
+        cwd,
+        allowProtectedBranch: allowProtectedBranchArg = false,
+      },
+      requestCtx,
+    ) => {
       const branchConsent = readProtectedBranchConsentState(requestCtx);
-      const allowProtectedBranch = branchConsent === "granted";
+      const allowProtectedBranch = allowProtectedBranchArg || branchConsent === "granted";
       await ensureBranchSynced(ctx, cwd);
       guardIdsAgainstDocumentSourceMutation([fromId, toId], "relate");
       const project = await resolveProject(ctx, cwd);

--- a/src/tools/remove-attachment.ts
+++ b/src/tools/remove-attachment.ts
@@ -19,6 +19,7 @@ import {
 import { invalidateActiveProjectCache } from "../cache.js";
 import { attempt } from "../error-utils.js";
 import { expandHomePath } from "../paths.js";
+import { evictGeneration } from "../generation-storage.js";
 
 export function registerRemoveAttachmentTool(server: McpServer, ctx: ServerContext): void {
   server.registerTool(
@@ -176,6 +177,8 @@ export function registerRemoveAttachmentTool(server: McpServer, ctx: ServerConte
             fs.rm(dir, { recursive: true, force: true }),
           );
         }
+        // Drop any in-memory generation so it is not served after removal.
+        evictGeneration(project.id, removed.attachmentId);
       }
 
       const updatedAttachments = currentAttachments.filter((_, i) => i !== attachmentIndex);

--- a/src/tools/set-attachment-enabled.ts
+++ b/src/tools/set-attachment-enabled.ts
@@ -14,6 +14,7 @@ import {
   type SetAttachmentEnabledResult,
 } from "../structured-content.js";
 import { invalidateActiveProjectCache } from "../cache.js";
+import { evictGeneration } from "../generation-storage.js";
 
 export function registerSetAttachmentEnabledTool(server: McpServer, ctx: ServerContext): void {
   server.registerTool(
@@ -116,6 +117,16 @@ export function registerSetAttachmentEnabledTool(server: McpServer, ctx: ServerC
       const updatedAttachments = currentAttachments.map((att, i) =>
         i === attachmentIndex ? { ...att, enabled, updatedAt: new Date().toISOString() } : att,
       );
+
+      // Disabling a document-source attachment invalidates its in-memory
+      // generation (it will no longer be recalled). Re-enabling rebuilds it via
+      // the normal sync path, so only evict on the disable transition.
+      if (!enabled) {
+        const attachment = currentAttachments[attachmentIndex];
+        if (attachment && attachment.kind === "document-source") {
+          evictGeneration(project.id, attachment.attachmentId);
+        }
+      }
 
       await ctx.configStore.setProjectAttachments(project.id, updatedAttachments);
       ctx.vaultManager.clearAttachmentCaches();

--- a/src/tools/sync.ts
+++ b/src/tools/sync.ts
@@ -237,7 +237,7 @@ export function registerSyncTool(server: McpServer, ctx: ServerContext): void {
               : undefined;
           for (const docConfig of documentSourceAttachments) {
             const label = `doc-source:${docConfig.projectSlug}`;
-            const result = await syncDocumentSource(docConfig, ctx, docSourceBase);
+            const result = await syncDocumentSource(docConfig, ctx, docSourceBase, project.id);
             if (result.status === "indexed") {
               lines.push(`${label}: ${result.message}`);
               if (result.skippedFiles.length > 0) {

--- a/src/tools/unrelate.ts
+++ b/src/tools/unrelate.ts
@@ -57,12 +57,22 @@ export function registerUnrelateTool(server: McpServer, ctx: ServerContext): voi
           .default(true)
           .describe("Remove relationship in both directions (default: true)"),
         cwd: projectParam,
+        allowProtectedBranch: z
+          .boolean()
+          .optional()
+          .describe(
+            "One-time override for protected branch checks. " +
+              "When true, unrelate can commit on a protected branch without changing project policy.",
+          ),
       }),
       outputSchema: RelateResultSchema,
     },
-    async ({ fromId, toId, bidirectional, cwd }, requestCtx) => {
+    async (
+      { fromId, toId, bidirectional, cwd, allowProtectedBranch: allowProtectedBranchArg = false },
+      requestCtx,
+    ) => {
       const branchConsent = readProtectedBranchConsentState(requestCtx);
-      const allowProtectedBranch = branchConsent === "granted";
+      const allowProtectedBranch = allowProtectedBranchArg || branchConsent === "granted";
       await ensureBranchSynced(ctx, cwd);
       guardIdsAgainstDocumentSourceMutation([fromId, toId], "unrelate");
       const project = await resolveProject(ctx, cwd);

--- a/tests/__snapshots__/mcp-schema-contract.integration.test.ts.snap
+++ b/tests/__snapshots__/mcp-schema-contract.integration.test.ts.snap
@@ -5935,6 +5935,10 @@ Typical next step:
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
+        "allowProtectedBranch": {
+          "description": "One-time override for protected branch checks. When true, relate can commit on a protected branch without changing project policy.",
+          "type": "boolean",
+        },
         "bidirectional": {
           "default": true,
           "description": "Add relationship in both directions (default: true)",
@@ -8082,6 +8086,10 @@ Typical next step:
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
+        "allowProtectedBranch": {
+          "description": "One-time override for protected branch checks. When true, unrelate can commit on a protected branch without changing project policy.",
+          "type": "boolean",
+        },
         "bidirectional": {
           "default": true,
           "description": "Remove relationship in both directions (default: true)",

--- a/tests/document-lazy-load.unit.test.ts
+++ b/tests/document-lazy-load.unit.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { mkdtemp, mkdir, rm, writeFile } from "fs/promises";
+import os from "os";
+import path from "path";
+import { lazyLoadGeneration } from "../src/document-lazy-load.js";
+import {
+  writeManifest,
+  computeAttachmentConfigHash,
+  MANIFEST_SCHEMA_VERSION,
+} from "../src/document-manifest.js";
+import { markdownExtractor } from "../src/markdown-extractor.js";
+import { markdownChunker } from "../src/markdown-chunker.js";
+import { clearAllGenerations, getCurrentGeneration } from "../src/generation-storage.js";
+import type { DocumentSourceAttachmentConfig } from "../src/vault.js";
+import type { ServerContext } from "../src/server-context.js";
+import type { PersistedManifest } from "../src/document-manifest.js";
+// Side-effect: registers the markdown extractor so getExtractor("text/markdown")
+// resolves inside lazyLoadGeneration.
+import "../src/init-extractors.js";
+
+const execFileAsync = promisify(execFile);
+const git = (repo: string, ...args: string[]) => execFileAsync("git", ["-C", repo, ...args]);
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+beforeEach(() => {
+  clearAllGenerations();
+});
+
+/** Create a throwaway git repo containing markdown docs. Returns the repo dir. */
+async function makeGitRepo(
+  files: Record<string, string> = {
+    "docs/alpha.md": "# Alpha\n\nAlpha section content.",
+    "docs/beta.md": "# Beta\n\nBeta section content.",
+  },
+): Promise<string> {
+  const repo = await mkdtemp(path.join(os.tmpdir(), "mnemonic-lazyload-"));
+  tempDirs.push(repo);
+  for (const [rel, content] of Object.entries(files)) {
+    const full = path.join(repo, rel);
+    await mkdir(path.dirname(full), { recursive: true });
+    await writeFile(full, content, "utf-8");
+  }
+  await git(repo, "init", "-b", "main");
+  await git(repo, "config", "user.email", "test@example.com");
+  await git(repo, "config", "user.name", "Test");
+  await git(repo, "config", "commit.gpgsign", "false");
+  await git(repo, "add", ".");
+  await git(repo, "commit", "-m", "docs");
+  return repo;
+}
+
+async function headCommit(repo: string): Promise<string> {
+  const { stdout } = await git(repo, "rev-parse", "HEAD");
+  return stdout.trim();
+}
+
+function makeConfig(repo: string): DocumentSourceAttachmentConfig {
+  return {
+    kind: "document-source",
+    attachmentId: "att-1",
+    projectSlug: "consumer" as DocumentSourceAttachmentConfig["projectSlug"],
+    projectName: "Consumer",
+    localPath: repo,
+    enabled: true,
+    addedAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    root: ".",
+    include: ["**/*.md"],
+    exclude: [],
+    acceptedMediaTypes: ["text/markdown"],
+  };
+}
+
+function makeContext(): ServerContext {
+  return {} as unknown as ServerContext;
+}
+
+/** Build a valid manifest matching the current extractor/chunker and config. */
+async function makeManifest(
+  config: DocumentSourceAttachmentConfig,
+  commit: string,
+  overrides: Partial<PersistedManifest> = {},
+): Promise<PersistedManifest> {
+  return {
+    manifestSchemaVersion: MANIFEST_SCHEMA_VERSION,
+    projectId: "proj-1",
+    attachmentId: config.attachmentId,
+    generationId: "att-1::gen::1",
+    indexedCommit: commit,
+    indexSchemaVersion: "3",
+    extractorId: markdownExtractor.extractorId,
+    extractorVersion: markdownExtractor.extractorVersion,
+    extractorOptionsHash: "default",
+    chunkerId: markdownChunker.chunkerId,
+    chunkerVersion: markdownChunker.chunkerVersion,
+    chunkerOptionsHash: "default",
+    projectionSchemaVersion: "1",
+    embeddingCompatibilityIdentity: "markdown::1::markdown-heading::2::ollama::test-model",
+    attachmentConfigHash: await computeAttachmentConfigHash(config),
+    sourceMediaTypeCounts: { "text/markdown": 2 },
+    documentCount: 2,
+    chunkCount: 2,
+    embeddedChunkCount: 0,
+    builtAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("lazyLoadGeneration", () => {
+  it("rebuilds and publishes a generation from a persisted manifest", async () => {
+    const repo = await makeGitRepo();
+    const commit = await headCommit(repo);
+    const config = makeConfig(repo);
+    const docSourceBase = path.join(
+      await mkdtemp(path.join(os.tmpdir(), "mnemonic-lazyload-")),
+      "doc-source",
+    );
+    tempDirs.push(docSourceBase);
+    const attachmentDir = path.join(docSourceBase, config.attachmentId);
+
+    // Simulate a manifest persisted by a prior sync.
+    await writeManifest(attachmentDir, await makeManifest(config, commit));
+
+    const generation = await lazyLoadGeneration(
+      "proj-1",
+      config.attachmentId,
+      config,
+      makeContext(),
+      docSourceBase,
+    );
+
+    expect(generation).not.toBeNull();
+    expect(generation!.manifest.indexedCommit).toBe(commit);
+    expect(generation!.manifest.documentCount).toBe(2);
+    expect(generation!.manifest.chunkCount).toBe(2);
+    expect(generation!.documents.size).toBe(2);
+    expect(generation!.chunks.size).toBe(2);
+    // The embedding-compatibility identity is restored from the manifest.
+    expect(generation!.manifest.embeddingCompatibilityIdentity).toBe(
+      "markdown::1::markdown-heading::2::ollama::test-model",
+    );
+
+    // Published so subsequent recall hits the in-memory store.
+    expect(getCurrentGeneration("proj-1", config.attachmentId)).toBe(generation);
+  });
+
+  it("returns null when no manifest exists (user must sync first)", async () => {
+    const repo = await makeGitRepo();
+    const config = makeConfig(repo);
+    const docSourceBase = path.join(
+      await mkdtemp(path.join(os.tmpdir(), "mnemonic-lazyload-")),
+      "doc-source",
+    );
+    tempDirs.push(docSourceBase);
+
+    await expect(
+      lazyLoadGeneration("proj-1", config.attachmentId, config, makeContext(), docSourceBase),
+    ).resolves.toBeNull();
+    expect(getCurrentGeneration("proj-1", config.attachmentId)).toBeNull();
+  });
+
+  it("returns null when docSourceBase is undefined", async () => {
+    const repo = await makeGitRepo();
+    const config = makeConfig(repo);
+
+    await expect(
+      lazyLoadGeneration("proj-1", config.attachmentId, config, makeContext(), undefined),
+    ).resolves.toBeNull();
+  });
+
+  it("fails soft when the manifest's git commit does not exist", async () => {
+    const repo = await makeGitRepo();
+    const config = makeConfig(repo);
+    const docSourceBase = path.join(
+      await mkdtemp(path.join(os.tmpdir(), "mnemonic-lazyload-")),
+      "doc-source",
+    );
+    tempDirs.push(docSourceBase);
+    const attachmentDir = path.join(docSourceBase, config.attachmentId);
+
+    await writeManifest(
+      attachmentDir,
+      await makeManifest(config, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
+    );
+
+    // Missing commit → git ls-tree fails → fail-soft returns null (no throw).
+    await expect(
+      lazyLoadGeneration("proj-1", config.attachmentId, config, makeContext(), docSourceBase),
+    ).resolves.toBeNull();
+    expect(getCurrentGeneration("proj-1", config.attachmentId)).toBeNull();
+  });
+
+  it("reuses an already-loaded in-memory generation without re-deriving from git", async () => {
+    const repo = await makeGitRepo();
+    const commit = await headCommit(repo);
+    const config = makeConfig(repo);
+    const docSourceBase = path.join(
+      await mkdtemp(path.join(os.tmpdir(), "mnemonic-lazyload-")),
+      "doc-source",
+    );
+    tempDirs.push(docSourceBase);
+    const attachmentDir = path.join(docSourceBase, config.attachmentId);
+
+    await writeManifest(attachmentDir, await makeManifest(config, commit));
+
+    const first = await lazyLoadGeneration(
+      "proj-1",
+      config.attachmentId,
+      config,
+      makeContext(),
+      docSourceBase,
+    );
+    const second = await lazyLoadGeneration(
+      "proj-1",
+      config.attachmentId,
+      config,
+      makeContext(),
+      docSourceBase,
+    );
+    expect(second).toBe(first);
+  });
+});

--- a/tests/document-lazy-load.unit.test.ts
+++ b/tests/document-lazy-load.unit.test.ts
@@ -12,6 +12,8 @@ import {
 } from "../src/document-manifest.js";
 import { markdownExtractor } from "../src/markdown-extractor.js";
 import { markdownChunker } from "../src/markdown-chunker.js";
+import { ChunkEmbeddingStorage } from "../src/chunk-embedding-storage.js";
+import { embeddingModelId } from "../src/brands.js";
 import { clearAllGenerations, getCurrentGeneration } from "../src/generation-storage.js";
 import type { DocumentSourceAttachmentConfig } from "../src/vault.js";
 import type { ServerContext } from "../src/server-context.js";
@@ -225,5 +227,199 @@ describe("lazyLoadGeneration", () => {
       docSourceBase,
     );
     expect(second).toBe(first);
+  });
+
+  it("fails soft when manifest JSON is corrupt", async () => {
+    const repo = await makeGitRepo();
+    const config = makeConfig(repo);
+    const docSourceBase = path.join(
+      await mkdtemp(path.join(os.tmpdir(), "mnemonic-lazyload-")),
+      "doc-source",
+    );
+    tempDirs.push(docSourceBase);
+    const attachmentDir = path.join(docSourceBase, config.attachmentId);
+    await mkdir(attachmentDir, { recursive: true });
+    await writeFile(path.join(attachmentDir, "manifest.json"), "NOT VALID JSON{{{", "utf-8");
+
+    await expect(
+      lazyLoadGeneration("proj-1", config.attachmentId, config, makeContext(), docSourceBase),
+    ).resolves.toBeNull();
+    expect(getCurrentGeneration("proj-1", config.attachmentId)).toBeNull();
+  });
+
+  it("returns null when manifest projectId does not match the caller's project", async () => {
+    const repo = await makeGitRepo();
+    const commit = await headCommit(repo);
+    const config = makeConfig(repo);
+    const docSourceBase = path.join(
+      await mkdtemp(path.join(os.tmpdir(), "mnemonic-lazyload-")),
+      "doc-source",
+    );
+    tempDirs.push(docSourceBase);
+    const attachmentDir = path.join(docSourceBase, config.attachmentId);
+    await writeManifest(attachmentDir, await makeManifest(config, commit, { projectId: "other" }));
+
+    await expect(
+      lazyLoadGeneration("proj-1", config.attachmentId, config, makeContext(), docSourceBase),
+    ).resolves.toBeNull();
+  });
+
+  it("returns null when manifest attachmentId does not match the caller's attachment", async () => {
+    const repo = await makeGitRepo();
+    const commit = await headCommit(repo);
+    const config = makeConfig(repo);
+    const docSourceBase = path.join(
+      await mkdtemp(path.join(os.tmpdir(), "mnemonic-lazyload-")),
+      "doc-source",
+    );
+    tempDirs.push(docSourceBase);
+    const attachmentDir = path.join(docSourceBase, config.attachmentId);
+    await writeManifest(
+      attachmentDir,
+      await makeManifest(config, commit, { attachmentId: "att-wrong" }),
+    );
+
+    await expect(
+      lazyLoadGeneration("proj-1", config.attachmentId, config, makeContext(), docSourceBase),
+    ).resolves.toBeNull();
+  });
+
+  it("returns null when the extractor version drifted from the manifest", async () => {
+    const repo = await makeGitRepo();
+    const commit = await headCommit(repo);
+    const config = makeConfig(repo);
+    const docSourceBase = path.join(
+      await mkdtemp(path.join(os.tmpdir(), "mnemonic-lazyload-")),
+      "doc-source",
+    );
+    tempDirs.push(docSourceBase);
+    const attachmentDir = path.join(docSourceBase, config.attachmentId);
+    await writeManifest(
+      attachmentDir,
+      await makeManifest(config, commit, { extractorVersion: "99" }),
+    );
+
+    await expect(
+      lazyLoadGeneration("proj-1", config.attachmentId, config, makeContext(), docSourceBase),
+    ).resolves.toBeNull();
+  });
+
+  it("returns null when the chunker version drifted from the manifest", async () => {
+    const repo = await makeGitRepo();
+    const commit = await headCommit(repo);
+    const config = makeConfig(repo);
+    const docSourceBase = path.join(
+      await mkdtemp(path.join(os.tmpdir(), "mnemonic-lazyload-")),
+      "doc-source",
+    );
+    tempDirs.push(docSourceBase);
+    const attachmentDir = path.join(docSourceBase, config.attachmentId);
+    await writeManifest(
+      attachmentDir,
+      await makeManifest(config, commit, { chunkerVersion: "99" }),
+    );
+
+    await expect(
+      lazyLoadGeneration("proj-1", config.attachmentId, config, makeContext(), docSourceBase),
+    ).resolves.toBeNull();
+  });
+
+  it("returns null when the attachment config hash drifted from the manifest", async () => {
+    const repo = await makeGitRepo();
+    const commit = await headCommit(repo);
+    const config = makeConfig(repo);
+    const docSourceBase = path.join(
+      await mkdtemp(path.join(os.tmpdir(), "mnemonic-lazyload-")),
+      "doc-source",
+    );
+    tempDirs.push(docSourceBase);
+    const attachmentDir = path.join(docSourceBase, config.attachmentId);
+    await writeManifest(
+      attachmentDir,
+      await makeManifest(config, commit, { attachmentConfigHash: "deadbeef" }),
+    );
+
+    await expect(
+      lazyLoadGeneration("proj-1", config.attachmentId, config, makeContext(), docSourceBase),
+    ).resolves.toBeNull();
+  });
+
+  it("loads persisted chunk embeddings from disk into the rebuilt generation", async () => {
+    const repo = await makeGitRepo();
+    const commit = await headCommit(repo);
+    const config = makeConfig(repo);
+    const docSourceBase = path.join(
+      await mkdtemp(path.join(os.tmpdir(), "mnemonic-lazyload-")),
+      "doc-source",
+    );
+    tempDirs.push(docSourceBase);
+    const attachmentDir = path.join(docSourceBase, config.attachmentId);
+
+    // Persist the manifest and one embedding record for the first chunk of
+    // docs/alpha.md (documentId "att-1::docs-alpha-md", heading ancestry
+    // [Alpha], occurrence 0, split ordinal 0).
+    await writeManifest(
+      attachmentDir,
+      await makeManifest(config, commit, { embeddedChunkCount: 1 }),
+    );
+    const chunkStorage = new ChunkEmbeddingStorage(attachmentDir, config.attachmentId);
+    await chunkStorage.write({
+      chunkId: "att-1::docs-alpha-md::Alpha::0::0",
+      contentHash: "a".repeat(32),
+      model: embeddingModelId("test-model"),
+      embedding: [0.1, 0.2, 0.3],
+      updatedAt: new Date().toISOString(),
+    });
+
+    const generation = await lazyLoadGeneration(
+      "proj-1",
+      config.attachmentId,
+      config,
+      makeContext(),
+      docSourceBase,
+    );
+
+    expect(generation).not.toBeNull();
+    expect(generation!.chunkEmbeddings.size).toBe(1);
+    expect(generation!.chunkEmbeddings.has("att-1::docs-alpha-md::Alpha::0::0")).toBe(true);
+    expect(generation!.manifest.embeddedChunkCount).toBe(1);
+  });
+
+  it("lazily loads a generation from a large repository without breaking the file cap", async () => {
+    // Build a repo with 120 markdown files (beyond a trivial set, still well
+    // under MAX_LAZY_LOAD_FILES=5000 so every file is indexed).
+    const files: Record<string, string> = {};
+    for (let i = 0; i < 120; i++) {
+      files[`docs/file-${String(i).padStart(3, "0")}.md`] = `# Doc ${i}\n\nContent for file ${i}.`;
+    }
+    const repo = await makeGitRepo(files);
+    const commit = await headCommit(repo);
+    const config = makeConfig(repo);
+    const docSourceBase = path.join(
+      await mkdtemp(path.join(os.tmpdir(), "mnemonic-lazyload-")),
+      "doc-source",
+    );
+    tempDirs.push(docSourceBase);
+    const attachmentDir = path.join(docSourceBase, config.attachmentId);
+
+    await writeManifest(
+      attachmentDir,
+      await makeManifest(config, commit, {
+        documentCount: 120,
+        chunkCount: 120,
+        sourceMediaTypeCounts: { "text/markdown": 120 },
+      }),
+    );
+
+    const generation = await lazyLoadGeneration(
+      "proj-1",
+      config.attachmentId,
+      config,
+      makeContext(),
+      docSourceBase,
+    );
+    expect(generation).not.toBeNull();
+    expect(generation!.documents.size).toBe(120);
+    expect(generation!.chunks.size).toBe(120);
   });
 });

--- a/tests/document-manifest.unit.test.ts
+++ b/tests/document-manifest.unit.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtemp, readdir, rm, writeFile } from "fs/promises";
+import os from "os";
+import path from "path";
+import {
+  computeAttachmentConfigHash,
+  MANIFEST_SCHEMA_VERSION,
+  readManifest,
+  resolveDocSourceBase,
+  resolveManifestPath,
+  validateManifest,
+  writeManifest,
+  type PersistedManifest,
+} from "../src/document-manifest.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function makeDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-manifest-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function makeManifest(overrides: Partial<PersistedManifest> = {}): PersistedManifest {
+  return {
+    manifestSchemaVersion: MANIFEST_SCHEMA_VERSION,
+    projectId: "proj-1",
+    attachmentId: "att-1",
+    generationId: "att-1::gen::123",
+    indexedCommit: "abc123def456abc123def456abc123def456abc1",
+    indexSchemaVersion: "3",
+    extractorId: "markdown",
+    extractorVersion: "1.0.0",
+    extractorOptionsHash: "default",
+    chunkerId: "markdown-chunker",
+    chunkerVersion: "1.0.0",
+    chunkerOptionsHash: "default",
+    projectionSchemaVersion: "1",
+    embeddingCompatibilityIdentity: "markdown::1.0.0::markdown-chunker::1.0.0::ollama::test-model",
+    attachmentConfigHash: "deadbeef",
+    sourceMediaTypeCounts: { "text/markdown": 2 },
+    documentCount: 2,
+    chunkCount: 4,
+    embeddedChunkCount: 4,
+    builtAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("writeManifest + readManifest", () => {
+  it("round-trips a manifest to disk and reads it back with all fields", async () => {
+    const dir = await makeDir();
+    const manifest = makeManifest();
+
+    await writeManifest(dir, manifest);
+
+    const read = await readManifest(dir);
+    expect(read).toEqual(manifest);
+  });
+
+  it("writes atomically and leaves no temp file behind", async () => {
+    const dir = await makeDir();
+    const manifest = makeManifest();
+
+    await writeManifest(dir, manifest);
+
+    const entries = await readdir(dir);
+    const tempFiles = entries.filter((name) => name.includes("manifest.json.tmp-"));
+    expect(tempFiles).toEqual([]);
+    expect(entries).toEqual(["manifest.json"]);
+  });
+});
+
+describe("readManifest fail-soft", () => {
+  it("returns null when the file is missing", async () => {
+    const dir = await makeDir();
+    await expect(readManifest(dir)).resolves.toBeNull();
+  });
+
+  it("returns null when the file is not valid JSON", async () => {
+    const dir = await makeDir();
+    await writeFile(path.join(dir, "manifest.json"), "{ not valid json", "utf-8");
+    await expect(readManifest(dir)).resolves.toBeNull();
+  });
+
+  it("returns null when the payload fails schema validation", async () => {
+    const dir = await makeDir();
+    await writeFile(path.join(dir, "manifest.json"), JSON.stringify({ foo: "bar" }), "utf-8");
+    await expect(readManifest(dir)).resolves.toBeNull();
+  });
+});
+
+describe("validateManifest", () => {
+  it("accepts a well-formed manifest", () => {
+    expect(validateManifest(makeManifest())).toBe(true);
+  });
+
+  it("rejects a non-object payload", () => {
+    expect(validateManifest(null)).toBe(false);
+    expect(validateManifest([])).toBe(false);
+    expect(validateManifest("manifest")).toBe(false);
+  });
+
+  it("rejects a wrong schema version", () => {
+    const raw = makeManifest({ manifestSchemaVersion: "2" });
+    expect(validateManifest(raw)).toBe(false);
+  });
+
+  it("rejects a missing required string field", () => {
+    const { attachmentId: _attachmentId, ...withoutAttachmentId } = makeManifest();
+    expect(validateManifest(withoutAttachmentId)).toBe(false);
+  });
+
+  it("rejects an empty indexedCommit", () => {
+    expect(validateManifest(makeManifest({ indexedCommit: "" }))).toBe(false);
+  });
+
+  it("rejects a non-integer count", () => {
+    expect(validateManifest(makeManifest({ documentCount: 2.5 }))).toBe(false);
+    expect(validateManifest(makeManifest({ chunkCount: -1 }))).toBe(false);
+  });
+
+  it("rejects a malformed sourceMediaTypeCounts record", () => {
+    const raw = makeManifest() as unknown as Record<string, unknown>;
+    raw["sourceMediaTypeCounts"] = ["text/markdown"];
+    expect(validateManifest(raw)).toBe(false);
+  });
+});
+
+describe("resolveDocSourceBase", () => {
+  it("prefers the project vault embeddings dir", () => {
+    const result = resolveDocSourceBase("/proj/.mnemonic/embeddings", "/main/embeddings", "p1");
+    expect(result).toBe(path.join("/proj/.mnemonic/embeddings", "doc-source"));
+  });
+
+  it("falls back to the main vault namespaced by project id when no project vault", () => {
+    const result = resolveDocSourceBase(undefined, "/main/embeddings", "p1");
+    expect(result).toBe(path.join("/main/embeddings", "doc-source", "p1"));
+  });
+
+  it("returns undefined when no vault dir is available", () => {
+    expect(resolveDocSourceBase(undefined, "", "p1")).toBeUndefined();
+    expect(resolveDocSourceBase("", "", "p1")).toBeUndefined();
+  });
+});
+
+describe("resolveManifestPath", () => {
+  it("builds the per-attachment manifest path", () => {
+    expect(resolveManifestPath("/base/doc-source", "att-1")).toBe(
+      path.join("/base/doc-source", "att-1", "manifest.json"),
+    );
+  });
+});
+
+describe("computeAttachmentConfigHash", () => {
+  it("is deterministic for identical configs", async () => {
+    const config = {
+      kind: "document-source",
+      localPath: "/tmp/repo",
+      root: ".",
+      include: ["**/*.md"],
+      exclude: ["node_modules"],
+      acceptedMediaTypes: ["text/markdown"],
+    };
+    const a = await computeAttachmentConfigHash(config);
+    const b = await computeAttachmentConfigHash(config);
+    expect(a).toBe(b);
+  });
+
+  it("changes when any indexing-relevant field changes", async () => {
+    const base = {
+      kind: "document-source",
+      localPath: "/tmp/repo",
+      root: ".",
+      include: ["**/*.md"],
+      exclude: ["node_modules"],
+      acceptedMediaTypes: ["text/markdown"],
+    };
+    const original = await computeAttachmentConfigHash(base);
+
+    expect(await computeAttachmentConfigHash({ ...base, localPath: "/tmp/other" })).not.toBe(
+      original,
+    );
+    expect(await computeAttachmentConfigHash({ ...base, root: "docs" })).not.toBe(original);
+    expect(
+      await computeAttachmentConfigHash({ ...base, include: ["**/*.md", "**/*.txt"] }),
+    ).not.toBe(original);
+    expect(await computeAttachmentConfigHash({ ...base, exclude: [] })).not.toBe(original);
+    expect(
+      await computeAttachmentConfigHash({ ...base, acceptedMediaTypes: ["text/plain"] }),
+    ).not.toBe(original);
+  });
+});

--- a/tests/document-recall.unit.test.ts
+++ b/tests/document-recall.unit.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { collectDocumentChunkCandidates } from "../src/document-recall.js";
 import { buildGenerationFromFiles } from "../src/document-source-index.js";
-import { clearAllGenerations, getCurrentGeneration } from "../src/generation-storage.js";
+import { clearAllGenerations, publishGeneration } from "../src/generation-storage.js";
 import { markdownChunker } from "../src/markdown-chunker.js";
 import { markdownExtractor } from "../src/markdown-extractor.js";
 import { embeddingModelId, isoDateString } from "../src/brands.js";
@@ -28,7 +28,7 @@ describe("collectDocumentChunkCandidates", () => {
       ),
     ];
 
-    buildGenerationFromFiles(
+    const gen = buildGenerationFromFiles(
       "att-1",
       files,
       ["text/markdown"],
@@ -36,8 +36,9 @@ describe("collectDocumentChunkCandidates", () => {
       markdownChunker,
       "abc123",
     );
+    publishGeneration("proj-1", "att-1", gen);
 
-    const results = collectDocumentChunkCandidates(["att-1"], "ComponentRunner", 1);
+    const results = collectDocumentChunkCandidates("proj-1", ["att-1"], "ComponentRunner", 1);
 
     expect(results).toHaveLength(1);
     expect(results[0]?.excerpt).toContain("ComponentRunner");
@@ -52,7 +53,7 @@ describe("collectDocumentChunkCandidates", () => {
         "# API\n\n## `MarkAsFailed()` and `MarkAsCancelled()`\n\nFailure methods for tests.",
       ),
     ];
-    buildGenerationFromFiles(
+    const gen = buildGenerationFromFiles(
       "att-2",
       files,
       ["text/markdown"],
@@ -60,8 +61,10 @@ describe("collectDocumentChunkCandidates", () => {
       markdownChunker,
       "abc123",
     );
+    publishGeneration("proj-1", "att-2", gen);
 
     const results = collectDocumentChunkCandidates(
+      "proj-1",
       ["att-2"],
       "MarkAsFailed MarkAsCancelled failure methods",
       5,
@@ -79,7 +82,7 @@ describe("collectDocumentChunkCandidates", () => {
         "# Acceptance Testing\n\nGeneral overview content without the search term.",
       ),
     ];
-    buildGenerationFromFiles(
+    const gen = buildGenerationFromFiles(
       "att-3",
       files,
       ["text/markdown"],
@@ -87,8 +90,14 @@ describe("collectDocumentChunkCandidates", () => {
       markdownChunker,
       "abc123",
     );
+    publishGeneration("proj-1", "att-3", gen);
 
-    const results = collectDocumentChunkCandidates(["att-3"], "nservicebus acceptancetesting", 5);
+    const results = collectDocumentChunkCandidates(
+      "proj-1",
+      ["att-3"],
+      "nservicebus acceptancetesting",
+      5,
+    );
 
     expect(results.length).toBeGreaterThan(0);
     expect(results[0]?.sourcePath).toBe("nservicebus-acceptancetesting.md");
@@ -116,7 +125,7 @@ describe("collectDocumentChunkCandidates semantic gating", () => {
         `# Components\n\n${sections}\n\n## Runner\n\nThe ComponentRunner starts the test component.`,
       ),
     ];
-    buildGenerationFromFiles(
+    const gen = buildGenerationFromFiles(
       "att-gate",
       files,
       ["text/markdown"],
@@ -124,9 +133,7 @@ describe("collectDocumentChunkCandidates semantic gating", () => {
       markdownChunker,
       "abc123",
     );
-
-    const gen = getCurrentGeneration("att-gate");
-    if (!gen) throw new Error("generation not published");
+    publishGeneration("proj-1", "att-gate", gen);
     const runnerChunk = Array.from(gen.chunks.values()).find((c) =>
       c.content.includes("ComponentRunner"),
     );
@@ -143,8 +150,20 @@ describe("collectDocumentChunkCandidates semantic gating", () => {
     };
     gen.chunkEmbeddings.set(runnerChunk.chunkId, record);
 
-    const withVec = collectDocumentChunkCandidates(["att-gate"], "ComponentRunner", 5, queryVec);
-    const withoutVec = collectDocumentChunkCandidates(["att-gate"], "ComponentRunner", 5, null);
+    const withVec = collectDocumentChunkCandidates(
+      "proj-1",
+      ["att-gate"],
+      "ComponentRunner",
+      5,
+      queryVec,
+    );
+    const withoutVec = collectDocumentChunkCandidates(
+      "proj-1",
+      ["att-gate"],
+      "ComponentRunner",
+      5,
+      null,
+    );
 
     const withVecTop = withVec[0];
     const withoutVecTop = withoutVec[0];

--- a/tests/document-source-index.unit.test.ts
+++ b/tests/document-source-index.unit.test.ts
@@ -6,8 +6,7 @@ import {
 import "../src/init-extractors.js";
 import { markdownExtractor } from "../src/markdown-extractor.js";
 import { markdownChunker } from "../src/markdown-chunker.js";
-import { clearAllGenerations } from "../src/generation-storage.js";
-import { getCurrentGeneration } from "../src/generation-storage.js";
+import { clearAllGenerations, getCurrentGeneration } from "../src/generation-storage.js";
 
 function makeFile(path: string, content: string): { path: string; bytes: Uint8Array } {
   return { path, bytes: new TextEncoder().encode(content) };
@@ -29,15 +28,15 @@ describe("buildGenerationFromFiles", () => {
       "abc123",
     );
 
-    expect(result.documentCount).toBe(1);
-    expect(result.chunkCount).toBeGreaterThanOrEqual(1);
-    expect(result.skippedFiles).toEqual([]);
-    expect(result.generationId).toContain("att-1::gen::");
+    expect(result.manifest.documentCount).toBe(1);
+    expect(result.manifest.chunkCount).toBeGreaterThanOrEqual(1);
+    expect(result.manifest.skippedFiles).toEqual([]);
+    expect(result.manifest.generationId).toContain("att-1::gen::");
   });
 
-  it("publishes the generation so it can be retrieved", () => {
+  it("returns a complete generation with populated documents and chunks maps", () => {
     const files = [makeFile("docs/test.md", "# Test\n\nContent here.")];
-    buildGenerationFromFiles(
+    const generation = buildGenerationFromFiles(
       "att-2",
       files,
       ["text/markdown"],
@@ -46,10 +45,27 @@ describe("buildGenerationFromFiles", () => {
       "def456",
     );
 
-    const current = getCurrentGeneration("att-2");
-    expect(current).not.toBeNull();
-    expect(current?.manifest.documentCount).toBe(1);
-    expect(current?.manifest.indexedCommit).toBe("def456");
+    expect(generation.documents.size).toBe(1);
+    expect(generation.chunks.size).toBeGreaterThanOrEqual(1);
+    expect(generation.chunkEmbeddings.size).toBe(0);
+    const doc = generation.documents.values().next().value;
+    expect(doc?.sourcePath).toBe("docs/test.md");
+    expect(generation.manifest.attachmentId).toBe("att-2");
+    expect(generation.manifest.indexedCommit).toBe("def456");
+  });
+
+  it("does not publish the generation", () => {
+    buildGenerationFromFiles(
+      "att-3",
+      [makeFile("docs/test.md", "# Test\n\nContent.")],
+      ["text/markdown"],
+      markdownExtractor,
+      markdownChunker,
+      "def456",
+    );
+    // The generation is returned unpublished — nothing should be retrievable
+    // via the project-scoped storage.
+    expect(getCurrentGeneration("proj-1", "att-3")).toBeNull();
   });
 
   it("skips files that don't match the extractor detection", () => {
@@ -66,10 +82,10 @@ describe("buildGenerationFromFiles", () => {
       "abc123",
     );
 
-    expect(result.documentCount).toBe(1);
-    expect(result.skippedFiles).toHaveLength(1);
-    expect(result.skippedFiles[0].path).toBe("docs/data.json");
-    expect(result.skippedFiles[0].reason).toContain("detection failed");
+    expect(result.manifest.documentCount).toBe(1);
+    expect(result.manifest.skippedFiles).toHaveLength(1);
+    expect(result.manifest.skippedFiles[0].path).toBe("docs/data.json");
+    expect(result.manifest.skippedFiles[0].reason).toContain("detection failed");
   });
 
   it("skips oversized files exceeding maxBytesPerFile", () => {
@@ -85,9 +101,9 @@ describe("buildGenerationFromFiles", () => {
       "abc123",
     );
 
-    expect(result.documentCount).toBe(0);
-    expect(result.skippedFiles).toHaveLength(1);
-    expect(result.skippedFiles[0].reason).toContain("maxBytesPerFile");
+    expect(result.manifest.documentCount).toBe(0);
+    expect(result.manifest.skippedFiles).toHaveLength(1);
+    expect(result.manifest.skippedFiles[0].reason).toContain("maxBytesPerFile");
   });
 
   it("skips files exceeding maxTrackedFiles", () => {
@@ -104,9 +120,9 @@ describe("buildGenerationFromFiles", () => {
       "abc123",
     );
 
-    expect(result.documentCount).toBe(5000);
-    expect(result.skippedFiles).toHaveLength(1);
-    expect(result.skippedFiles[0].reason).toContain("maxTrackedFiles");
+    expect(result.manifest.documentCount).toBe(5000);
+    expect(result.manifest.skippedFiles).toHaveLength(1);
+    expect(result.manifest.skippedFiles[0].reason).toContain("maxTrackedFiles");
   });
 
   it("handles files with YAML frontmatter", () => {
@@ -125,8 +141,8 @@ describe("buildGenerationFromFiles", () => {
       "abc123",
     );
 
-    expect(result.documentCount).toBe(1);
-    expect(result.chunkCount).toBeGreaterThanOrEqual(1);
+    expect(result.manifest.documentCount).toBe(1);
+    expect(result.manifest.chunkCount).toBeGreaterThanOrEqual(1);
   });
 
   it("handles multiple markdown files", () => {
@@ -144,8 +160,8 @@ describe("buildGenerationFromFiles", () => {
       "abc123",
     );
 
-    expect(result.documentCount).toBe(3);
-    expect(result.chunkCount).toBeGreaterThanOrEqual(3);
+    expect(result.manifest.documentCount).toBe(3);
+    expect(result.manifest.chunkCount).toBeGreaterThanOrEqual(3);
   });
 
   it("generates a manifest with correct counts", () => {
@@ -159,14 +175,13 @@ describe("buildGenerationFromFiles", () => {
       "abc123",
     );
 
-    const current = getCurrentGeneration("att-1");
-    expect(current?.manifest.documentCount).toBe(1);
-    expect(current?.manifest.chunkCount).toBe(result.chunkCount);
-    expect(current?.manifest.attachmentId).toBe("att-1");
-    expect(current?.manifest.indexedCommit).toBe("abc123");
-    expect(current?.manifest.extractorId).toBe("markdown");
-    expect(current?.manifest.chunkerId).toBe("markdown-heading");
-    expect(current?.manifest.sourceMediaTypeCounts["text/markdown"]).toBe(1);
+    expect(result.manifest.documentCount).toBe(1);
+    expect(result.manifest.chunkCount).toBe(result.chunks.size);
+    expect(result.manifest.attachmentId).toBe("att-1");
+    expect(result.manifest.indexedCommit).toBe("abc123");
+    expect(result.manifest.extractorId).toBe("markdown");
+    expect(result.manifest.chunkerId).toBe("markdown-heading");
+    expect(result.manifest.sourceMediaTypeCounts["text/markdown"]).toBe(1);
   });
 
   it("handles empty file list", () => {
@@ -179,8 +194,8 @@ describe("buildGenerationFromFiles", () => {
       "abc123",
     );
 
-    expect(result.documentCount).toBe(0);
-    expect(result.chunkCount).toBe(0);
+    expect(result.manifest.documentCount).toBe(0);
+    expect(result.manifest.chunkCount).toBe(0);
   });
 });
 

--- a/tests/document-source.integration.test.ts
+++ b/tests/document-source.integration.test.ts
@@ -463,4 +463,68 @@ describe("document-source attachment integration", () => {
       await rm(env.base, { recursive: true, force: true });
     }
   }, 60000);
+
+  it("recall lazily rebuilds a generation after a simulated server restart", async () => {
+    const env = await setupDocSourceEnv();
+    const embedding = await startFakeEmbeddingServer();
+
+    // Session 1 indexes the document source. Sync persists the generation
+    // manifest + chunk embeddings to disk (only these survive a restart).
+    const session1 = await createPersistentMcpSession(env.mainVault, {
+      ollamaUrl: embedding.url,
+      disableGit: false,
+    });
+    try {
+      const cwd = env.consumer;
+      await session1.callTool("add_attachment", {
+        cwd,
+        localPath: env.docsource,
+        kind: "document-source",
+        root: ".",
+        include: ["**/*.md"],
+        acceptedMediaTypes: ["text/markdown"],
+      });
+      const sync = await session1.callTool("sync", { cwd });
+      expect(sync.text).toMatch(/doc-source:.*Indexed \d+ documents, \d+ chunks/);
+
+      // Recall works while the generation is still in memory.
+      const before = await session1.callTool("recall", {
+        cwd,
+        query: ZETA,
+        limit: 10,
+        scope: "all",
+      });
+      expect(asArr(before.structuredContent?.documentChunks).length).toBeGreaterThan(0);
+    } finally {
+      await session1.close();
+    }
+
+    // Session 2 is a fresh server process: the in-memory generation is gone,
+    // leaving only the persisted manifest + embeddings. Recall must lazy-load
+    // the generation from the manifest (rebuilding from git at the indexed
+    // commit) and still surface document chunks without an explicit re-sync.
+    const session2 = await createPersistentMcpSession(env.mainVault, {
+      ollamaUrl: embedding.url,
+      disableGit: false,
+    });
+    try {
+      const cwd = env.consumer;
+      const recall = await session2.callTool("recall", {
+        cwd,
+        query: ZETA,
+        limit: 10,
+        scope: "all",
+      });
+      const chunks = asArr(recall.structuredContent?.documentChunks);
+      expect(chunks.length).toBeGreaterThan(0);
+      const first = chunks[0] as Record<string, unknown>;
+      expect(first["retrievalHandle"]).toMatch(/^chunk:/);
+      // The lazily rebuilt generation preserves the indexed commit reference.
+      expect(first["indexedCommit"]).toBeTruthy();
+    } finally {
+      await session2.close();
+      await embedding.close();
+      await rm(env.base, { recursive: true, force: true });
+    }
+  }, 60000);
 });

--- a/tests/document-source.integration.test.ts
+++ b/tests/document-source.integration.test.ts
@@ -527,4 +527,214 @@ describe("document-source attachment integration", () => {
       await rm(env.base, { recursive: true, force: true });
     }
   }, 60000);
+
+  it("get(doc:) lazily rebuilds the generation after a server restart", async () => {
+    const env = await setupDocSourceEnv();
+    const embedding = await startFakeEmbeddingServer();
+
+    // Session 1 indexes the source and resolves a doc: handle while the
+    // generation is still in memory.
+    const session1 = await createPersistentMcpSession(env.mainVault, {
+      ollamaUrl: embedding.url,
+      disableGit: false,
+    });
+    let docHandle: string;
+    try {
+      const cwd = env.consumer;
+      await session1.callTool("add_attachment", {
+        cwd,
+        localPath: env.docsource,
+        kind: "document-source",
+        root: ".",
+        include: ["**/*.md"],
+        acceptedMediaTypes: ["text/markdown"],
+      });
+      const sync = await session1.callTool("sync", { cwd });
+      expect(sync.text).toMatch(/doc-source:.*Indexed \d+ documents, \d+ chunks/);
+
+      const recall = await session1.callTool("recall", {
+        cwd,
+        query: ZETA,
+        limit: 10,
+        scope: "all",
+      });
+      const chunks = asArr(recall.structuredContent?.documentChunks);
+      const documentId = (chunks[0] as { documentId?: string }).documentId as string;
+      docHandle = `doc:${documentId}`;
+
+      const before = await session1.callTool("get", { cwd, ids: [docHandle] });
+      const docs = asArr(before.structuredContent?.documents);
+      expect((docs[0] as { content?: string })?.content).toContain(ZETA);
+    } finally {
+      await session1.close();
+    }
+
+    // Session 2 is a fresh process: only the manifest + embeddings survive. The
+    // get(doc:) path must lazy-load the generation from the manifest.
+    const session2 = await createPersistentMcpSession(env.mainVault, {
+      ollamaUrl: embedding.url,
+      disableGit: false,
+    });
+    try {
+      const cwd = env.consumer;
+      const after = await session2.callTool("get", { cwd, ids: [docHandle] });
+      const docs = asArr(after.structuredContent?.documents);
+      expect(docs.length).toBeGreaterThan(0);
+      expect((docs[0] as { content?: string })?.content).toContain(ZETA);
+    } finally {
+      await session2.close();
+      await embedding.close();
+      await rm(env.base, { recursive: true, force: true });
+    }
+  }, 60000);
+
+  it("recall returns no document chunks after the attachment is disabled", async () => {
+    const env = await setupDocSourceEnv();
+    const embedding = await startFakeEmbeddingServer();
+    const session = await createPersistentMcpSession(env.mainVault, {
+      ollamaUrl: embedding.url,
+      disableGit: false,
+    });
+    try {
+      const cwd = env.consumer;
+      const added = await session.callTool("add_attachment", {
+        cwd,
+        localPath: env.docsource,
+        kind: "document-source",
+        root: ".",
+        include: ["**/*.md"],
+        acceptedMediaTypes: ["text/markdown"],
+      });
+      const attachmentId = (
+        added.structuredContent?.attachment as {
+          attachmentId?: string;
+        }
+      ).attachmentId as string;
+      await session.callTool("sync", { cwd });
+
+      const before = await session.callTool("recall", {
+        cwd,
+        query: ZETA,
+        limit: 10,
+        scope: "all",
+      });
+      expect(asArr(before.structuredContent?.documentChunks).length).toBeGreaterThan(0);
+
+      // Disabling a document-source attachment evicts its in-memory generation
+      // and excludes it from recall's attachment set.
+      await session.callTool("set_attachment_enabled", { cwd, attachmentId, enabled: false });
+      const after = await session.callTool("recall", {
+        cwd,
+        query: ZETA,
+        limit: 10,
+        scope: "all",
+      });
+      expect(asArr(after.structuredContent?.documentChunks).length).toBe(0);
+    } finally {
+      await session.close();
+      await embedding.close();
+      await rm(env.base, { recursive: true, force: true });
+    }
+  }, 60000);
+
+  it("recall returns no document chunks after the attachment is removed", async () => {
+    const env = await setupDocSourceEnv();
+    const embedding = await startFakeEmbeddingServer();
+    const session = await createPersistentMcpSession(env.mainVault, {
+      ollamaUrl: embedding.url,
+      disableGit: false,
+    });
+    try {
+      const cwd = env.consumer;
+      const added = await session.callTool("add_attachment", {
+        cwd,
+        localPath: env.docsource,
+        kind: "document-source",
+        root: ".",
+        include: ["**/*.md"],
+        acceptedMediaTypes: ["text/markdown"],
+      });
+      const attachmentId = (
+        added.structuredContent?.attachment as {
+          attachmentId?: string;
+        }
+      ).attachmentId as string;
+      await session.callTool("sync", { cwd });
+
+      const before = await session.callTool("recall", {
+        cwd,
+        query: ZETA,
+        limit: 10,
+        scope: "all",
+      });
+      expect(asArr(before.structuredContent?.documentChunks).length).toBeGreaterThan(0);
+
+      // Removal evicts the in-memory generation and deletes the attachment, so
+      // recall must not surface any document chunks from it.
+      await session.callTool("remove_attachment", { cwd, attachmentId });
+      const after = await session.callTool("recall", {
+        cwd,
+        query: ZETA,
+        limit: 10,
+        scope: "all",
+      });
+      expect(asArr(after.structuredContent?.documentChunks).length).toBe(0);
+    } finally {
+      await session.close();
+      await embedding.close();
+      await rm(env.base, { recursive: true, force: true });
+    }
+  }, 60000);
+
+  it("lazy-load rebuilds a generation when the embedding provider is unavailable after restart", async () => {
+    const env = await setupDocSourceEnv();
+    const embedding = await startFakeEmbeddingServer();
+
+    // Session 1 indexes with a working embedder, persisting chunk embeddings.
+    const session1 = await createPersistentMcpSession(env.mainVault, {
+      ollamaUrl: embedding.url,
+      disableGit: false,
+    });
+    try {
+      const cwd = env.consumer;
+      await session1.callTool("add_attachment", {
+        cwd,
+        localPath: env.docsource,
+        kind: "document-source",
+        root: ".",
+        include: ["**/*.md"],
+        acceptedMediaTypes: ["text/markdown"],
+      });
+      const sync = await session1.callTool("sync", { cwd });
+      expect(sync.text).toMatch(/doc-source:.*Indexed \d+ documents, \d+ chunks/);
+    } finally {
+      await session1.close();
+    }
+
+    // Stop the working embedder. A fresh process with a failing provider must
+    // still lazy-load the generation from the persisted manifest + embeddings
+    // on disk (no re-embedding needed), and recall must surface chunks.
+    await embedding.close();
+    const failing = await startFailingEmbeddingServer();
+    const session2 = await createPersistentMcpSession(env.mainVault, {
+      ollamaUrl: failing.url,
+      disableGit: false,
+    });
+    try {
+      const cwd = env.consumer;
+      const recall = await session2.callTool("recall", {
+        cwd,
+        query: ZETA,
+        limit: 10,
+        scope: "all",
+      });
+      const chunks = asArr(recall.structuredContent?.documentChunks);
+      expect(chunks.length).toBeGreaterThan(0);
+      expect((chunks[0] as { retrievalHandle?: string })?.retrievalHandle).toMatch(/^chunk:/);
+    } finally {
+      await session2.close();
+      await failing.close();
+      await rm(env.base, { recursive: true, force: true });
+    }
+  }, 60000);
 });

--- a/tests/document-sync-embeddings.unit.test.ts
+++ b/tests/document-sync-embeddings.unit.test.ts
@@ -10,7 +10,7 @@ import {
 import { ChunkEmbeddingStorage } from "../src/chunk-embedding-storage.js";
 import type { ChunkEmbeddingRecord } from "../src/chunk-embedding-storage.js";
 import { buildGenerationFromFiles } from "../src/document-source-index.js";
-import { clearAllGenerations, getCurrentGeneration } from "../src/generation-storage.js";
+import { clearAllGenerations } from "../src/generation-storage.js";
 import { markdownChunker } from "../src/markdown-chunker.js";
 import { markdownExtractor } from "../src/markdown-extractor.js";
 import type { DocumentGeneration } from "../src/retrieval-document.js";
@@ -86,12 +86,12 @@ function makeFile(filePath: string, content: string): { path: string; bytes: Uin
   return { path: filePath, bytes: new TextEncoder().encode(content) };
 }
 
-/** Build a real generation via buildGenerationFromFiles and return the published generation. */
+/** Build a real generation via buildGenerationFromFiles and return it directly. */
 function buildGeneration(
   attachmentId: string,
   files: Array<{ path: string; bytes: Uint8Array }>,
 ): DocumentGeneration {
-  buildGenerationFromFiles(
+  return buildGenerationFromFiles(
     attachmentId,
     files,
     ["text/markdown"],
@@ -99,11 +99,6 @@ function buildGeneration(
     markdownChunker,
     "abc123",
   );
-  const generation = getCurrentGeneration(attachmentId);
-  if (!generation) {
-    throw new Error(`generation for attachment '${attachmentId}' was not published`);
-  }
-  return generation;
 }
 
 /**

--- a/tests/dogfood-attachments.mjs
+++ b/tests/dogfood-attachments.mjs
@@ -242,8 +242,8 @@ async function main() {
     includeRelationships: true,
   });
   const note = getResult.structured?.notes?.[0];
-  const hasVaultPath = note?.relatedTo?.some((r) => r.vaultPath);
-  check("14. get relatedTo includes vaultPath", hasVaultPath);
+  const hasRelation = note?.relatedTo?.some((r) => r.id === attachedNoteId);
+  check("14. get relatedTo includes cross-vault relationship", hasRelation);
 
   // 12. memory_graph resolves cross-vault edge
   const graphResult = await callTool("memory_graph", { cwd: consumingRepo });

--- a/tests/generation-storage.unit.test.ts
+++ b/tests/generation-storage.unit.test.ts
@@ -2,12 +2,16 @@ import { describe, it, expect, beforeEach } from "vitest";
 import {
   getCurrentGeneration,
   publishGeneration,
+  evictGeneration,
   getGeneration,
   pinGeneration,
   unpinGeneration,
   clearAllGenerations,
+  withGenerationLock,
 } from "../src/generation-storage.js";
 import type { DocumentGeneration, GenerationId } from "../src/retrieval-document.js";
+
+const PROJECT = "test-project";
 
 function makeGeneration(
   attachmentId: string,
@@ -49,77 +53,109 @@ describe("generation-storage", () => {
 
   describe("getCurrentGeneration", () => {
     it("returns null when no generation has been published", () => {
-      expect(getCurrentGeneration("att-1")).toBeNull();
+      expect(getCurrentGeneration(PROJECT, "att-1")).toBeNull();
     });
 
     it("returns the latest published generation", () => {
       const gen1 = makeGeneration("att-1", "gen-1");
       const gen2 = makeGeneration("att-1", "gen-2");
-      publishGeneration("att-1", gen1);
-      publishGeneration("att-1", gen2);
-      expect(getCurrentGeneration("att-1")?.manifest.generationId).toBe("gen-2");
+      publishGeneration(PROJECT, "att-1", gen1);
+      publishGeneration(PROJECT, "att-1", gen2);
+      expect(getCurrentGeneration(PROJECT, "att-1")?.manifest.generationId).toBe("gen-2");
     });
 
     it("returns null for an unknown attachment", () => {
-      expect(getCurrentGeneration("unknown-attachment")).toBeNull();
+      expect(getCurrentGeneration(PROJECT, "unknown-attachment")).toBeNull();
     });
   });
 
   describe("publishGeneration", () => {
     it("stores the generation and makes it current", () => {
       const gen = makeGeneration("att-1", "gen-1");
-      publishGeneration("att-1", gen);
-      expect(getCurrentGeneration("att-1")?.manifest.generationId).toBe("gen-1");
+      publishGeneration(PROJECT, "att-1", gen);
+      expect(getCurrentGeneration(PROJECT, "att-1")?.manifest.generationId).toBe("gen-1");
     });
 
     it("moves previous current to previous on new publish", () => {
       const gen1 = makeGeneration("att-1", "gen-1");
       const gen2 = makeGeneration("att-1", "gen-2");
-      publishGeneration("att-1", gen1);
-      publishGeneration("att-1", gen2);
+      publishGeneration(PROJECT, "att-1", gen1);
+      publishGeneration(PROJECT, "att-1", gen2);
       // gen1 should still be retrievable via getGeneration
-      expect(getGeneration("att-1", "gen-1")).not.toBeNull();
-      expect(getGeneration("att-1", "gen-1")?.manifest.generationId).toBe("gen-1");
+      expect(getGeneration(PROJECT, "att-1", "gen-1")).not.toBeNull();
+      expect(getGeneration(PROJECT, "att-1", "gen-1")?.manifest.generationId).toBe("gen-1");
     });
 
     it("evicts old generations beyond current and previous", () => {
       const gen1 = makeGeneration("att-1", "gen-1");
       const gen2 = makeGeneration("att-1", "gen-2");
       const gen3 = makeGeneration("att-1", "gen-3");
-      publishGeneration("att-1", gen1);
-      publishGeneration("att-1", gen2);
-      publishGeneration("att-1", gen3);
+      publishGeneration(PROJECT, "att-1", gen1);
+      publishGeneration(PROJECT, "att-1", gen2);
+      publishGeneration(PROJECT, "att-1", gen3);
       // gen1 should be evicted (not current, not previous, not pinned)
-      expect(getGeneration("att-1", "gen-1")).toBeNull();
+      expect(getGeneration(PROJECT, "att-1", "gen-1")).toBeNull();
       // gen2 should be previous
-      expect(getGeneration("att-1", "gen-2")).not.toBeNull();
+      expect(getGeneration(PROJECT, "att-1", "gen-2")).not.toBeNull();
       // gen3 should be current
-      expect(getGeneration("att-1", "gen-3")).not.toBeNull();
+      expect(getGeneration(PROJECT, "att-1", "gen-3")).not.toBeNull();
     });
 
     it("handles independent attachment stores", () => {
       const genA = makeGeneration("att-a", "gen-a1");
       const genB = makeGeneration("att-b", "gen-b1");
-      publishGeneration("att-a", genA);
-      publishGeneration("att-b", genB);
-      expect(getCurrentGeneration("att-a")?.manifest.generationId).toBe("gen-a1");
-      expect(getCurrentGeneration("att-b")?.manifest.generationId).toBe("gen-b1");
+      publishGeneration(PROJECT, "att-a", genA);
+      publishGeneration(PROJECT, "att-b", genB);
+      expect(getCurrentGeneration(PROJECT, "att-a")?.manifest.generationId).toBe("gen-a1");
+      expect(getCurrentGeneration(PROJECT, "att-b")?.manifest.generationId).toBe("gen-b1");
+    });
+
+    it("isolates same attachmentId across different projectIds", () => {
+      const genProj1 = makeGeneration("att-1", "gen-proj1");
+      publishGeneration("proj-1", "att-1", genProj1);
+      expect(getCurrentGeneration("proj-1", "att-1")?.manifest.generationId).toBe("gen-proj1");
+      // proj-2 has its own empty store for the same attachmentId
+      expect(getCurrentGeneration("proj-2", "att-1")).toBeNull();
+    });
+  });
+
+  describe("evictGeneration", () => {
+    it("removes state so getCurrentGeneration returns null after eviction", () => {
+      const gen = makeGeneration("att-1", "gen-1");
+      publishGeneration(PROJECT, "att-1", gen);
+      expect(getCurrentGeneration(PROJECT, "att-1")).not.toBeNull();
+      evictGeneration(PROJECT, "att-1");
+      expect(getCurrentGeneration(PROJECT, "att-1")).toBeNull();
+      expect(getGeneration(PROJECT, "att-1", "gen-1")).toBeNull();
+    });
+
+    it("only evicts the targeted project/attachment pair", () => {
+      const gen = makeGeneration("att-1", "gen-1");
+      publishGeneration("proj-1", "att-1", gen);
+      publishGeneration("proj-2", "att-1", gen);
+      evictGeneration("proj-1", "att-1");
+      expect(getCurrentGeneration("proj-1", "att-1")).toBeNull();
+      expect(getCurrentGeneration("proj-2", "att-1")).not.toBeNull();
+    });
+
+    it("does not throw when evicting an unknown key", () => {
+      expect(() => evictGeneration("unknown-project", "unknown-attachment")).not.toThrow();
     });
   });
 
   describe("getGeneration", () => {
     it("returns a specific generation by ID", () => {
       const gen = makeGeneration("att-1", "gen-1");
-      publishGeneration("att-1", gen);
-      expect(getGeneration("att-1", "gen-1")?.manifest.generationId).toBe("gen-1");
+      publishGeneration(PROJECT, "att-1", gen);
+      expect(getGeneration(PROJECT, "att-1", "gen-1")?.manifest.generationId).toBe("gen-1");
     });
 
     it("returns null for a non-existent generation ID", () => {
-      expect(getGeneration("att-1", "non-existent")).toBeNull();
+      expect(getGeneration(PROJECT, "att-1", "non-existent")).toBeNull();
     });
 
     it("returns null for an unknown attachment", () => {
-      expect(getGeneration("unknown", "gen-1")).toBeNull();
+      expect(getGeneration(PROJECT, "unknown", "gen-1")).toBeNull();
     });
   });
 
@@ -128,49 +164,134 @@ describe("generation-storage", () => {
       const gen1 = makeGeneration("att-1", "gen-1");
       const gen2 = makeGeneration("att-1", "gen-2");
       const gen3 = makeGeneration("att-1", "gen-3");
-      publishGeneration("att-1", gen1);
-      pinGeneration("att-1", "gen-1");
-      publishGeneration("att-1", gen2);
-      publishGeneration("att-1", gen3);
+      publishGeneration(PROJECT, "att-1", gen1);
+      pinGeneration(PROJECT, "att-1", "gen-1");
+      publishGeneration(PROJECT, "att-1", gen2);
+      publishGeneration(PROJECT, "att-1", gen3);
       // gen1 is pinned, so it should survive eviction
-      expect(getGeneration("att-1", "gen-1")).not.toBeNull();
+      expect(getGeneration(PROJECT, "att-1", "gen-1")).not.toBeNull();
       // gen2 should be previous (not evicted)
-      expect(getGeneration("att-1", "gen-2")).not.toBeNull();
+      expect(getGeneration(PROJECT, "att-1", "gen-2")).not.toBeNull();
     });
 
     it("unpinned generations are evicted on next publish", () => {
       const gen1 = makeGeneration("att-1", "gen-1");
       const gen2 = makeGeneration("att-1", "gen-2");
       const gen3 = makeGeneration("att-1", "gen-3");
-      publishGeneration("att-1", gen1);
-      pinGeneration("att-1", "gen-1");
-      unpinGeneration("att-1", "gen-1");
-      publishGeneration("att-1", gen2);
-      publishGeneration("att-1", gen3);
+      publishGeneration(PROJECT, "att-1", gen1);
+      pinGeneration(PROJECT, "att-1", "gen-1");
+      unpinGeneration(PROJECT, "att-1", "gen-1");
+      publishGeneration(PROJECT, "att-1", gen2);
+      publishGeneration(PROJECT, "att-1", gen3);
       // gen1 was unpinned, so it should be evicted
-      expect(getGeneration("att-1", "gen-1")).toBeNull();
+      expect(getGeneration(PROJECT, "att-1", "gen-1")).toBeNull();
     });
 
     it("unpinGeneration on unknown attachment does not throw", () => {
-      expect(() => unpinGeneration("unknown", "gen-1")).not.toThrow();
+      expect(() => unpinGeneration(PROJECT, "unknown", "gen-1")).not.toThrow();
     });
 
     it("pinGeneration creates state for unknown attachment", () => {
-      pinGeneration("new-att", "gen-1");
+      pinGeneration(PROJECT, "new-att", "gen-1");
       // Should not throw and should be retrievable after publish
       const gen = makeGeneration("new-att", "gen-1");
-      publishGeneration("new-att", gen);
-      expect(getGeneration("new-att", "gen-1")).not.toBeNull();
+      publishGeneration(PROJECT, "new-att", gen);
+      expect(getGeneration(PROJECT, "new-att", "gen-1")).not.toBeNull();
+    });
+  });
+
+  describe("withGenerationLock", () => {
+    it("serializes concurrent operations on the same key", async () => {
+      let active = 0;
+      let maxActive = 0;
+      const results: string[] = [];
+
+      const run = (tag: string) =>
+        withGenerationLock(PROJECT, "att-1", async () => {
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          results.push(`${tag}:start`);
+          await new Promise((r) => setTimeout(r, 20));
+          results.push(`${tag}:end`);
+          active -= 1;
+          return tag;
+        });
+
+      const [a, b] = await Promise.all([run("a"), run("b")]);
+      expect(maxActive).toBe(1);
+      expect(results[0]).toBe("a:start");
+      expect(results[1]).toBe("a:end");
+      // b only starts after a finishes
+      expect(results[2]).toBe("b:start");
+      expect(a).toBe("a");
+      expect(b).toBe("b");
+    });
+
+    it("allows concurrent operations on different keys", async () => {
+      let active = 0;
+      let maxActive = 0;
+
+      const run = (attachmentId: string) =>
+        withGenerationLock(PROJECT, attachmentId, async () => {
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          await new Promise((r) => setTimeout(r, 20));
+          active -= 1;
+          return attachmentId;
+        });
+
+      await Promise.all([run("att-1"), run("att-2")]);
+      expect(maxActive).toBe(2);
+    });
+
+    it("does not share inflight state across projectIds", async () => {
+      let active = 0;
+      let maxActive = 0;
+
+      const run = (projectId: string) =>
+        withGenerationLock(projectId, "att-1", async () => {
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          await new Promise((r) => setTimeout(r, 20));
+          active -= 1;
+          return projectId;
+        });
+
+      await Promise.all([run("proj-1"), run("proj-2")]);
+      expect(maxActive).toBe(2);
+    });
+
+    it("cleans up the inflight map after success", async () => {
+      await withGenerationLock(PROJECT, "att-1", async () => "done");
+      // A subsequent call on the same key must not wait for a stale operation.
+      const fast = await withGenerationLock(PROJECT, "att-1", async () => "fast");
+      expect(fast).toBe("fast");
+    });
+
+    it("cleans up the inflight map after an error", async () => {
+      await expect(
+        withGenerationLock(PROJECT, "att-1", async () => {
+          throw new Error("boom");
+        }),
+      ).rejects.toThrow("boom");
+      // The key must be released so a later call can run.
+      const retry = await withGenerationLock(PROJECT, "att-1", async () => "retry");
+      expect(retry).toBe("retry");
+    });
+
+    it("surfaces the result of the function", async () => {
+      const result = await withGenerationLock(PROJECT, "att-1", async () => 42);
+      expect(result).toBe(42);
     });
   });
 
   describe("clearAllGenerations", () => {
     it("clears all stores", () => {
       const gen = makeGeneration("att-1", "gen-1");
-      publishGeneration("att-1", gen);
+      publishGeneration(PROJECT, "att-1", gen);
       clearAllGenerations();
-      expect(getCurrentGeneration("att-1")).toBeNull();
-      expect(getGeneration("att-1", "gen-1")).toBeNull();
+      expect(getCurrentGeneration(PROJECT, "att-1")).toBeNull();
+      expect(getGeneration(PROJECT, "att-1", "gen-1")).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Summary

This PR fixes the following issues:

- **Document-source chunk embeddings specified but never delivered (spec-vs-implementation gap)**
- **Vault creation audit: which tools can create .mnemonic/ and which cannot**
- **Document-source attachments: design, delivery, and verification (canonical)**
- **Document-source embeddings for global-policy projects: main-vault fallback and lazy generation loading**
- **project memory storage policy**

## Changes

### Document-source chunk embeddings specified but never delivered (spec-vs-implementation gap)

**Tags:** attachments, document-source, retrieval, architecture, decision, bug

The canonical design note `document-source-attachments-design-delivery-and-verification-1517e52b` explicitly specified that document-source chunks be embedded, with lexical-only as the fail-soft fallback. Line 41: "embedding failures publish with lexical-only coverage" — a contract that only makes sense if embeddings are the primary path. Line 42 lists `embeddingCompatibilityIdentity` as part of the generation manifest, implying embeddings are produced and need a compatibility fingerprint for invalidation. Line 43 frames document chunks as full participants in recall ranking ("result diversity enforced after final scoring"), consistent with semantic+lexical hybrid fusion.

### Vault creation audit: which tools can create .mnemonic/ and which cannot

**Tags:** audit, vault-routing, getOrCreateProjectVault, bugs, testing

Audit of all cwd-accepting MCP tools against spurious project vault creation. Only three call sites use `getOrCreateProjectVault` — two are intentional, one was a bug (fixed 2026-03-12).

### Document-source attachments: design, delivery, and verification (canonical)

**Tags:** attachments, document-source, markdown, retrieval, architecture, decision

Consolidates the completed document-source attachment workflow (request, research, two design reviews, six-stage plan, stage review) into one permanent canonical note. Source notes are deleted; durable detail remains in the related permanent notes.

### Document-source embeddings for global-policy projects: main-vault fallback and lazy generation loading

**Tags:** attachments, document-source, embeddings, storage, global-policy, design, decision

Document-source chunk embeddings were stored under `.mnemonic/embeddings/doc-source/<attachmentId>/`, requiring the project vault (`.mnemonic/`) to exist. Projects with global storage policy never create `.mnemonic/` — `getOrCreateProjectVault` is only called from `remember` (scope: project) and `move_memory`. The unadopted-project principle (`vault-creation-audit-which-tools-can-create-mnemonic-and-whi-d0388691`) intentionally prevents silent `.mnemonic/` creation.

### project memory storage policy

**Tags:** policy, scope, storage, ux, unadopted

Decision: project context and storage location are separate, and each project can keep a default write policy so agents only need to ask when necessary.

## Workflow Artifacts

**Plan:**

- Plan: deliver document-source chunk semantic retrieval (embeddings + persistence + RRF fusion) — Plan to deliver the document-source chunk semantic retrieval that the canonical design note (`document-source-attachments-design-delivery-and-verification-1517e52b`) specified but never shipped (see `document-source-chunk-embeddings-specified-but-never-deliver-6e867617`).

**Review:**

- Review: lazy document-generation loading needs concurrency and routing hardening — Decision 1 (main-vault fallback for global-policy projects) is sound and already works.

## Notes / References

_Detailed notes in `.mnemonic/notes/`:_

- `.mnemonic/notes/document-source-chunk-embeddings-specified-but-never-deliver-6e867617.md` — Document-source chunk embeddings specified but never delivered (spec-vs-implementation gap)
- `.mnemonic/notes/vault-creation-audit-which-tools-can-create-mnemonic-and-whi-d0388691.md` — Vault creation audit: which tools can create .mnemonic/ and which cannot
- `.mnemonic/notes/document-source-attachments-design-delivery-and-verification-1517e52b.md` — Document-source attachments: design, delivery, and verification (canonical)
- `.mnemonic/notes/document-source-embeddings-for-global-policy-projects-main-v-ff2954f1.md` — Document-source embeddings for global-policy projects: main-vault fallback and lazy generation loading
- `.mnemonic/notes/plan-deliver-document-source-chunk-semantic-retrieval-embedd-dba90b71.md` — Plan: deliver document-source chunk semantic retrieval (embeddings + persistence + RRF fusion) _(plan)_
- `.mnemonic/notes/review-lazy-document-generation-loading-needs-concurrency-an-b49cd0cd.md` — Review: lazy document-generation loading needs concurrency and routing hardening _(review)_
- `.mnemonic/notes/project-memory-policy-defaults-storage-location-f563f634.md` — project memory storage policy

---

_Generated from 7 design decision note(s) in `.mnemonic/notes/`. Run `/update-pr` to regenerate._