### PR TITLE
fix: flatten doc-source embeddings path, drop redundant projectId segment

### DIFF
--- a/.mnemonic/notes/chunk-embedding-path-layout-drop-redundant-guid-prefix-lower-6b739d42.md
+++ b/.mnemonic/notes/chunk-embedding-path-layout-drop-redundant-guid-prefix-lower-6b739d42.md
@@ -9,7 +9,7 @@ tags:
   - embeddings
 lifecycle: permanent
 createdAt: '2026-08-01T22:39:23.145Z'
-updatedAt: '2026-08-02T06:16:01.222Z'
+updatedAt: '2026-08-03T15:21:34.929Z'
 role: decision
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -18,6 +18,8 @@ relatedTo:
   - id: plan-deliver-document-source-chunk-semantic-retrieval-embedd-dba90b71
     type: derives-from
   - id: document-source-chunk-embeddings-use-xxh128-for-filenames-an-e3e988b8
+    type: derives-from
+  - id: flatten-doc-source-embeddings-path-drop-redundant-projectid--c8c5824f
     type: derives-from
 memoryVersion: 1
 ---

--- a/.mnemonic/notes/document-source-chunk-embeddings-use-xxh128-for-filenames-an-e3e988b8.md
+++ b/.mnemonic/notes/document-source-chunk-embeddings-use-xxh128-for-filenames-an-e3e988b8.md
@@ -7,13 +7,15 @@ tags:
   - attachments
 lifecycle: permanent
 createdAt: '2026-08-02T06:15:43.841Z'
-updatedAt: '2026-08-02T06:24:14.893Z'
+updatedAt: '2026-08-03T15:21:39.085Z'
 role: decision
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
   - id: chunk-embedding-path-layout-drop-redundant-guid-prefix-lower-6b739d42
+    type: derives-from
+  - id: flatten-doc-source-embeddings-path-drop-redundant-projectid--c8c5824f
     type: derives-from
 memoryVersion: 1
 ---

--- a/.mnemonic/notes/document-source-embeddings-for-global-policy-projects-main-v-ff2954f1.md
+++ b/.mnemonic/notes/document-source-embeddings-for-global-policy-projects-main-v-ff2954f1.md
@@ -12,7 +12,7 @@ tags:
   - decision
 lifecycle: permanent
 createdAt: '2026-08-03T09:57:33.038Z'
-updatedAt: '2026-08-03T10:08:13.894Z'
+updatedAt: '2026-08-03T15:21:30.680Z'
 role: decision
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -22,6 +22,8 @@ relatedTo:
     type: related-to
   - id: review-lazy-document-generation-loading-needs-concurrency-an-b49cd0cd
     type: follows
+  - id: flatten-doc-source-embeddings-path-drop-redundant-projectid--c8c5824f
+    type: supersedes
 memoryVersion: 1
 ---
 # Document-source embeddings for global-policy projects: main-vault fallback and lazy generation loading

--- a/.mnemonic/notes/flatten-doc-source-embeddings-path-drop-redundant-projectid--c8c5824f.md
+++ b/.mnemonic/notes/flatten-doc-source-embeddings-path-drop-redundant-projectid--c8c5824f.md
@@ -9,7 +9,7 @@ tags:
   - path-layout
 lifecycle: permanent
 createdAt: '2026-08-03T15:21:23.609Z'
-updatedAt: '2026-08-03T15:21:34.929Z'
+updatedAt: '2026-08-03T15:21:39.085Z'
 role: decision
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -18,6 +18,8 @@ relatedTo:
   - id: document-source-embeddings-for-global-policy-projects-main-v-ff2954f1
     type: supersedes
   - id: chunk-embedding-path-layout-drop-redundant-guid-prefix-lower-6b739d42
+    type: derives-from
+  - id: document-source-chunk-embeddings-use-xxh128-for-filenames-an-e3e988b8
     type: derives-from
 memoryVersion: 1
 ---

--- a/.mnemonic/notes/flatten-doc-source-embeddings-path-drop-redundant-projectid--c8c5824f.md
+++ b/.mnemonic/notes/flatten-doc-source-embeddings-path-drop-redundant-projectid--c8c5824f.md
@@ -1,0 +1,75 @@
+---
+title: 'Flatten doc-source embeddings path: drop redundant projectId segment'
+tags:
+  - decision
+  - attachments
+  - document-source
+  - embeddings
+  - storage
+  - path-layout
+lifecycle: permanent
+createdAt: '2026-08-03T15:21:23.609Z'
+updatedAt: '2026-08-03T15:21:23.609Z'
+role: decision
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+# Flatten doc-source embeddings path: drop redundant projectId segment
+
+## Context
+
+The main-vault fallback path for document-source chunk embeddings included a `projectId` directory segment derived from the git remote URL:
+
+```text
+~/mnemonic-vault/embeddings/doc-source/{projectId}/{attachmentId}/
+```
+
+The `projectId` was the slugified remote URL (e.g. `github-com-particular-nservicebus`, ~40 chars). The `attachmentId` is a UUID (v4), so the project namespace was redundant for uniqueness. It only provided organizational grouping and bulk cleanup, both also achievable via the attachment config.
+
+## Decision
+
+Remove the `projectId` segment. The path is now `doc-source/{attachmentId}/` in all cases:
+
+```text
+Project vault: .mnemonic/embeddings/doc-source/{attachmentId}/
+Main fallback: ~/mnemonic-vault/embeddings/doc-source/{attachmentId}/
+```
+
+The `resolveDocSourceBase` function in `document-manifest.ts` dropped its `projectId` parameter. All callers in `sync.ts`, `recall.ts`, `get.ts`, and `remove-attachment.ts` were updated.
+
+## Why
+
+1. Redundant uniqueness — `attachmentId` is a UUID; collisions between projects are astronomically unlikely.
+2. Path depth — the project ID segment added ~40 chars, risking deep-path issues on Windows (NTFS 260-char limit). The recent `chunk-embedding-path-layout` decision fixed filename length (slug to xxh128), but directory nesting was a separate concern.
+3. Consistency — the project-vault case never had the segment; only the main-vault fallback did. Now both are uniform.
+
+## Breaking change
+
+Existing embeddings at the old `doc-source/{projectId}/{attachmentId}/` path are orphaned. Users run `sync` to re-index at the new flat path. Old directories are gitignored and re-computable, so no data loss — just a one-time re-embed.
+
+## What changed (commit d5d7aa9, branch flatten-doc-source-path, v0.42.1)
+
+- `src/document-manifest.ts` — `resolveDocSourceBase` drops `projectId` param
+- `src/tools/sync.ts` — remove `project.id` from main-vault path construction
+- `src/tools/recall.ts` — same
+- `src/tools/get.ts` — same
+- `src/tools/remove-attachment.ts` — remove `project.id` from main-vault cleanup path
+- `src/document-sync.ts` — updated comment
+- `tests/document-manifest.unit.test.ts` — updated `resolveDocSourceBase` calls
+- `tests/document-source.integration.test.ts` — updated fallback path assertion
+- `CHANGELOG.md` — 0.42.1 entry
+- `package.json` and `package-lock.json` — bumped to 0.42.1
+
+## Verification
+
+- Typecheck clean, lint clean, format clean
+- 42 unit + integration tests pass (document-manifest, document-lazy-load, document-source)
+- Pack D dogfood: 12/12 green
+
+## Relationship to prior decisions
+
+- Reverses the namespacing choice in `document-source-embeddings-for-global-policy-projects-main-v-ff2954f1` (Decision 1), which added the `projectId` segment.
+- Consistent with `chunk-embedding-path-layout-drop-redundant-guid-prefix-lower-6b739d42` which stripped redundant prefixes from filenames.
+- Consistent with `document-source-chunk-embeddings-use-xxh128-for-filenames-an-e3e988b8` which bounded filenames to 32 hex chars.

--- a/.mnemonic/notes/flatten-doc-source-embeddings-path-drop-redundant-projectid--c8c5824f.md
+++ b/.mnemonic/notes/flatten-doc-source-embeddings-path-drop-redundant-projectid--c8c5824f.md
@@ -9,7 +9,7 @@ tags:
   - path-layout
 lifecycle: permanent
 createdAt: '2026-08-03T15:21:23.609Z'
-updatedAt: '2026-08-03T15:21:30.680Z'
+updatedAt: '2026-08-03T15:21:34.929Z'
 role: decision
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -17,6 +17,8 @@ projectName: mnemonic
 relatedTo:
   - id: document-source-embeddings-for-global-policy-projects-main-v-ff2954f1
     type: supersedes
+  - id: chunk-embedding-path-layout-drop-redundant-guid-prefix-lower-6b739d42
+    type: derives-from
 memoryVersion: 1
 ---
 # Flatten doc-source embeddings path: drop redundant projectId segment

--- a/.mnemonic/notes/flatten-doc-source-embeddings-path-drop-redundant-projectid--c8c5824f.md
+++ b/.mnemonic/notes/flatten-doc-source-embeddings-path-drop-redundant-projectid--c8c5824f.md
@@ -9,11 +9,14 @@ tags:
   - path-layout
 lifecycle: permanent
 createdAt: '2026-08-03T15:21:23.609Z'
-updatedAt: '2026-08-03T15:21:23.609Z'
+updatedAt: '2026-08-03T15:21:30.680Z'
 role: decision
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: document-source-embeddings-for-global-policy-projects-main-v-ff2954f1
+    type: supersedes
 memoryVersion: 1
 ---
 # Flatten doc-source embeddings path: drop redundant projectId segment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 
 ## [Unreleased]
 
+## [0.42.1] - 2026-08-03
+
+### Changed
+
+- Document-source chunk embeddings in the main-vault fallback path no longer include a `<projectId>` directory segment. The path is now `doc-source/<attachmentId>/` in all cases — the attachmentId UUID is globally unique, so the project namespace was redundant and added unnecessary path depth. **Breaking:** existing embeddings at the old `doc-source/<projectId>/<attachmentId>/` path are orphaned; run `sync` to re-index at the new flat path.
+
 ## [0.42.0] - 2026-08-03
 
 ### Added
@@ -15,7 +21,7 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 
 ### Changed
 
-- Document-source attachments now store chunk embeddings in the main vault (namespaced by project ID) when the project has no `.mnemonic/` directory, so projects with global storage policy get full semantic retrieval instead of falling back to lexical-only. Previously, embeddings were silently skipped when the project vault didn't exist.
+- Document-source attachments now store chunk embeddings in the main vault when the project has no `.mnemonic/` directory, so projects with global storage policy get full semantic retrieval instead of falling back to lexical-only. Previously, embeddings were silently skipped when the project vault didn't exist.
 - Removing or disabling a document-source attachment now immediately clears its in-memory index, so recall no longer returns stale chunks from a detached or disabled source.
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.42.0",
+  "version": "0.42.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@danielmarbach/mnemonic-mcp",
-      "version": "0.42.0",
+      "version": "0.42.1",
       "dependencies": {
         "@modelcontextprotocol/server": "^2.0.0",
         "gray-matter": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.42.0",
+  "version": "0.42.1",
   "description": "A local MCP memory server backed by markdown + JSON files, synced via git",
   "type": "module",
   "repository": {

--- a/src/document-manifest.ts
+++ b/src/document-manifest.ts
@@ -56,21 +56,20 @@ export const MANIFEST_SCHEMA_VERSION = "1" as const;
  *
  * Mirrors `sync.ts`'s docSourceBase construction:
  * - a project vault embeddings dir is preferred → `.../embeddings/doc-source`
- * - otherwise the main vault, namespaced by project id →
- *   `.../embeddings/doc-source/<projectId>`
+ * - otherwise the main vault → `.../embeddings/doc-source`
+ *   (the attachmentId UUID is globally unique, so no project namespace is needed)
  * - otherwise (no vault at all) → `undefined`, meaning no doc-source
  *   embeddings/manifest location is available.
  */
 export function resolveDocSourceBase(
   projectVaultEmbeddingsDir: string | undefined,
   mainVaultEmbeddingsDir: string,
-  projectId: string,
 ): string | undefined {
   if (projectVaultEmbeddingsDir && projectVaultEmbeddingsDir.length > 0) {
     return path.join(projectVaultEmbeddingsDir, "doc-source");
   }
   if (mainVaultEmbeddingsDir && mainVaultEmbeddingsDir.length > 0) {
-    return path.join(mainVaultEmbeddingsDir, "doc-source", projectId);
+    return path.join(mainVaultEmbeddingsDir, "doc-source");
   }
   return undefined;
 }

--- a/src/document-sync.ts
+++ b/src/document-sync.ts
@@ -465,9 +465,9 @@ export async function syncDocumentSource(
     // or the document-source embeddings base directory cannot be resolved, the
     // generation still publishes with lexical-only coverage — the spec's line-41
     // contract. `docSourceBase` is the directory that directly contains per-
-    // attachment subdirectories; the caller (sync.ts) constructs it, including
-    // the `doc-source` segment and any project-ID namespacing for the main-vault
-    // fallback when the project vault is missing.
+    // attachment subdirectories; the caller (sync.ts) constructs it, always
+    // ending at the `doc-source` segment (the attachmentId UUID is globally
+    // unique, so no project-ID namespacing is needed).
     if (docSourceBase) {
       const chunkStorage = new ChunkEmbeddingStorage(
         path.join(docSourceBase, config.attachmentId),

--- a/src/tools/get.ts
+++ b/src/tools/get.ts
@@ -60,7 +60,7 @@ async function ensureDocumentGeneration(
   const projectVault = cwd ? await ctx.vaultManager.getProjectVaultIfExists(cwd) : null;
   const docSourceBase = projectVault
     ? path.join(projectVault.storage.embeddingsDir, "doc-source")
-    : path.join(ctx.vaultManager.main.storage.embeddingsDir, "doc-source", project.id);
+    : path.join(ctx.vaultManager.main.storage.embeddingsDir, "doc-source");
 
   return withGenerationLock(project.id, attachmentId, async () => {
     const recheck = getCurrentGeneration(project.id, attachmentId);

--- a/src/tools/recall.ts
+++ b/src/tools/recall.ts
@@ -630,15 +630,15 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
           // Chunk embeddings (and the lazy-load manifest) live under the
           // project vault's embeddings directory
           // (<gitRoot>/.mnemonic/embeddings/doc-source/<attachmentId>/) when a
-          // project vault exists, and under the main vault, namespaced by
-          // project ID
-          // (~/mnemonic-vault/embeddings/doc-source/<projectId>/<attachmentId>/)
-          // otherwise (global storage policy). Mirror sync.ts so the recall
+          // project vault exists, and under the main vault
+          // (~/mnemonic-vault/embeddings/doc-source/<attachmentId>/) otherwise
+          // (global storage policy). The attachmentId UUID is globally unique,
+          // so no project namespace is needed. Mirror sync.ts so the recall
           // path resolves the same base directory.
           const projectVault = cwd ? await ctx.vaultManager.getProjectVaultIfExists(cwd) : null;
           const docSourceBase = projectVault
             ? path.join(projectVault.storage.embeddingsDir, "doc-source")
-            : path.join(ctx.vaultManager.main.storage.embeddingsDir, "doc-source", project.id);
+            : path.join(ctx.vaultManager.main.storage.embeddingsDir, "doc-source");
 
           // Lazy-load any in-memory generation that was dropped by a server
           // restart. Only the persisted manifest + chunk embeddings survive

--- a/src/tools/remove-attachment.ts
+++ b/src/tools/remove-attachment.ts
@@ -151,10 +151,10 @@ export function registerRemoveAttachmentTool(server: McpServer, ctx: ServerConte
       // Clean up per-attachment chunk embeddings for document-source attachments.
       // They live under the project vault's embeddings directory
       // (<gitRoot>/.mnemonic/embeddings/doc-source/<attachmentId>/) when the
-      // project vault exists, and under the main vault, namespaced by project ID
-      // (~/mnemonic-vault/embeddings/doc-source/<projectId>/<attachmentId>/) when
-      // it does not (global storage policy). Try both locations so cleanup also
-      // works if the storage policy changed after embeddings were stored;
+      // project vault exists, and under the main vault
+      // (~/mnemonic-vault/embeddings/doc-source/<attachmentId>/) when it does
+      // not (global storage policy). Try both locations so cleanup also works
+      // if the storage policy changed after embeddings were stored;
       // `fs.rm` with `force: true` is a no-op for non-existent paths.
       if (removed.kind === "document-source") {
         const dirs: string[] = [];
@@ -168,7 +168,6 @@ export function registerRemoveAttachmentTool(server: McpServer, ctx: ServerConte
           path.join(
             ctx.vaultManager.main.storage.embeddingsDir,
             "doc-source",
-            project.id,
             removed.attachmentId,
           ),
         );

--- a/src/tools/sync.ts
+++ b/src/tools/sync.ts
@@ -227,13 +227,14 @@ export function registerSyncTool(server: McpServer, ctx: ServerContext): void {
           // Chunk embeddings live under the project vault's embeddings directory
           // (.mnemonic/embeddings/doc-source/<attachmentId>/). When the project
           // vault is missing (global storage policy), embeddings fall back to
-          // the main vault, namespaced by project ID
-          // (~/mnemonic-vault/embeddings/doc-source/<projectId>/<attachmentId>/).
+          // the main vault (~/mnemonic-vault/embeddings/doc-source/<attachmentId>/).
+          // The attachmentId UUID is globally unique, so no project namespace
+          // is needed.
           const projectVault = await ctx.vaultManager.getProjectVaultIfExists(cwd);
           const docSourceBase = projectVault
             ? path.join(projectVault.storage.embeddingsDir, "doc-source")
             : project
-              ? path.join(ctx.vaultManager.main.storage.embeddingsDir, "doc-source", project.id)
+              ? path.join(ctx.vaultManager.main.storage.embeddingsDir, "doc-source")
               : undefined;
           for (const docConfig of documentSourceAttachments) {
             const label = `doc-source:${docConfig.projectSlug}`;

--- a/tests/document-manifest.unit.test.ts
+++ b/tests/document-manifest.unit.test.ts
@@ -133,18 +133,18 @@ describe("validateManifest", () => {
 
 describe("resolveDocSourceBase", () => {
   it("prefers the project vault embeddings dir", () => {
-    const result = resolveDocSourceBase("/proj/.mnemonic/embeddings", "/main/embeddings", "p1");
+    const result = resolveDocSourceBase("/proj/.mnemonic/embeddings", "/main/embeddings");
     expect(result).toBe(path.join("/proj/.mnemonic/embeddings", "doc-source"));
   });
 
-  it("falls back to the main vault namespaced by project id when no project vault", () => {
-    const result = resolveDocSourceBase(undefined, "/main/embeddings", "p1");
-    expect(result).toBe(path.join("/main/embeddings", "doc-source", "p1"));
+  it("falls back to the main vault when no project vault", () => {
+    const result = resolveDocSourceBase(undefined, "/main/embeddings");
+    expect(result).toBe(path.join("/main/embeddings", "doc-source"));
   });
 
   it("returns undefined when no vault dir is available", () => {
-    expect(resolveDocSourceBase(undefined, "", "p1")).toBeUndefined();
-    expect(resolveDocSourceBase("", "", "p1")).toBeUndefined();
+    expect(resolveDocSourceBase(undefined, "")).toBeUndefined();
+    expect(resolveDocSourceBase("", "")).toBeUndefined();
   });
 });
 

--- a/tests/document-source.integration.test.ts
+++ b/tests/document-source.integration.test.ts
@@ -438,9 +438,9 @@ describe("document-source attachment integration", () => {
       expect(sync.text).not.toMatch(/embedding failure/);
 
       // Embeddings were persisted to the main-vault fallback path
-      // (~/mnemonic-vault/embeddings/doc-source/<projectId>/<attachmentId>/),
+      // (~/mnemonic-vault/embeddings/doc-source/<attachmentId>/),
       // because the consumer has no project vault.
-      const fallbackBase = path.join(env.mainVault, "embeddings", "doc-source", "consumer");
+      const fallbackBase = path.join(env.mainVault, "embeddings", "doc-source");
       const entries = await readdir(fallbackBase, { withFileTypes: true }).catch(() => []);
       expect(entries.some((e) => e.isDirectory())).toBe(true);
 


### PR DESCRIPTION
The main-vault fallback path for document-source chunk embeddings included a <projectId> directory segment derived from the git remote URL (e.g. doc-source/github-com-particular-nservicebus/<attachmentId>/). The attachmentId is a UUID, so the project namespace was redundant and added unnecessary path depth. The path is now doc-source/<attachmentId>/ in all cases.

Breaking: existing embeddings at the old namespaced path are orphaned. Run sync to re-index at the new flat path.