### PR TITLE
Bounded concurrency and single-source-of-truth principles

### DIFF
--- a/.mnemonic/notes/bounded-concurrency-and-single-source-of-truth-principles-c987a7ba.md
+++ b/.mnemonic/notes/bounded-concurrency-and-single-source-of-truth-principles-c987a7ba.md
@@ -1,0 +1,51 @@
+---
+title: Bounded concurrency and single-source-of-truth principles
+tags:
+  - concurrency
+  - design
+  - principles
+  - typescript
+  - refactoring
+  - performance
+lifecycle: permanent
+createdAt: '2026-08-05T00:00:00.000Z'
+updatedAt: '2026-08-05T00:00:00.000Z'
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+relatedTo:
+  - id: performance-principles-for-file-first-mcp-and-git-backed-wor-4e7d3bc8
+    type: derives-from
+  - id: implementation-principles-for-mnemonic-mcp-2e178bba
+    type: related-to
+  - id: typescript-development-principles-for-mcp-servers-1dc01593
+    type: related-to
+memoryVersion: 1
+---
+## Bounded concurrency: one shared primitive, not five hand-rolled pools
+
+When mapping independent async work over a collection with bounded concurrency, use the shared `mapWithConcurrency` in `src/concurrency.ts`. It is order-preserving (each result is placed at its source index) and result-returning.
+
+### Rules
+- Return a value per item and reduce post-loop. Express a skip as a `null` sentinel filtered after, not a `continue` inside the loop.
+- Do NOT mutate shared arrays or Maps from inside the per-item function. That reintroduces the nondeterministic-completion-order problem the primitive exists to remove (and forces a "sort afterward for determinism" step).
+- Keep each call site's own concurrency constant / config knob (the bound is domain-specific: bulk file reads, embedding backfills, note hydration all want different limits).
+
+### When to keep a hand-rolled side-effect pool (prefer duplication)
+Reserve a hand-rolled `Array.from({ length }, async () => { while (true) { ... } })` pool for the case where the per-item body has an intrinsic side effect on a shared structure that cannot be expressed as a return value without a tagged-union dispatch that obscures the real axis of change. Example: `embedGenerationChunks` in `src/document-sync.ts` mutates a shared `gen.chunkEmbeddings` Map while iterating — folding it into a pure result-returning API would force a `{kind:'reuse'|'embed'}` union and a dispatch reduce that hides the side effect. Leaving it duplicated is clearer than over-abstracting.
+
+### Do not conflate concurrency axes
+Fixed-size `Promise.all` batching (e.g. `BATCH_SIZE = 100` in `src/chunk-embedding-storage.ts`) bounds file descriptors, not worker count. It is a different axis and must not be folded into `mapWithConcurrency`. (If a batched site genuinely wants worker-count bounding instead, it may switch — but only when the axis actually matches.)
+
+### History
+Extracted from five near-identical inline worker pools: `src/storage.ts` (the only generic one, previously private), `src/tools/project-memory-summary.ts` `hydrateEntries`, `src/helpers/embed.ts` `embedMissingNotes` (migrated), plus two in `src/document-sync.ts` and one batched `Promise.all` in `src/chunk-embedding-storage.ts` (intentionally left duplicated per the rules above).
+
+## Single source of truth for repeated sequences
+
+When an exact operation sequence is duplicated verbatim across ≥3 call sites, extract one helper that owns the sequence. Example: `embedNote(storage, note, now)` in `src/helpers/embed.ts` owns the `embedTextForNote → embed → embeddingMetadata → writeEmbedding` sequence, replacing four identical copies in `remember`, `update`, `consolidate-helpers`, and `embedMissingNotes`.
+
+### Rules
+- Callers keep their own `attempt("scope:...", ...)` fail-soft wrapper and scope label; the helper is the inner body. This preserves per-site error scopes without parameterizing the helper.
+- Do NOT extract if the sites diverge along their real axis of change. Prefer duplication over a parameterized wrapper that hides per-site differences or adds boolean flags. The bar: extraction must remove real duplication without increasing complexity or making the code harder to change along its axis of change.
+
+### Counter-example from the same audit
+The chunk-embedding sequence in `src/document-sync.ts` (`ChunkEmbeddingRecord` + `contentHash` + `ChunkEmbeddingStorage.write`) looks similar to the note-embedding sequence but has a genuinely different record shape and storage backend. It correctly stays separate — forcing it through `embedNote` would parameterize away the differences.

--- a/AGENT.md
+++ b/AGENT.md
@@ -399,6 +399,14 @@ Let TypeScript infer when obvious; explicit types for function boundaries and pu
 ### Unknown for dynamic data
 Use `unknown` instead of `any` for external data (APIs, user input). Forces type checking before use.
 
+### Bounded concurrency
+Use the shared `mapWithConcurrency` (`src/concurrency.ts`) for "map independent async work over a collection without unbounded concurrency". It preserves input order in the result by construction. Return a value per item and reduce post-loop; express a skip as a sentinel (`null`) filtered after. Do NOT hand-roll `Array.from({ length }, async () => { while (true) { ... } })` worker pools, and do NOT mutate shared arrays/Maps from inside the per-item function — that reintroduces nondeterministic completion order.
+
+Keep a hand-rolled side-effect worker pool only when the per-item body has an intrinsic side effect on a shared structure that cannot be returned as a value without a tagged-union dispatch that obscures the real axis of change (see `embedGenerationChunks` in `src/document-sync.ts`). Fixed-size `Promise.all` batching (e.g. `BATCH_SIZE` in `src/chunk-embedding-storage.ts`) is a different axis — file-descriptor bounding, not worker count — and must not be conflated. Each call site keeps its own concurrency constant/knob; the bound is domain-specific.
+
+### Single source of truth for repeated sequences
+When an exact operation sequence is duplicated verbatim across ≥3 call sites, extract one helper that owns the sequence and reuse it (see `embedNote` in `src/helpers/embed.ts` for the embed → metadata → write sequence). Callers keep their own `attempt("scope:...")` fail-soft wrapper and scope label; the helper is the inner body. Do NOT extract if the sites diverge along their real axis of change — prefer duplication over a parameterized wrapper that hides per-site differences.
+
 ## Testing Requirements
 
 ### Data format changes MUST have tests

--- a/src/concurrency.ts
+++ b/src/concurrency.ts
@@ -1,0 +1,48 @@
+/**
+ * Bounded-concurrency primitives.
+ *
+ * The single shared scheduling primitive for "map independent async work over a
+ * collection without opening a descriptor / firing a request for every item at
+ * once". Prefer this over hand-rolled `Array.from({ length }, async () => { while
+ * (true) { ... } })` worker pools: it preserves input order in the result by
+ * construction (each result is placed at its source index), so callers never
+ * need a "workers append in completion order, sort afterward for determinism"
+ * step.
+ *
+ * Design rule for callers:
+ *  - Return a value per item and reduce post-loop. Do NOT mutate shared arrays
+ *    or Maps from inside the per-item function — that reintroduces the
+ *    nondeterministic-completion-order problem this helper exists to remove.
+ *  - Express a "skip" as a sentinel return value (e.g. `null`) and filter after,
+ *    rather than a `continue` inside the loop.
+ *  - Keep each caller's own concurrency constant / config knob (the bound is
+ *    domain-specific: bulk file reads, embedding backfills, note hydration all
+ *    want different limits).
+ *
+ * Reserve a hand-rolled side-effect worker pool only when the per-item body has
+ * an intrinsic side effect on a shared structure that cannot be expressed as a
+ * return value without a tagged-union dispatch that obscures the real axis of
+ * change. Do not conflate this with fixed-size `Promise.all` batching, which
+ * bounds file descriptors rather than worker count.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) return [];
+  const results = new Array<R>(items.length);
+  let next = 0;
+  const workerCount = Math.min(concurrency, items.length);
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (true) {
+      const index = next++;
+      if (index >= items.length) return;
+      const item = items[index];
+      if (item === undefined) return;
+      results[index] = await fn(item, index);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}

--- a/src/helpers/embed.ts
+++ b/src/helpers/embed.ts
@@ -5,7 +5,8 @@ import {
   embed,
   embeddingMetadata,
 } from "../embeddings.js";
-import { memoryId, isoDateString } from "../brands.js";
+import { memoryId, isoDateString, type ISO8601DateString } from "../brands.js";
+import { mapWithConcurrency } from "../concurrency.js";
 import { getOrBuildProjection } from "../projections.js";
 import { attempt, getErrorMessage } from "../error-utils.js";
 import type { NoteStorage, Note, NoteMetadata, EmbeddingRecord } from "../storage.js";
@@ -32,6 +33,30 @@ export async function embedTextForNote(storage: NoteStorage, note: Note): Promis
   const result = await attempt("projection:build", () => getOrBuildProjection(storage, note));
   if (!result.ok) return `${note.title}\n\n${note.content}`;
   return result.value.projectionText;
+}
+
+/**
+ * Build a note's projection text, embed it, persist the embedding, and return
+ * the record. Shared by every note-embedding call site (remember / update /
+ * consolidate / backfill) so the embed -> metadata -> write sequence is defined
+ * once. Callers keep their own `attempt("scope:...", ...)` fail-soft wrapper and
+ * scope label; this is the inner body.
+ */
+export async function embedNote(
+  storage: NoteStorage,
+  note: Note,
+  now: ISO8601DateString,
+): Promise<EmbeddingRecord> {
+  const text = await embedTextForNote(storage, note);
+  const vector = await embed(text);
+  const record: EmbeddingRecord = {
+    id: note.id,
+    ...embeddingMetadata(vector),
+    embedding: vector,
+    updatedAt: now,
+  };
+  await storage.writeEmbedding(record);
+  return record;
 }
 
 export async function embedMissingNotes(
@@ -72,52 +97,34 @@ export async function embedMissingNotes(
   // Only notes that actually need (re)embedding are hydrated, and the full-body
   // read happens inside the worker pool below so concurrent reads stay bounded
   // by `reindexEmbedConcurrency` and no worker retains every full note at once.
-  let rebuilt = 0;
-  const failed: FailedEmbedding[] = [];
-  const rebuiltEmbeddings: EmbeddingRecord[] = [];
-  let index = 0;
-
-  const workerCount = Math.min(
+  const workResults = await mapWithConcurrency(
+    needsEmbedding,
     ctx.config.reindexEmbedConcurrency,
-    Math.max(needsEmbedding.length, 1),
-  );
-  const workers = Array.from({ length: workerCount }, async () => {
-    while (true) {
-      const meta = needsEmbedding[index++];
-      if (!meta) return;
-
+    async (meta) => {
       const note = await storage.readNote(meta.id);
-      if (!note) continue;
+      if (!note) return null;
 
-      const embedResult = await attempt("embed:note", async () => {
-        const text = await embedTextForNote(storage, note);
-        const vector = await embed(text);
-        const record: EmbeddingRecord = {
-          id: note.id,
-          ...embeddingMetadata(vector),
-          embedding: vector,
-          updatedAt: isoDateString(new Date().toISOString()),
-        };
-        await storage.writeEmbedding(record);
-        return record;
-      });
-      if (embedResult.ok) {
-        rebuilt++;
-        rebuiltEmbeddings.push(embedResult.value);
-      } else {
-        failed.push({ id: meta.id, error: getErrorMessage(embedResult.error) });
-      }
-    }
-  });
+      const embedResult = await attempt("embed:note", () =>
+        embedNote(storage, note, isoDateString(new Date().toISOString())),
+      );
+      if (embedResult.ok) return { kind: "ok" as const, record: embedResult.value };
+      return { kind: "failed" as const, id: meta.id, error: getErrorMessage(embedResult.error) };
+    },
+  );
 
-  await Promise.all(workers);
-
+  const rebuiltEmbeddings: EmbeddingRecord[] = [];
+  const failed: FailedEmbedding[] = [];
+  for (const r of workResults) {
+    if (r === null) continue;
+    if (r.kind === "ok") rebuiltEmbeddings.push(r.record);
+    else failed.push({ id: r.id, error: r.error });
+  }
   failed.sort((a, b) => a.id.localeCompare(b.id));
-  // Workers append records in completion order, which is nondeterministic.
-  // Sort by id so rebuilt embeddings preserve deterministic ranking for score ties.
+  // mapWithConcurrency preserves input order, but keep the id sort so the
+  // returned embeddings array keeps its existing deterministic ordering.
   rebuiltEmbeddings.sort((a, b) => a.id.localeCompare(b.id));
 
-  return { rebuilt, failed, embeddings: rebuiltEmbeddings };
+  return { rebuilt: rebuiltEmbeddings.length, failed, embeddings: rebuiltEmbeddings };
 }
 
 export async function backfillEmbeddingsAfterSync(

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -19,6 +19,7 @@ import type {
 } from "./brands.js";
 import { memoryId, isoDateString, isValidMemoryId } from "./brands.js";
 import { attempt } from "./error-utils.js";
+import { mapWithConcurrency } from "./concurrency.js";
 import {
   AtomicWriteInProgressError,
   MalformedNoteError,
@@ -108,34 +109,6 @@ export function hasNoteContent(note: NoteMetadata): note is Note {
 
 /** Maximum number of file descriptors opened at once during bulk listings. */
 const LIST_CONCURRENCY = 32;
-
-/**
- * Map over an array with a bounded number of concurrent async operations while
- * preserving input order in the result (each result is placed at its source
- * index). Used by bulk listings so we never open a descriptor for every note or
- * embedding at once when a vault grows large.
- */
-async function mapWithConcurrency<T, R>(
-  items: readonly T[],
-  concurrency: number,
-  fn: (item: T, index: number) => Promise<R>,
-): Promise<R[]> {
-  if (items.length === 0) return [];
-  const results = new Array<R>(items.length);
-  let next = 0;
-  const workerCount = Math.min(concurrency, items.length);
-  const workers = Array.from({ length: workerCount }, async () => {
-    while (true) {
-      const index = next++;
-      if (index >= items.length) return;
-      const item = items[index];
-      if (item === undefined) return;
-      results[index] = await fn(item, index);
-    }
-  });
-  await Promise.all(workers);
-  return results;
-}
 
 export interface EmbeddingRecord {
   id: MemoryId;

--- a/src/tools/consolidate-helpers.ts
+++ b/src/tools/consolidate-helpers.ts
@@ -24,8 +24,6 @@ import type { EffectiveNoteMetadata } from "../role-suggestions.js";
 import {
   checkEmbeddingCompatibility,
   currentEmbeddingIdentity,
-  embed,
-  embeddingMetadata,
   safeCosineSimilarity,
 } from "../embeddings.js";
 import { classifyTheme, titleCaseTheme } from "../project-introspection.js";
@@ -52,8 +50,8 @@ import {
   removeRelationshipsToNoteIds as removeRelationshipsToNoteIdsFromModule,
 } from "../helpers/vault.js";
 import { toProjectRef } from "../helpers/project.js";
-import { embedTextForNote as embedTextForNoteFromModule } from "../helpers/embed.js";
-import type { EmbeddingRecord, Note, NoteStorage } from "../storage.js";
+import { embedNote } from "../helpers/embed.js";
+import type { EmbeddingRecord, Note } from "../storage.js";
 import { hasNoteContent } from "../storage.js";
 import type { Vault } from "../vault.js";
 import type { ConsolidationMode, ProjectMemoryPolicy } from "../project-memory-policy.js";
@@ -96,10 +94,6 @@ async function pushAfterMutation(ctx: ServerContext, vault: Vault) {
 
 async function removeRelationshipsToNoteIds(ctx: ServerContext, noteIds: string[]) {
   return removeRelationshipsToNoteIdsFromModule(ctx, noteIds);
-}
-
-async function embedTextForNote(storage: NoteStorage, note: Note) {
-  return embedTextForNoteFromModule(storage, note);
 }
 
 /**
@@ -585,16 +579,9 @@ export async function executeMerge(
 
   // Embed consolidated note
   let embeddingStatus: { status: "written" | "skipped"; reason?: string } = { status: "written" };
-  const embedResult = await attempt("consolidate:embed", async () => {
-    const text = await embedTextForNote(targetVault.storage, consolidatedNote);
-    const vector = await embed(text);
-    await targetVault.storage.writeEmbedding({
-      id: targetId,
-      ...embeddingMetadata(vector),
-      embedding: vector,
-      updatedAt: now,
-    });
-  });
+  const embedResult = await attempt("consolidate:embed", () =>
+    embedNote(targetVault.storage, consolidatedNote, now),
+  );
   if (!embedResult.ok) {
     embeddingStatus = { status: "skipped", reason: getErrorMessage(embedResult.error) };
     console.error(`[embedding] Failed for consolidated note '${targetId}': ${embedResult.error}`);

--- a/src/tools/project-memory-summary.ts
+++ b/src/tools/project-memory-summary.ts
@@ -4,6 +4,7 @@ import type { ServerContext } from "../server-context.js";
 import { performance } from "perf_hooks";
 
 import { memoryId } from "../brands.js";
+import { mapWithConcurrency } from "../concurrency.js";
 import {
   checkEmbeddingCompatibility,
   currentEmbeddingIdentity,
@@ -65,42 +66,27 @@ const HYDRATION_CONCURRENCY = 16;
  * their source index to preserve the caller's ordering.
  */
 async function hydrateEntries(projectId: string, raw: NoteEntry[]): Promise<HydratedNoteEntry[]> {
-  const results = new Array<HydratedNoteEntry>(raw.length);
-  let next = 0;
-  const workerCount = Math.min(HYDRATION_CONCURRENCY, Math.max(raw.length, 1));
-  const workers = Array.from({ length: workerCount }, async () => {
-    while (true) {
-      const i = next++;
-      if (i >= raw.length) return;
-      const entry = raw[i];
-      if (entry === undefined) return;
-
-      if (hasNoteContent(entry.note)) {
-        results[i] = { note: entry.note, vault: entry.vault };
-        continue;
-      }
-
-      const cached = getSessionCachedNote(projectId, entry.vault.storage.vaultPath, entry.note.id);
-      if (cached !== undefined && hasNoteContent(cached)) {
-        results[i] = { note: cached, vault: entry.vault };
-        continue;
-      }
-
-      const full = await attempt("project-summary:read-note", () =>
-        entry.vault.storage.readNote(memoryId(entry.note.id)),
-      );
-      if (full.ok && full.value) {
-        setSessionCachedNote(projectId, entry.vault.storage.vaultPath, full.value);
-        results[i] = { note: full.value, vault: entry.vault };
-      } else {
-        // Full read failed — keep the note visible with empty content
-        // (matches prior behavior where metadata notes carried content: "").
-        results[i] = { note: { ...entry.note, content: "" }, vault: entry.vault };
-      }
+  return mapWithConcurrency(raw, HYDRATION_CONCURRENCY, async (entry) => {
+    if (hasNoteContent(entry.note)) {
+      return { note: entry.note, vault: entry.vault };
     }
+
+    const cached = getSessionCachedNote(projectId, entry.vault.storage.vaultPath, entry.note.id);
+    if (cached !== undefined && hasNoteContent(cached)) {
+      return { note: cached, vault: entry.vault };
+    }
+
+    const full = await attempt("project-summary:read-note", () =>
+      entry.vault.storage.readNote(memoryId(entry.note.id)),
+    );
+    if (full.ok && full.value) {
+      setSessionCachedNote(projectId, entry.vault.storage.vaultPath, full.value);
+      return { note: full.value, vault: entry.vault };
+    }
+    // Full read failed — keep the note visible with empty content
+    // (matches prior behavior where metadata notes carried content: "").
+    return { note: { ...entry.note, content: "" }, vault: entry.vault };
   });
-  await Promise.all(workers);
-  return results;
 }
 
 function sampleWarningNotes(entries: NoteEntry[]): Array<{ id: string; title: string }> {

--- a/src/tools/remember.ts
+++ b/src/tools/remember.ts
@@ -10,7 +10,6 @@ import { NOTE_LIFECYCLES, NOTE_ROLES, type Note } from "../storage.js";
 import type { Vault } from "../vault.js";
 import { isoDateString } from "../brands.js";
 import { getErrorMessage, attempt } from "../error-utils.js";
-import { embed, embeddingMetadata } from "../embeddings.js";
 import {
   invalidateActiveProjectCache,
   getRecentSessionNoteAccesses,
@@ -38,7 +37,7 @@ import {
   vaultSelectionDecision,
   type VaultChoiceOption,
 } from "../helpers/mrtr.js";
-import { embedTextForNote } from "../helpers/embed.js";
+import { embedNote } from "../helpers/embed.js";
 import {
   buildPersistenceStatus,
   formatPersistenceSummary,
@@ -389,16 +388,9 @@ export function registerRememberTool(server: McpServer, ctx: ServerContext): voi
         status: "written",
       };
 
-      const embedResult = await attempt("remember:embed", async () => {
-        const text = await embedTextForNote(vault.storage, note);
-        const vector = await embed(text);
-        await vault.storage.writeEmbedding({
-          id,
-          ...embeddingMetadata(vector),
-          embedding: vector,
-          updatedAt: now,
-        });
-      });
+      const embedResult = await attempt("remember:embed", () =>
+        embedNote(vault.storage, note, now),
+      );
       if (!embedResult.ok) {
         embeddingStatus = { status: "skipped", reason: getErrorMessage(embedResult.error) };
         console.error(`[embedding] Skipped for '${id}': ${embedResult.error}`);

--- a/src/tools/update.ts
+++ b/src/tools/update.ts
@@ -19,11 +19,11 @@ import {
   formatPersistenceSummary,
   pushAfterMutation,
 } from "../helpers/persistence.js";
-import { embedTextForNote } from "../helpers/embed.js";
+import { embedNote } from "../helpers/embed.js";
 import { memoryId, isoDateString } from "../brands.js";
 import { cleanMarkdown, MarkdownLintError } from "../markdown.js";
 import { getErrorMessage, attempt, attemptSync } from "../error-utils.js";
-import { embed, embedModel, embeddingMetadata } from "../embeddings.js";
+import { embedModel } from "../embeddings.js";
 import { applySemanticPatches, type SemanticPatch } from "../semantic-patch.js";
 import { hasActualChanges, computeFieldsModified } from "../update-detect-changes.js";
 import { suggestAutoRelationships } from "../auto-relate.js";
@@ -213,7 +213,6 @@ export function registerUpdateTool(server: McpServer, ctx: ServerContext): void 
       const allowProtectedBranch = allowProtectedBranchArg || branchConsent === "granted";
       await ensureBranchSynced(ctx, cwd);
       guardIdsAgainstDocumentSourceMutation([id], "update");
-      const noteId = memoryId(id);
       const project = await resolveProject(ctx, cwd);
       const projectId = project?.id;
       if (projectId) await ensureAttachmentsLoaded(ctx, projectId);
@@ -462,16 +461,9 @@ export function registerUpdateTool(server: McpServer, ctx: ServerContext): void 
       };
 
       if (shouldReembed) {
-        const embedResult = await attempt("update:re-embed", async () => {
-          const text = await embedTextForNote(vault.storage, updated);
-          const vector = await embed(text);
-          await vault.storage.writeEmbedding({
-            id: noteId,
-            ...embeddingMetadata(vector),
-            embedding: vector,
-            updatedAt: now,
-          });
-        });
+        const embedResult = await attempt("update:re-embed", () =>
+          embedNote(vault.storage, updated, now),
+        );
         if (embedResult.ok) {
           embeddingStatus = { status: "written" };
         } else {


### PR DESCRIPTION
## Summary

When mapping independent async work over a collection with bounded concurrency, use the shared `mapWithConcurrency` in `src/concurrency.ts`. It is order-preserving (each result is placed at its source index) and result-returning.

## Notes / References

_Detailed notes in `.mnemonic/notes/`:_

- `.mnemonic/notes/bounded-concurrency-and-single-source-of-truth-principles-c987a7ba.md` — Bounded concurrency and single-source-of-truth principles

---

_Generated from 1 design decision note(s) in `.mnemonic/notes/`. Run `/update-pr` to regenerate._