### PR TITLE
fix(ci): auto-select Copilot model from live /models list; fix TDZ crash

### DIFF
--- a/.github/workflows/update-pr-description.md
+++ b/.github/workflows/update-pr-description.md
@@ -1,0 +1,142 @@
+---
+name: Update PR Description (agentic)
+description: >-
+  Regenerates a PR title and description from the mnemonic design decision notes
+  (.mnemonic/notes/*.md) changed in the PR. Pure agentic workflow — no script:
+  the agent finds the notes, reads them at the PR head ref, and writes a
+  structured description from the format spec below. Supports a staged dry-run
+  via workflow_dispatch (dry-run input) or `gh aw trial`.
+
+on:
+  slash_command:
+    name: update-pr
+    events: [pull_request_comment]
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: PR number to update (required for manual runs)
+        required: true
+        type: string
+      dry-run:
+        description: Preview the generated title/description without applying it
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  pull-requests: read
+  copilot-requests: write
+
+roles: [admin, maintainer, write]
+reaction: eyes
+status-comment: true
+
+engine: copilot
+
+network:
+  allowed:
+    - defaults
+    - github
+
+tools:
+  github:
+    toolsets: [default]
+  bash:
+    - "gh *"
+    - "cat *"
+    - "head *"
+    - "tail *"
+    - "wc *"
+    - "ls *"
+    - "echo *"
+    - "sed *"
+    - "grep *"
+
+safe-outputs:
+  update-pull-request:
+    target: ${{ github.event.inputs.pr_number || github.event.issue.number }}
+    title: true
+    body: true
+    operation: replace
+    staged: ${{ github.event.inputs.dry-run == 'true' }}
+
+---
+# Regenerate PR Title and Description from Mnemonic Notes
+
+Update the title and description of PR #${{ github.event.inputs.pr_number || github.event.issue.number }} in ${{ github.repository }} from the mnemonic design decision notes it contains.
+
+## Find the notes
+
+1. List the files changed in the PR (GitHub API — `gh pr view <number> --json files` — or the GitHub MCP).
+2. Keep only paths under `.mnemonic/notes/` ending in `.md`.
+3. Read each note **at the PR head ref** via the GitHub API (`gh api repos/<owner>/<repo>/contents/<path>?ref=<head sha>`) or the GitHub MCP. The local checkout is the base branch and does NOT contain the PR's notes.
+4. If the PR contains no mnemonic notes, emit `noop` and stop — do not touch the PR.
+
+## Read each note
+
+Every note has YAML frontmatter (`title`, `tags`, `role`, `lifecycle`) followed by a markdown body. Classify notes:
+
+- `role: research` → Research artifact
+- `role: plan` → Plan artifact
+- `role: review` → Review artifact
+- `role: context`, or unroled with `lifecycle: temporary` → Context artifact
+- Everything else (no role, or `lifecycle: permanent`) → permanent design decision
+
+## Title
+
+- One note: use that note's `title`.
+- Multiple notes: prefer the most actionable one — a bug/fix note first, then a decision/design/architecture note — and use its `title`. When the notes are the result of an applied plan, prefix with `Apply: `.
+
+## Description
+
+Emit the body with exactly these sections, in this order (the `##` headers are literal; omit a section when its condition is not met):
+
+```
+## Summary
+
+<lead with what changed and why>
+
+## Changes
+
+<one block per permanent note — only when there are 2+ notes>
+
+## Workflow Artifacts
+
+<grouped research/plan/review/context notes — only when such notes exist>
+
+## Open Questions
+
+<content from any note's "Open Questions" or "Risks" section — only when present>
+
+## Notes / References
+
+_Detailed notes in `.mnemonic/notes/`:_
+- `<path>` — <Note title>
+
+---
+_Generated from N design decision note(s) in `.mnemonic/notes/`. Run `/update-pr` to regenerate._
+```
+
+Per section:
+
+- **Summary** — lead with WHAT changed and WHY. Single permanent note: use its leading paragraph. Multiple notes: one intro line, then one bullet per permanent note. Intro line: if any note is a bug/fix → `This PR fixes the following issues:`; else if any is an enhancement → `This PR adds the following enhancements:`; else → `This PR captures the following design decisions:`. Bullet: `- **<Note title>**`.
+- **Changes** — for each permanent note: `### <Note title>`, then `**Tags:** <tags>` when the note has tags, then the note's leading paragraph condensed to one paragraph.
+- **Workflow Artifacts** — group notes under `**Research:**`, `**Plan:**`, `**Review:**`, `**Context:**` (skip empty groups), with one line per note: `- <Note title> — <first sentence of the note>`.
+- **Open Questions** — include the content of each contributing note's `Open Questions`/`Risks` section; prefix with the note title when more than one note contributes.
+- **Notes / References** — the literal `_Detailed notes in `.mnemonic/notes/`:_` line, then one line per note: `` - `<path>` — <Note title> ``.
+- **Footer** — `---` followed by `_Generated from N design decision note(s) in `.mnemonic/notes/`. Run `/update-pr` to regenerate._`, where `N` is the number of notes.
+
+## Quality rules
+
+- Summary: WHAT changed and WHY, not HOW; be specific about components or decisions; avoid vague phrases such as "various improvements" or "several changes"; do not list filenames or file extensions; keep it to 2–4 sentences.
+- Only state decisions that are actually in the notes — never invent.
+- The body must be complete and reviewable. Never collapse it to a one-liner.
+
+## Output
+
+Emit the result with the `update_pull_request` safe output: `title` and `body` (the full markdown body including the footer).
+
+If the resulting title and body are identical to the PR's current values, emit `noop` instead.
+
+Do not edit files, open issues, or post comments — this workflow only updates the PR description.

--- a/.github/workflows/update-pr-description.yml
+++ b/.github/workflows/update-pr-description.yml
@@ -3,12 +3,13 @@ name: Update PR Description
 # Triggered manually by maintainers commenting `/update-pr` on a PR.
 # Updates the PR title and description from mnemonic design decision notes.
 #
-# Optional AI summary enhancement uses the GitHub Copilot chat completions API
-# with `model: "auto"`. GitHub Models (which previously powered this and needed
-# `permissions: models: read`) was fully retired on 2026-07-30, so AI enhancement
-# now requires a `GH_COPILOT_TOKEN` secret: a fine-grained PAT owned by a personal
-# account with the "Copilot Requests" account permission, from a Copilot-subscribed
-# account. Without it, the description is still generated deterministically.
+# Optional AI summary enhancement uses the GitHub Copilot chat completions API,
+# auto-selecting a concrete model from the account's live Copilot model list.
+# GitHub Models (which previously powered this and needed `permissions: models:
+# read`) was fully retired on 2026-07-30, so AI enhancement now requires a
+# `GH_COPILOT_TOKEN` secret: a fine-grained PAT owned by a personal account with
+# the "Copilot Requests" account permission, from a Copilot-subscribed account.
+# Without it, the description is still generated deterministically.
 
 on:
   issue_comment:

--- a/scripts/ci/update-pr-description.mjs
+++ b/scripts/ci/update-pr-description.mjs
@@ -15,7 +15,8 @@
  *
  * All AI calls are optional — the script degrades to deterministic output if the
  * AI API is unavailable or returns a weak result. AI enhancement uses the GitHub
- * Copilot chat completions API with `model: "auto"` (Copilot picks the best model).
+ * Copilot chat completions API, auto-selecting a concrete model from the account's
+ * live Copilot model list (the cheap tier prefers fast/low-cost models).
  * GitHub Models was retired on 2026-07-30, so the old models.inference.ai.azure.com
  * endpoint is gone. The Copilot API needs a fine-grained PAT with the "Copilot
  * Requests" permission from a Copilot-subscribed account, passed via the
@@ -60,13 +61,35 @@ const THRESHOLDS = {
 // GitHub Copilot chat completions API.
 // GitHub Models (models.inference.ai.azure.com / models.github.ai) was fully
 // retired on 2026-07-30, so AI enhancement now uses the Copilot API.
-// `model: "auto"` lets Copilot route each request to the best available model
-// (fast/low-cost for simple tasks), so no model names need pinning to this file.
+//
+// The Copilot `/chat/completions` endpoint does NOT accept `model: "auto"` —
+// auto model selection is resolved client-side (e.g. VS Code calls a separate
+// routing API). So we auto-select a concrete model from the account's live
+// `GET /models` list, preferring fast/low-cost models for the cheap tier.
+//
 // Enterprise Copilot hosts use a different base URL (api.<org>.githubcopilot.com) —
 // override via COPILOT_API_URL when needed.
 const COPILOT_API = process.env.COPILOT_API_URL ?? "https://api.githubcopilot.com/chat/completions";
-const MODEL_CHEAP = process.env.PR_DESC_AI_MODEL_CHEAP ?? "auto";
-const MODEL_PREMIUM = process.env.PR_DESC_AI_MODEL_PREMIUM ?? "auto";
+const COPILOT_MODELS_URL = new URL("/models", COPILOT_API).href;
+
+// Explicit pins win; otherwise a model is auto-selected from the live list.
+const MODEL_CHEAP = process.env.PR_DESC_AI_MODEL_CHEAP ?? null;
+const MODEL_PREMIUM = process.env.PR_DESC_AI_MODEL_PREMIUM ?? null;
+const PREFERRED_CHEAP_MODELS = [
+  "gpt-5-mini",
+  "claude-haiku-4.5",
+  "gemini-3.5-flash",
+  "gpt-4.1-mini",
+];
+const PREFERRED_PREMIUM_MODELS = ["gpt-5.4", "gpt-5.5", "claude-sonnet-4.6", "gpt-5-mini"];
+// Safe fallback when the model list cannot be fetched (GA across Copilot plans).
+const FALLBACK_MODEL = "gpt-5-mini";
+
+// Module-level cache for the Copilot model list (populated lazily).
+// NOTE: must live at the top of the module — the script invokes `await main()`
+// mid-file, and any `let` declared after that call stays in the temporal dead
+// zone while main()'s async body runs.
+const COPILOT_MODELS_CACHE = { promise: null };
 
 // Copilot API requires these client headers; missing Copilot-Integration-Id
 // yields 403 "token not authorized for this integration". `x-initiator: user`
@@ -407,26 +430,111 @@ export function isWeakSummary(text) {
 // =============================================================================
 
 /**
+ * Resolves the token used for Copilot API calls.
+ *
+ * Prefers GH_COPILOT_TOKEN — a fine-grained PAT with the "Copilot Requests"
+ * permission from a Copilot-subscribed account, stored as a repo/org secret.
+ * Falls back to GH_TOKEN / GITHUB_TOKEN for local runs; note the
+ * Actions-built-in GITHUB_TOKEN has NO Copilot entitlements, so the workflow
+ * must pass GH_COPILOT_TOKEN for AI to work.
+ *
+ * @returns {string|null}
+ */
+function copilotToken() {
+  return process.env.GH_COPILOT_TOKEN ?? process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN ?? null;
+}
+
+/**
+ * Fetches the list of Copilot models available to the authenticated account.
+ * Resolves to an array of model ids, or null when the list cannot be fetched
+ * (network/auth/rate-limit). The result is cached for the lifetime of the run.
+ *
+ * @returns {Promise<Array<string>|null>}
+ */
+function fetchAvailableModels() {
+  if (!COPILOT_MODELS_CACHE.promise) {
+    COPILOT_MODELS_CACHE.promise = (async () => {
+      const token = copilotToken();
+      if (!token) return null;
+      try {
+        const response = await fetch(COPILOT_MODELS_URL, {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            ...COPILOT_HEADERS,
+          },
+          signal: AbortSignal.timeout(10_000),
+        });
+        if (!response.ok) {
+          process.stderr.write(
+            `Copilot models API error: ${response.status} ${response.statusText}\n`,
+          );
+          return null;
+        }
+        const data = await response.json();
+        const list = Array.isArray(data) ? data : (data?.models ?? data?.data ?? []);
+        return list.filter((m) => m && typeof m.id === "string").map((m) => m.id);
+      } catch (err) {
+        process.stderr.write(`Copilot models API fetch failed: ${err.message}\n`);
+        return null;
+      }
+    })();
+  }
+  return COPILOT_MODELS_CACHE.promise;
+}
+
+/**
+ * Picks the first available model matching the preferred ids (exact match first,
+ * then substring). Falls back to the first available model, then to FALLBACK_MODEL
+ * when the list is unavailable.
+ *
+ * @param {string[]} preferredIds
+ * @returns {Promise<string>}
+ */
+async function pickModel(preferredIds) {
+  const available = await fetchAvailableModels();
+  if (!available || available.length === 0) return FALLBACK_MODEL;
+
+  const lower = (s) => s.toLowerCase();
+  for (const id of preferredIds) {
+    if (available.some((m) => lower(m) === lower(id))) return id;
+  }
+  for (const id of preferredIds) {
+    const hit = available.find((m) => lower(m).includes(lower(id)));
+    if (hit) return hit;
+  }
+  return available[0];
+}
+
+/**
+ * Resolves the concrete model id for a tier.
+ * An explicit pin (PR_DESC_AI_MODEL_CHEAP / PR_DESC_AI_MODEL_PREMIUM) wins;
+ * otherwise a model is auto-selected from the account's live Copilot model list.
+ *
+ * @param {'cheap'|'premium'} tier
+ * @returns {Promise<string>}
+ */
+async function resolveTierModel(tier) {
+  const pin = tier === "cheap" ? MODEL_CHEAP : MODEL_PREMIUM;
+  if (pin) return pin;
+  const preferred = tier === "cheap" ? PREFERRED_CHEAP_MODELS : PREFERRED_PREMIUM_MODELS;
+  return pickModel(preferred);
+}
+
+/**
  * Calls the GitHub Copilot chat completions API with the given prompt and model.
  * Returns the generated text or null on any error (network, auth, rate-limit).
  *
- * Uses `fetch` (Node 18+ built-in). Token resolution:
- *   1. GH_COPILOT_TOKEN — fine-grained PAT with the "Copilot Requests" permission
- *      from a Copilot-subscribed account, stored as a repo/org secret.
- *   2. GH_TOKEN / GITHUB_TOKEN fallback (e.g. local runs against a PAT already on
- *      the PATH). Note the Actions-built-in GITHUB_TOKEN has NO Copilot
- *      entitlements, so the workflow must pass GH_COPILOT_TOKEN for AI to work.
- *
- * `max_tokens` and `temperature` are intentionally omitted: `model: "auto"` may
- * route to reasoning models (GPT-5 family) that reject those fields. The prompt
- * already constrains the output to 2-4 sentences.
+ * `max_tokens` and `temperature` are intentionally omitted: an auto-selected
+ * model may be a reasoning model (GPT-5 family) that rejects those fields. The
+ * prompt already constrains the output to 2-4 sentences.
  *
  * @param {string} prompt
- * @param {string} model  Copilot model identifier or "auto"
+ * @param {string} model  Concrete Copilot model identifier (resolved beforehand)
  * @returns {Promise<string|null>}
  */
 async function fetchAiEnhancement(prompt, model) {
-  const token = process.env.GH_COPILOT_TOKEN ?? process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN;
+  const token = copilotToken();
   if (!token) return null;
 
   try {
@@ -435,7 +543,6 @@ async function fetchAiEnhancement(prompt, model) {
       headers: {
         Authorization: `Bearer ${token}`,
         "Content-Type": "application/json",
-        Accept: "application/json",
         ...COPILOT_HEADERS,
       },
       body: JSON.stringify({
@@ -449,8 +556,11 @@ async function fetchAiEnhancement(prompt, model) {
     });
 
     if (!response.ok) {
+      const detail = await response.text().catch(() => "");
       process.stderr.write(
-        `Copilot API error: ${response.status} ${response.statusText} (model: ${model})\n`,
+        `Copilot API error: ${response.status} ${response.statusText} (model: ${model})` +
+          (detail ? ` — ${detail.slice(0, 300)}` : "") +
+          "\n",
       );
       return null;
     }
@@ -485,8 +595,9 @@ function buildEnhancementPrompt(currentSummary, noteContext) {
  *   C — one attempt with the cheap model; fall back to deterministic if weak.
  *   D — cheap attempt first; if weak, one premium attempt; fall back if still weak.
  *
- * Both tiers default to `model: "auto"`; pin specific models via
- * PR_DESC_AI_MODEL_CHEAP / PR_DESC_AI_MODEL_PREMIUM when desired.
+ * Each tier auto-selects a concrete model from the account's live Copilot model
+ * list (cheap prefers fast/low-cost models; premium prefers higher quality).
+ * Pin specific models via PR_DESC_AI_MODEL_CHEAP / PR_DESC_AI_MODEL_PREMIUM.
  *
  * The rest of the description (Changes, Workflow Artifacts, etc.) is kept intact.
  * Returns null when no improvement was produced, so the caller can keep the original.
@@ -517,15 +628,17 @@ async function enhancedSummary(description, notes, tier) {
 
   const prompt = buildEnhancementPrompt(currentSummary, noteContext);
 
-  // Try cheap model first
-  const cheapResult = await fetchAiEnhancement(prompt, MODEL_CHEAP);
+  // Try cheap model first (explicit pin, or auto-selected from the live list)
+  const cheapModel = await resolveTierModel("cheap");
+  const cheapResult = await fetchAiEnhancement(prompt, cheapModel);
   if (cheapResult && !isWeakSummary(cheapResult)) {
     return description.replace(summaryRe, `## Summary\n\n${cheapResult}\n\n`);
   }
 
   // Tier D only: escalate to premium if cheap result was weak
   if (tier === "D") {
-    const premiumResult = await fetchAiEnhancement(prompt, MODEL_PREMIUM);
+    const premiumModel = await resolveTierModel("premium");
+    const premiumResult = await fetchAiEnhancement(prompt, premiumModel);
     if (premiumResult && !isWeakSummary(premiumResult)) {
       return description.replace(summaryRe, `## Summary\n\n${premiumResult}\n\n`);
     }


### PR DESCRIPTION
The Copilot /chat/completions endpoint rejects model: "auto" (400 Bad Request) — auto selection is resolved client-side. Resolve a concrete model instead: fetch GET /models once per run (cached), prefer fast/low-cost models for the cheap tier and higher-quality ones for premium, falling back to gpt-5-mini when the list is unavailable.

Also fixes a TDZ crash: the model cache was declared after the mid-file await main() invocation, so it was uninitialized while main() ran. Hoisted the cache to the top constants block.

Errors now include the API response body (first 300 chars) so future failures are self-diagnosing.