### PR TITLE
Project-anchored precision for recall's derived default scope

### DIFF
--- a/.mnemonic/notes/apply-project-anchored-precision-for-recall-s-derived-defaul-2d318266.md
+++ b/.mnemonic/notes/apply-project-anchored-precision-for-recall-s-derived-defaul-2d318266.md
@@ -1,0 +1,32 @@
+---
+title: 'Apply: project-anchored precision for recall''s derived default scope'
+tags:
+  - workflow
+  - apply
+  - recall
+  - scope
+  - gating
+lifecycle: temporary
+createdAt: '2026-08-29T21:20:33.609Z'
+updatedAt: '2026-08-29T21:20:33.609Z'
+role: context
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+All 14 plan steps implemented (flash worker subagent + orchestrator stabilization). Files: src/recall.ts (subBarGlobal flag, GLOBAL_BAR_DELTA 0.15, shouldGateGlobalCandidate, partitionGatedCandidates, selection filter + lift options), src/tools/recall.ts (derived gate in semantic loop, lexical-merge flag clear, empty-pool lift, suppression/lift/cwd-hint lines, scope zod without default, graph-filter global alignment), src/tools/recall-helpers.ts (lexical global alignment + re-export), src/helpers/project.ts (missingCwdHint + projectParam wording), hints in list/recent-memories/memory-graph/get/update/forget/where-is-memory, scripts/run-dogfood-packs.mjs (2 derived-scope observations), README/AGENT.md/CHANGELOG/docs/index.html, tests/recall.unit.test.ts (bar-boundary + gate + partition units), new tests/recall-scope-gating.integration.test.ts (9 integration tests incl. onboarding regressions).
+
+## Deviations
+
+- GLOBAL_BAR_DELTA lives in src/recall.ts, re-exported from recall-helpers.ts (avoids circular import; plan named recall-helpers.ts as home). Equivalent.
+- Worker hit its 30-min budget mid self-repair of a botched edit in its own new test file; syntax was fixed by the worker, orchestrator applied eslint --fix (one blank line) and re-verified.
+- Worker's full-suite run showed 2 test TIMEOUTS (vault.unit getPendingNoteFiles x2, working-state-continuity lifecycle recall) - both files pass fresh in targeted run (flaky under full-suite parallel load, not regressions).
+- Known minor finding from TS-skill review: get.ts not-found path pushes an empty line when cwd IS present (missingCwdHint returns '' and is pushed unconditionally) - pre-flagged for review.
+
+## Verification (orchestrator)
+
+- Command: npm run build - Result: pass
+- Command: vitest run recall-scope-gating.integration + recall.unit + vault.unit + working-state-continuity + dogfooding-runner - Result: pass (138 tests, 19s)
+- Command: prettier/eslint on new test file - Result: pass
+- Full suite + full lint + dogfood:isolated: deferred to fresh-context review (must run fresh).

--- a/.mnemonic/notes/apply-project-anchored-precision-for-recall-s-derived-defaul-2d318266.md
+++ b/.mnemonic/notes/apply-project-anchored-precision-for-recall-s-derived-defaul-2d318266.md
@@ -8,11 +8,14 @@ tags:
   - gating
 lifecycle: temporary
 createdAt: '2026-08-29T21:20:33.609Z'
-updatedAt: '2026-08-29T21:20:33.609Z'
+updatedAt: '2026-08-29T21:20:39.624Z'
 role: context
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: plan-project-anchored-precision-for-recall-s-derived-default-88909532
+    type: follows
 memoryVersion: 1
 ---
 All 14 plan steps implemented (flash worker subagent + orchestrator stabilization). Files: src/recall.ts (subBarGlobal flag, GLOBAL_BAR_DELTA 0.15, shouldGateGlobalCandidate, partitionGatedCandidates, selection filter + lift options), src/tools/recall.ts (derived gate in semantic loop, lexical-merge flag clear, empty-pool lift, suppression/lift/cwd-hint lines, scope zod without default, graph-filter global alignment), src/tools/recall-helpers.ts (lexical global alignment + re-export), src/helpers/project.ts (missingCwdHint + projectParam wording), hints in list/recent-memories/memory-graph/get/update/forget/where-is-memory, scripts/run-dogfood-packs.mjs (2 derived-scope observations), README/AGENT.md/CHANGELOG/docs/index.html, tests/recall.unit.test.ts (bar-boundary + gate + partition units), new tests/recall-scope-gating.integration.test.ts (9 integration tests incl. onboarding regressions).

--- a/.mnemonic/notes/apply-project-anchored-precision-for-recall-s-derived-defaul-2d318266.md
+++ b/.mnemonic/notes/apply-project-anchored-precision-for-recall-s-derived-defaul-2d318266.md
@@ -8,7 +8,7 @@ tags:
   - gating
 lifecycle: temporary
 createdAt: '2026-08-29T21:20:33.609Z'
-updatedAt: '2026-08-29T21:20:39.624Z'
+updatedAt: '2026-08-29T21:28:05.413Z'
 role: context
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -16,6 +16,8 @@ projectName: mnemonic
 relatedTo:
   - id: plan-project-anchored-precision-for-recall-s-derived-default-88909532
     type: follows
+  - id: review-derived-scope-gating-implementation-continue-with-3-p-b52a2e1d
+    type: derives-from
 memoryVersion: 1
 ---
 All 14 plan steps implemented (flash worker subagent + orchestrator stabilization). Files: src/recall.ts (subBarGlobal flag, GLOBAL_BAR_DELTA 0.15, shouldGateGlobalCandidate, partitionGatedCandidates, selection filter + lift options), src/tools/recall.ts (derived gate in semantic loop, lexical-merge flag clear, empty-pool lift, suppression/lift/cwd-hint lines, scope zod without default, graph-filter global alignment), src/tools/recall-helpers.ts (lexical global alignment + re-export), src/helpers/project.ts (missingCwdHint + projectParam wording), hints in list/recent-memories/memory-graph/get/update/forget/where-is-memory, scripts/run-dogfood-packs.mjs (2 derived-scope observations), README/AGENT.md/CHANGELOG/docs/index.html, tests/recall.unit.test.ts (bar-boundary + gate + partition units), new tests/recall-scope-gating.integration.test.ts (9 integration tests incl. onboarding regressions).

--- a/.mnemonic/notes/plan-project-anchored-precision-for-recall-s-derived-default-88909532.md
+++ b/.mnemonic/notes/plan-project-anchored-precision-for-recall-s-derived-default-88909532.md
@@ -8,11 +8,14 @@ tags:
   - gating
 lifecycle: temporary
 createdAt: '2026-08-29T20:40:46.880Z'
-updatedAt: '2026-08-29T20:41:23.226Z'
+updatedAt: '2026-08-29T20:41:26.705Z'
 role: plan
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: rpir-request-smarter-default-scoping-for-recall-and-read-too-7ffd0632
+    type: derives-from
 memoryVersion: 1
 ---
 Derived-default read scoping for recall: keep default `all`, gate weak global semantic matches when cwd resolves a project and scope was NOT explicitly passed. Preserves the weaving design goal (curated/strong/lexical/graph-linked globals weave in; weak-global noise gated out of the default top-K). Exemption signal: `alwaysLoad: true` only (explicit, tool-settable). GLOBAL\_BAR\_DELTA = 0.15 (code constant). Research: `research-read-tool-scoping-behavior-and-missing-cwd-handling-8a77b8a5`.

--- a/.mnemonic/notes/plan-project-anchored-precision-for-recall-s-derived-default-88909532.md
+++ b/.mnemonic/notes/plan-project-anchored-precision-for-recall-s-derived-default-88909532.md
@@ -8,7 +8,7 @@ tags:
   - gating
 lifecycle: temporary
 createdAt: '2026-08-29T20:40:46.880Z'
-updatedAt: '2026-08-29T20:46:02.333Z'
+updatedAt: '2026-08-29T20:52:00.000Z'
 role: plan
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -30,3 +30,19 @@ Derived default scope `all` for recall stays; gate weak global SEMANTIC candidat
 - [ ] 6. Selection filters flagged candidates; empty notes AND empty chunks -> re-select unfiltered (lift).
 - [ ] 7. Output: suppressed-count line when gated notes dropped; lift line when widened; no structuredContent schema change.
 - [ ] 8. global-scope alignment: collectLexicalCandidates + graph filter switch to vault-provenance (main vault only), matching semantic channel and vault-routing test :379.
+- [ ] 9. Missing-cwd hints: recall/list/recent_memories/memory_graph one line when cwd undefined; get/update/forget/where_is_memory hint in not-found responses.
+- [ ] 10. projectParam description: consequence-oriented (without cwd only the main vault is visible).
+- [ ] 11. Unit: gate predicate + filter/lift in recall.unit.test.ts. Integration: new recall-scope-gating.integration.test.ts via callLocalMcp + fake embedding server (read tests/helpers/mcp.ts first for vector control): gating, alwaysLoad exemption, explicit-all, lift, lexical override, hints, global alignment, onboarding regressions.
+- [ ] 12. Docs: README scope section, AGENT.md, CHANGELOG, homepage docs/index.html 'Project-scoped recall' card + recall examples (include cwd); do NOT reintroduce fill-the-limit language (July RRF decision supersedes).
+- [ ] 13. Dogfood: npm run dogfood:isolated — no new advisories; add Pack A observations (derived recall with cwd works; missing-cwd hint without cwd).
+- [ ] 14. Verify: build, test, lint, typecheck, dogfood:isolated.
+
+## Onboarding constraints
+
+Unadopted project + cwd: no error; project-tagged global notes stay visible; empty results lift (pre-adoption unchanged or better). Global-policy adoption: project association -> isCurrentProject, never gated. Project-vault adoption: never gated. remember ask/vault-creation rules + project_memory_summary untouched.
+
+## Constraints
+
+No behavior change for explicit scope or unresolved cwd/project. Lexical/graph thresholds untouched. Tags/lifecycle orthogonal to gating. No new config/env; no schema break.
+
+Implementation: flash subagent. Review: fresh-context subagent (session model). Self-check: all research requirements mapped to steps 1-14; no placeholders.

--- a/.mnemonic/notes/plan-project-anchored-precision-for-recall-s-derived-default-88909532.md
+++ b/.mnemonic/notes/plan-project-anchored-precision-for-recall-s-derived-default-88909532.md
@@ -8,7 +8,7 @@ tags:
   - gating
 lifecycle: temporary
 createdAt: '2026-08-29T20:40:46.880Z'
-updatedAt: '2026-08-29T20:52:00.000Z'
+updatedAt: '2026-08-29T21:20:39.624Z'
 role: plan
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -16,6 +16,8 @@ projectName: mnemonic
 relatedTo:
   - id: rpir-request-smarter-default-scoping-for-recall-and-read-too-7ffd0632
     type: derives-from
+  - id: apply-project-anchored-precision-for-recall-s-derived-defaul-2d318266
+    type: follows
 memoryVersion: 1
 ---
 Derived default scope `all` for recall stays; gate weak global SEMANTIC candidates when cwd resolves a project and scope was NOT explicitly passed. Weaving goal preserved: curated (`alwaysLoad: true`), strong matches (rawScore >= minSimilarity + GLOBAL_BAR_DELTA = 0.15), lexical-exact, and graph-linked globals still weave in. Research: research-read-tool-scoping-behavior-and-missing-cwd-handling-8a77b8a5.

--- a/.mnemonic/notes/plan-project-anchored-precision-for-recall-s-derived-default-88909532.md
+++ b/.mnemonic/notes/plan-project-anchored-precision-for-recall-s-derived-default-88909532.md
@@ -8,7 +8,7 @@ tags:
   - gating
 lifecycle: temporary
 createdAt: '2026-08-29T20:40:46.880Z'
-updatedAt: '2026-08-29T20:45:00.823Z'
+updatedAt: '2026-08-29T20:45:05.053Z'
 role: plan
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -43,11 +43,17 @@ Derived-default read scoping for recall: keep default `all`, gate weak global se
 
 ## Additions: homepage, dogfood, tests (post-handoff)
 
+- [ ] 16\. Test placement. UNIT: gate predicate + selection filter/lift as pure exported helpers in src/recall.ts (backward-compatible optional param on selectRecallResults/selectWorkflowResults), tested in tests/recall.unit.test.ts. INTEGRATION: new tests/recall-scope-gating.integration.test.ts via callLocalMcp + fake embedding server — read tests/helpers/mcp.ts first to learn vector control, position similarities around the bar (e.g. via minSimilarity). Update tool-descriptions/mcp-schema-contract tests for changed param text.
+- [ ] 17\. Verify: add `npm run dogfood:isolated` to step 13 commands.
+
 - [ ] 14\. Homepage (docs/index.html): update the 'Project-scoped recall' feature card to state the derived default honestly (weak global matches gated; curated/strong/lexical/graph-linked remain; explicit scope 'all' disables gating). Check recall JSON examples on the page and include cwd where shown. Historical dogfood card recall-heuristic-instead-of-full-dynamic-context-12324717 (fill-the-limit idea, note no longer in vault) stays as-is; do NOT reintroduce fill-the-limit language — July RRF decision supersedes (bounded prior, no hard project-first).
+
 - [ ] 15\. Dogfood: run `npm run dogfood:isolated`, no NEW advisories vs baseline. Pack A line 98 passes explicit scope all (unaffected); other recall calls pass cwd without scope — derived gating is exercised. Add two bounded Pack A observations: derived-scope recall with cwd returns results; recall without cwd shows the missing-cwd hint line. Keep dogfooding-runner tests green.
 
 - No behavior change when scope is explicitly passed or when cwd/project unresolved.
+
 - Lexical/graph thresholds untouched; tags/lifecycle filters orthogonal to gating.
+
 - No new config/env; no structuredContent schema break.
 
 Implementation: flash subagent. Review: fresh-context subagent, session model. Self-check: every research requirement maps to a step; no placeholders; steps cite concrete files.

--- a/.mnemonic/notes/plan-project-anchored-precision-for-recall-s-derived-default-88909532.md
+++ b/.mnemonic/notes/plan-project-anchored-precision-for-recall-s-derived-default-88909532.md
@@ -1,0 +1,27 @@
+---
+title: 'Plan: project-anchored precision for recall''s derived default scope'
+tags:
+  - workflow
+  - plan
+  - recall
+  - scope
+  - gating
+lifecycle: temporary
+createdAt: '2026-08-29T20:40:46.880Z'
+updatedAt: '2026-08-29T20:40:46.880Z'
+role: plan
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+Derived-default read scoping for recall: keep default `all`, gate weak global semantic matches when cwd resolves a project and scope was NOT explicitly passed. Preserves the weaving design goal (curated/strong/lexical/graph-linked globals weave in; weak-global noise gated out of the default top-K). Exemption signal: `alwaysLoad: true` only (explicit, tool-settable). GLOBAL_BAR_DELTA = 0.15 (code constant). Research: `research-read-tool-scoping-behavior-and-missing-cwd-handling-8a77b8a5`.
+
+## Steps
+
+- [ ] 1. `src/tools/recall-helpers.ts`: export `GLOBAL_BAR_DELTA = 0.15` with rationale comment (bar = minSimilarity+0.15 = 0.45 < SPREADING_ACTIVATION_GATE 0.5, so sub-bar candidates can never be graph entry points).
+- [ ] 2. `src/tools/recall.ts` scope zod: remove `.default("all")`, keep optional; update description: omitted = derived project-anchored precision, explicit values unchanged (explicit `all` is ungated).
+- [ ] 3. `src/recall.ts` `ScoredRecallCandidate`: add optional `subBarGlobal?: boolean`.
+- [ ] 4. `src/tools/recall.ts` semantic loop: gateActive = scope === undefined && project !== undefined; for main-vault candidates with !isCurrentProject && !isAttachedVault && meta.alwaysLoad !== true && rawScore < minSimilarity + GLOBAL_BAR_DELTA: push with subBarGlobal true (still push, never skip).
+- [ ] 5. Lexical merge: when a lexical candidate attaches to an existing candidate, clear subBarGlobal (lexical admission overrides the bar).
+- [ ] 6. Selection: filter !subBarGlobal before selectRecallResults/selectWorkflowResults; if selected notes AND documentChunks are both empty, re-select unfiltered (lift).

--- a/.mnemonic/notes/plan-project-anchored-precision-for-recall-s-derived-default-88909532.md
+++ b/.mnemonic/notes/plan-project-anchored-precision-for-recall-s-derived-default-88909532.md
@@ -8,7 +8,7 @@ tags:
   - gating
 lifecycle: temporary
 createdAt: '2026-08-29T20:40:46.880Z'
-updatedAt: '2026-08-29T20:45:05.053Z'
+updatedAt: '2026-08-29T20:46:02.333Z'
 role: plan
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -18,49 +18,15 @@ relatedTo:
     type: derives-from
 memoryVersion: 1
 ---
-Derived-default read scoping for recall: keep default `all`, gate weak global semantic matches when cwd resolves a project and scope was NOT explicitly passed. Preserves the weaving design goal (curated/strong/lexical/graph-linked globals weave in; weak-global noise gated out of the default top-K). Exemption signal: `alwaysLoad: true` only (explicit, tool-settable). GLOBAL\_BAR\_DELTA = 0.15 (code constant). Research: `research-read-tool-scoping-behavior-and-missing-cwd-handling-8a77b8a5`.
+Derived default scope `all` for recall stays; gate weak global SEMANTIC candidates when cwd resolves a project and scope was NOT explicitly passed. Weaving goal preserved: curated (`alwaysLoad: true`), strong matches (rawScore >= minSimilarity + GLOBAL_BAR_DELTA = 0.15), lexical-exact, and graph-linked globals still weave in. Research: research-read-tool-scoping-behavior-and-missing-cwd-handling-8a77b8a5.
 
 ## Steps
 
-## Steps (continued)
-
-- [ ] 7\. Output: header keeps `scope: all`; suppressed>0 adds one line 'N weak global matches suppressed — pass scope: all to include'; lift adds 'no project matches; showing all matches'. No structuredContent schema change.
-- [ ] 8\. global-scope alignment (location-based across channels, matches vault-routing test :379): `collectLexicalCandidates` replaces the `isProjectNote` check with vault-provenance skip; recall.ts graph filter (\~:557) replaces `meta.project !== undefined` with vault-provenance skip.
-- [ ] 9\. Missing-cwd hints: recall/list/recent\_memories/memory\_graph append one line when cwd undefined; get/update/forget/where\_is\_memory append hint to not-found responses when cwd omitted.
-- [ ] 10\. `src/helpers/project.ts` projectParam description: consequence-oriented (without cwd only the global main vault is visible).
-- [ ] 11\. Tests: derived gating excludes weak unassociated globals; alwaysLoad exemption; explicit all ungated; empty-pool lift; strong-lexical override; missing-cwd hints; global scope includes project-tagged main-vault note; onboarding regressions (below).
-- [ ] 12\. Docs: README recall scope section, AGENT.md wording, CHANGELOG.
-- [ ] 13\. Verify: `npm run build`, `npm test`, `npm run lint`, `npm run typecheck` green.
-
-## Onboarding constraints (must not break)
-
-- Unadopted project (no .mnemonic/, no policy) + cwd recall: no error, existing project-tagged global notes stay visible, empty results lift to sub-bar globals — pre-adoption behavior unchanged or better.
-- Fresh adoption via global choice: main-vault notes with project association are isCurrentProject, never gated.
-- Fresh adoption via project vault: project-vault notes never gated.
-- remember unadopted-ask elicitation and vault-creation rules untouched; project\_memory\_summary untouched.
-
-## Constraints
-
-## Additions: homepage, dogfood, tests (post-handoff)
-
-- [ ] 16\. Test placement. UNIT: gate predicate + selection filter/lift as pure exported helpers in src/recall.ts (backward-compatible optional param on selectRecallResults/selectWorkflowResults), tested in tests/recall.unit.test.ts. INTEGRATION: new tests/recall-scope-gating.integration.test.ts via callLocalMcp + fake embedding server — read tests/helpers/mcp.ts first to learn vector control, position similarities around the bar (e.g. via minSimilarity). Update tool-descriptions/mcp-schema-contract tests for changed param text.
-- [ ] 17\. Verify: add `npm run dogfood:isolated` to step 13 commands.
-
-- [ ] 14\. Homepage (docs/index.html): update the 'Project-scoped recall' feature card to state the derived default honestly (weak global matches gated; curated/strong/lexical/graph-linked remain; explicit scope 'all' disables gating). Check recall JSON examples on the page and include cwd where shown. Historical dogfood card recall-heuristic-instead-of-full-dynamic-context-12324717 (fill-the-limit idea, note no longer in vault) stays as-is; do NOT reintroduce fill-the-limit language — July RRF decision supersedes (bounded prior, no hard project-first).
-
-- [ ] 15\. Dogfood: run `npm run dogfood:isolated`, no NEW advisories vs baseline. Pack A line 98 passes explicit scope all (unaffected); other recall calls pass cwd without scope — derived gating is exercised. Add two bounded Pack A observations: derived-scope recall with cwd returns results; recall without cwd shows the missing-cwd hint line. Keep dogfooding-runner tests green.
-
-- No behavior change when scope is explicitly passed or when cwd/project unresolved.
-
-- Lexical/graph thresholds untouched; tags/lifecycle filters orthogonal to gating.
-
-- No new config/env; no structuredContent schema break.
-
-Implementation: flash subagent. Review: fresh-context subagent, session model. Self-check: every research requirement maps to a step; no placeholders; steps cite concrete files.
-
-- [ ] 1\. `src/tools/recall-helpers.ts`: export `GLOBAL_BAR_DELTA = 0.15` with rationale comment (bar = minSimilarity+0.15 = 0.45 < SPREADING\_ACTIVATION\_GATE 0.5, so sub-bar candidates can never be graph entry points).
-- [ ] 2\. `src/tools/recall.ts` scope zod: remove `.default("all")`, keep optional; update description: omitted = derived project-anchored precision, explicit values unchanged (explicit `all` is ungated).
-- [ ] 3\. `src/recall.ts` `ScoredRecallCandidate`: add optional `subBarGlobal?: boolean`.
-- [ ] 4\. `src/tools/recall.ts` semantic loop: gateActive = scope === undefined && project !== undefined; for main-vault candidates with !isCurrentProject && !isAttachedVault && meta.alwaysLoad !== true && rawScore < minSimilarity + GLOBAL\_BAR\_DELTA: push with subBarGlobal true (still push, never skip).
-- [ ] 5\. Lexical merge: when a lexical candidate attaches to an existing candidate, clear subBarGlobal (lexical admission overrides the bar).
-- [ ] 6\. Selection: filter !subBarGlobal before selectRecallResults/selectWorkflowResults; if selected notes AND documentChunks are both empty, re-select unfiltered (lift).
+- [ ] 1. recall-helpers.ts: export GLOBAL_BAR_DELTA = 0.15 (comment: bar 0.45 < SPREADING_ACTIVATION_GATE 0.5, so sub-bar candidates never become graph entry points).
+- [ ] 2. recall.ts scope zod: drop .default("all"); description documents derived default; explicit values unchanged (explicit all = ungated).
+- [ ] 3. src/recall.ts ScoredRecallCandidate: optional subBarGlobal?: boolean.
+- [ ] 4. Semantic loop: gateActive = scope undefined && project; main-vault + !isCurrentProject + !isAttachedVault + alwaysLoad !== true + rawScore < minSimilarity + DELTA: push flagged (still push, never skip).
+- [ ] 5. Lexical merge clears the flag (lexical admission overrides the bar).
+- [ ] 6. Selection filters flagged candidates; empty notes AND empty chunks -> re-select unfiltered (lift).
+- [ ] 7. Output: suppressed-count line when gated notes dropped; lift line when widened; no structuredContent schema change.
+- [ ] 8. global-scope alignment: collectLexicalCandidates + graph filter switch to vault-provenance (main vault only), matching semantic channel and vault-routing test :379.

--- a/.mnemonic/notes/plan-project-anchored-precision-for-recall-s-derived-default-88909532.md
+++ b/.mnemonic/notes/plan-project-anchored-precision-for-recall-s-derived-default-88909532.md
@@ -8,7 +8,7 @@ tags:
   - gating
 lifecycle: temporary
 createdAt: '2026-08-29T20:40:46.880Z'
-updatedAt: '2026-08-29T20:41:26.705Z'
+updatedAt: '2026-08-29T20:45:00.823Z'
 role: plan
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -40,6 +40,11 @@ Derived-default read scoping for recall: keep default `all`, gate weak global se
 - remember unadopted-ask elicitation and vault-creation rules untouched; project\_memory\_summary untouched.
 
 ## Constraints
+
+## Additions: homepage, dogfood, tests (post-handoff)
+
+- [ ] 14\. Homepage (docs/index.html): update the 'Project-scoped recall' feature card to state the derived default honestly (weak global matches gated; curated/strong/lexical/graph-linked remain; explicit scope 'all' disables gating). Check recall JSON examples on the page and include cwd where shown. Historical dogfood card recall-heuristic-instead-of-full-dynamic-context-12324717 (fill-the-limit idea, note no longer in vault) stays as-is; do NOT reintroduce fill-the-limit language — July RRF decision supersedes (bounded prior, no hard project-first).
+- [ ] 15\. Dogfood: run `npm run dogfood:isolated`, no NEW advisories vs baseline. Pack A line 98 passes explicit scope all (unaffected); other recall calls pass cwd without scope — derived gating is exercised. Add two bounded Pack A observations: derived-scope recall with cwd returns results; recall without cwd shows the missing-cwd hint line. Keep dogfooding-runner tests green.
 
 - No behavior change when scope is explicitly passed or when cwd/project unresolved.
 - Lexical/graph thresholds untouched; tags/lifecycle filters orthogonal to gating.

--- a/.mnemonic/notes/plan-project-anchored-precision-for-recall-s-derived-default-88909532.md
+++ b/.mnemonic/notes/plan-project-anchored-precision-for-recall-s-derived-default-88909532.md
@@ -8,20 +8,45 @@ tags:
   - gating
 lifecycle: temporary
 createdAt: '2026-08-29T20:40:46.880Z'
-updatedAt: '2026-08-29T20:40:46.880Z'
+updatedAt: '2026-08-29T20:41:23.226Z'
 role: plan
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 memoryVersion: 1
 ---
-Derived-default read scoping for recall: keep default `all`, gate weak global semantic matches when cwd resolves a project and scope was NOT explicitly passed. Preserves the weaving design goal (curated/strong/lexical/graph-linked globals weave in; weak-global noise gated out of the default top-K). Exemption signal: `alwaysLoad: true` only (explicit, tool-settable). GLOBAL_BAR_DELTA = 0.15 (code constant). Research: `research-read-tool-scoping-behavior-and-missing-cwd-handling-8a77b8a5`.
+Derived-default read scoping for recall: keep default `all`, gate weak global semantic matches when cwd resolves a project and scope was NOT explicitly passed. Preserves the weaving design goal (curated/strong/lexical/graph-linked globals weave in; weak-global noise gated out of the default top-K). Exemption signal: `alwaysLoad: true` only (explicit, tool-settable). GLOBAL\_BAR\_DELTA = 0.15 (code constant). Research: `research-read-tool-scoping-behavior-and-missing-cwd-handling-8a77b8a5`.
 
 ## Steps
 
-- [ ] 1. `src/tools/recall-helpers.ts`: export `GLOBAL_BAR_DELTA = 0.15` with rationale comment (bar = minSimilarity+0.15 = 0.45 < SPREADING_ACTIVATION_GATE 0.5, so sub-bar candidates can never be graph entry points).
-- [ ] 2. `src/tools/recall.ts` scope zod: remove `.default("all")`, keep optional; update description: omitted = derived project-anchored precision, explicit values unchanged (explicit `all` is ungated).
-- [ ] 3. `src/recall.ts` `ScoredRecallCandidate`: add optional `subBarGlobal?: boolean`.
-- [ ] 4. `src/tools/recall.ts` semantic loop: gateActive = scope === undefined && project !== undefined; for main-vault candidates with !isCurrentProject && !isAttachedVault && meta.alwaysLoad !== true && rawScore < minSimilarity + GLOBAL_BAR_DELTA: push with subBarGlobal true (still push, never skip).
-- [ ] 5. Lexical merge: when a lexical candidate attaches to an existing candidate, clear subBarGlobal (lexical admission overrides the bar).
-- [ ] 6. Selection: filter !subBarGlobal before selectRecallResults/selectWorkflowResults; if selected notes AND documentChunks are both empty, re-select unfiltered (lift).
+## Steps (continued)
+
+- [ ] 7\. Output: header keeps `scope: all`; suppressed>0 adds one line 'N weak global matches suppressed — pass scope: all to include'; lift adds 'no project matches; showing all matches'. No structuredContent schema change.
+- [ ] 8\. global-scope alignment (location-based across channels, matches vault-routing test :379): `collectLexicalCandidates` replaces the `isProjectNote` check with vault-provenance skip; recall.ts graph filter (\~:557) replaces `meta.project !== undefined` with vault-provenance skip.
+- [ ] 9\. Missing-cwd hints: recall/list/recent\_memories/memory\_graph append one line when cwd undefined; get/update/forget/where\_is\_memory append hint to not-found responses when cwd omitted.
+- [ ] 10\. `src/helpers/project.ts` projectParam description: consequence-oriented (without cwd only the global main vault is visible).
+- [ ] 11\. Tests: derived gating excludes weak unassociated globals; alwaysLoad exemption; explicit all ungated; empty-pool lift; strong-lexical override; missing-cwd hints; global scope includes project-tagged main-vault note; onboarding regressions (below).
+- [ ] 12\. Docs: README recall scope section, AGENT.md wording, CHANGELOG.
+- [ ] 13\. Verify: `npm run build`, `npm test`, `npm run lint`, `npm run typecheck` green.
+
+## Onboarding constraints (must not break)
+
+- Unadopted project (no .mnemonic/, no policy) + cwd recall: no error, existing project-tagged global notes stay visible, empty results lift to sub-bar globals — pre-adoption behavior unchanged or better.
+- Fresh adoption via global choice: main-vault notes with project association are isCurrentProject, never gated.
+- Fresh adoption via project vault: project-vault notes never gated.
+- remember unadopted-ask elicitation and vault-creation rules untouched; project\_memory\_summary untouched.
+
+## Constraints
+
+- No behavior change when scope is explicitly passed or when cwd/project unresolved.
+- Lexical/graph thresholds untouched; tags/lifecycle filters orthogonal to gating.
+- No new config/env; no structuredContent schema break.
+
+Implementation: flash subagent. Review: fresh-context subagent, session model. Self-check: every research requirement maps to a step; no placeholders; steps cite concrete files.
+
+- [ ] 1\. `src/tools/recall-helpers.ts`: export `GLOBAL_BAR_DELTA = 0.15` with rationale comment (bar = minSimilarity+0.15 = 0.45 < SPREADING\_ACTIVATION\_GATE 0.5, so sub-bar candidates can never be graph entry points).
+- [ ] 2\. `src/tools/recall.ts` scope zod: remove `.default("all")`, keep optional; update description: omitted = derived project-anchored precision, explicit values unchanged (explicit `all` is ungated).
+- [ ] 3\. `src/recall.ts` `ScoredRecallCandidate`: add optional `subBarGlobal?: boolean`.
+- [ ] 4\. `src/tools/recall.ts` semantic loop: gateActive = scope === undefined && project !== undefined; for main-vault candidates with !isCurrentProject && !isAttachedVault && meta.alwaysLoad !== true && rawScore < minSimilarity + GLOBAL\_BAR\_DELTA: push with subBarGlobal true (still push, never skip).
+- [ ] 5\. Lexical merge: when a lexical candidate attaches to an existing candidate, clear subBarGlobal (lexical admission overrides the bar).
+- [ ] 6\. Selection: filter !subBarGlobal before selectRecallResults/selectWorkflowResults; if selected notes AND documentChunks are both empty, re-select unfiltered (lift).

--- a/.mnemonic/notes/research-read-tool-scoping-behavior-and-missing-cwd-handling-8a77b8a5.md
+++ b/.mnemonic/notes/research-read-tool-scoping-behavior-and-missing-cwd-handling-8a77b8a5.md
@@ -8,7 +8,7 @@ tags:
   - policy
 lifecycle: temporary
 createdAt: '2026-08-29T10:53:29.651Z'
-updatedAt: '2026-08-29T10:53:39.362Z'
+updatedAt: '2026-08-29T11:01:49.369Z'
 role: research
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -16,17 +16,19 @@ projectName: mnemonic
 relatedTo:
   - id: rpir-request-smarter-default-scoping-for-recall-and-read-too-7ffd0632
     type: derives-from
+  - id: mnemonic-key-design-decisions-3f2a6273
+    type: related-to
 memoryVersion: 1
 ---
 Verified against code at HEAD 1ff136a. Request root: `rpir-request-smarter-default-scoping-for-recall-and-read-too-7ffd0632`.
 
 ## Current behavior (facts)
 
-- All read tools hard-default `scope: "all"`: recall (`src/tools/recall.ts:159-167`), list (`src/tools/list.ts:36`), recent_memories (`src/tools/recent-memories.ts:37`), memory_graph (`src/tools/memory-graph.ts:31`). The zod `.default("all")` means the server never sees "caller did not choose".
+- All read tools hard-default `scope: "all"`: recall (`src/tools/recall.ts:159-167`), list (`src/tools/list.ts:36`), recent\_memories (`src/tools/recent-memories.ts:37`), memory\_graph (`src/tools/memory-graph.ts:31`). The zod `.default("all")` means the server never sees "caller did not choose".
 - `resolveWriteScope` (policy-aware) is used ONLY by `remember` (`src/tools/remember.ts:21,295`). Read tools never consult the project memory policy. `defaultScope` policy governs write location, not reads.
 - cwd omitted → `resolveProject` returns undefined (`src/helpers/project.ts:25-28`) → `searchOrder` appends only the main vault (`src/vault.ts:217-232`). Project vault is INVISIBLE to recall/list/recent/graph. Id-based tools (`get`/`update`/`forget`/`where_is_memory` → `findNote`) also cannot resolve project-vault notes without cwd.
 - `project_memory_summary` REQUIRES cwd and errors when unresolvable (`src/tools/project-memory-summary.ts:201-236`).
-- With cwd + scope "all", project notes get only a tiny bounded prior: `PROJECT_SCOPE_BOOST = 0.005` (`src/tools/recall-helpers.ts:60`) vs RRF fusion scale ~0.15 (`src/recall.ts`). Prior RRF plan note `plan-one-shot-bounded-rrf-hybrid-recall-alignment-7aa73aaa` explicitly rejected hard project-first RANKING within fused "all" results — but choosing the default candidate SET (scope) is a different lever and does not contradict it.
+- With cwd + scope "all", project notes get only a tiny bounded prior: `PROJECT_SCOPE_BOOST = 0.005` (`src/tools/recall-helpers.ts:60`) vs RRF fusion scale \~0.15 (`src/recall.ts`). Prior RRF plan note `plan-one-shot-bounded-rrf-hybrid-recall-alignment-7aa73aaa` explicitly rejected hard project-first RANKING within fused "all" results — but choosing the default candidate SET (scope) is a different lever and does not contradict it.
 - Pre-existing inconsistency inside recall for explicit scope `"global"`: semantic channel filters by VAULT LOCATION (main vault, includes project-tagged notes, `recall.ts:400-407`); lexical channel and graph filter by PROJECT ASSOCIATION (exclude project-tagged notes, `recall-helpers.ts` collectLexicalCandidates, `recall.ts:557-558`). Test `tests/vault-routing.integration.test.ts:379` ("scope: global returns project-tagged notes stored in the main vault") documents the location-based semantic as INTENTIONAL — the "repo you don't own" case: personal notes about a foreign repo stored globally but project-tagged must stay reachable. So lexical/graph deviate from the documented intent; the recall scope param description and README:406 ("only memories with no project association") are also inaccurate.
 - `list`-family funnel `collectVisibleNotes` (`src/helpers/vault.ts:58-129`): "global" = location-based (main vault, regardless of project tag) — consistent with the test intent. `list` sorts current-project notes first under "all".
 - `scope: "project"` + cwd resolves a project = current-project-associated notes (wherever stored) + attached vault notes. This covers notes written under BOTH write policies (project policy → project vault; global policy → main vault WITH project association, still `isCurrentProject`). So a derived read default of "project" finds everything the project wrote, regardless of the write policy.
@@ -46,6 +48,15 @@ Verified against code at HEAD 1ff136a. Request root: `rpir-request-smarter-defau
 2. Default "all" with broad queries: project + global candidates compete in one fused list; project prior is tiny; global noise crowds out project results and bloats context.
 
 ## Solution-space assessment
+
+## Verification against existing design notes (addendum)
+
+- `mnemonic-key-design-decisions-3f2a6273` (permanent summary): "**Similarity boost, not hard filter:** `recall` gives project notes +0.15 cosine similarity boost rather than excluding global notes. Global memories (user prefs, cross-project patterns) remain accessible in project context." — The `all` default is a DOCUMENTED decision with rationale. A derived `project` default would exclude global memories from default recall (except via zero-result widening), so it is a SUPERSESSION of this decision, not a bug fix. Note: the +0.15 figure is stale — the RRF rework replaced it with the bounded +0.005 `PROJECT_SCOPE_BOOST` — but the accessibility intent still governs the current default.
+- `vault-creation-audit-which-tools-can-create-mnemonic-and-whi-d0388691` (permanent): key invariant — passing cwd for context/lookup must never trigger vault creation. All read paths route through `getProjectVaultIfExists` — the proposed changes preserve this invariant (no `getOrCreateProjectVault` in any read path).
+- `project-memory-policy-defaults-storage-location-f563f634` (permanent): "`scope: \"global\"` stores a private note in the main vault while keeping project association for recall and relationships" — CONFIRMS the derived read scope `project` (association-based) finds global-policy notes. Supports the derivation design.
+- `move-memory-rewrites-project-association-on-project-vault-in-b9823cd8` (permanent): dogfooding incident where a note created without `cwd` landed in the main vault as a global note and needed relocation — corroborates that missing cwd also misroutes writes; strengthens the case for in-band missing-cwd hints.
+
+Design tension to resolve at plan handoff: derived-default proposal supersedes a documented decision. Alternatives that preserve it: (a) hints-only (no default change), (b) opt-in read-scope setting (per-project policy field or vault config default, keeping `all` until configured).
 
 - Server cannot know the client's cwd reliably (roots deprecated, env wrong, guessing unsafe) → in-band hints + consequence-oriented param descriptions are the honest fix for missing cwd.
 - Derived default scope: when scope omitted AND cwd resolves a project → effective scope "project" (symmetric with write default for adopted projects); otherwise current behavior. Explicit scope always wins. Policy consultation is unnecessary: read "project" finds project-relevant notes under both write policies.

--- a/.mnemonic/notes/research-read-tool-scoping-behavior-and-missing-cwd-handling-8a77b8a5.md
+++ b/.mnemonic/notes/research-read-tool-scoping-behavior-and-missing-cwd-handling-8a77b8a5.md
@@ -8,11 +8,14 @@ tags:
   - policy
 lifecycle: temporary
 createdAt: '2026-08-29T10:53:29.651Z'
-updatedAt: '2026-08-29T10:53:29.651Z'
+updatedAt: '2026-08-29T10:53:39.362Z'
 role: research
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: rpir-request-smarter-default-scoping-for-recall-and-read-too-7ffd0632
+    type: derives-from
 memoryVersion: 1
 ---
 Verified against code at HEAD 1ff136a. Request root: `rpir-request-smarter-default-scoping-for-recall-and-read-too-7ffd0632`.

--- a/.mnemonic/notes/research-read-tool-scoping-behavior-and-missing-cwd-handling-8a77b8a5.md
+++ b/.mnemonic/notes/research-read-tool-scoping-behavior-and-missing-cwd-handling-8a77b8a5.md
@@ -8,7 +8,7 @@ tags:
   - policy
 lifecycle: temporary
 createdAt: '2026-08-29T10:53:29.651Z'
-updatedAt: '2026-08-29T11:01:49.369Z'
+updatedAt: '2026-08-29T20:34:12.952Z'
 role: research
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -50,6 +50,10 @@ Verified against code at HEAD 1ff136a. Request root: `rpir-request-smarter-defau
 ## Solution-space assessment
 
 ## Verification against existing design notes (addendum)
+
+## User-confirmed design constraint (decides direction)
+
+The weaving goal is explicit user intent, not just note prose: the main/global vault holds common rules and design knowledge that must get woven into project context. A hard default `scope: 'project'` contradicts this goal and is rejected by the user.
 
 - `mnemonic-key-design-decisions-3f2a6273` (permanent summary): "**Similarity boost, not hard filter:** `recall` gives project notes +0.15 cosine similarity boost rather than excluding global notes. Global memories (user prefs, cross-project patterns) remain accessible in project context." — The `all` default is a DOCUMENTED decision with rationale. A derived `project` default would exclude global memories from default recall (except via zero-result widening), so it is a SUPERSESSION of this decision, not a bug fix. Note: the +0.15 figure is stale — the RRF rework replaced it with the bounded +0.005 `PROJECT_SCOPE_BOOST` — but the accessibility intent still governs the current default.
 - `vault-creation-audit-which-tools-can-create-mnemonic-and-whi-d0388691` (permanent): key invariant — passing cwd for context/lookup must never trigger vault creation. All read paths route through `getProjectVaultIfExists` — the proposed changes preserve this invariant (no `getOrCreateProjectVault` in any read path).

--- a/.mnemonic/notes/research-read-tool-scoping-behavior-and-missing-cwd-handling-8a77b8a5.md
+++ b/.mnemonic/notes/research-read-tool-scoping-behavior-and-missing-cwd-handling-8a77b8a5.md
@@ -1,0 +1,52 @@
+---
+title: 'Research: read-tool scoping behavior and missing-cwd handling'
+tags:
+  - workflow
+  - research
+  - recall
+  - scope
+  - policy
+lifecycle: temporary
+createdAt: '2026-08-29T10:53:29.651Z'
+updatedAt: '2026-08-29T10:53:29.651Z'
+role: research
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+Verified against code at HEAD 1ff136a. Request root: `rpir-request-smarter-default-scoping-for-recall-and-read-too-7ffd0632`.
+
+## Current behavior (facts)
+
+- All read tools hard-default `scope: "all"`: recall (`src/tools/recall.ts:159-167`), list (`src/tools/list.ts:36`), recent_memories (`src/tools/recent-memories.ts:37`), memory_graph (`src/tools/memory-graph.ts:31`). The zod `.default("all")` means the server never sees "caller did not choose".
+- `resolveWriteScope` (policy-aware) is used ONLY by `remember` (`src/tools/remember.ts:21,295`). Read tools never consult the project memory policy. `defaultScope` policy governs write location, not reads.
+- cwd omitted → `resolveProject` returns undefined (`src/helpers/project.ts:25-28`) → `searchOrder` appends only the main vault (`src/vault.ts:217-232`). Project vault is INVISIBLE to recall/list/recent/graph. Id-based tools (`get`/`update`/`forget`/`where_is_memory` → `findNote`) also cannot resolve project-vault notes without cwd.
+- `project_memory_summary` REQUIRES cwd and errors when unresolvable (`src/tools/project-memory-summary.ts:201-236`).
+- With cwd + scope "all", project notes get only a tiny bounded prior: `PROJECT_SCOPE_BOOST = 0.005` (`src/tools/recall-helpers.ts:60`) vs RRF fusion scale ~0.15 (`src/recall.ts`). Prior RRF plan note `plan-one-shot-bounded-rrf-hybrid-recall-alignment-7aa73aaa` explicitly rejected hard project-first RANKING within fused "all" results — but choosing the default candidate SET (scope) is a different lever and does not contradict it.
+- Pre-existing inconsistency inside recall for explicit scope `"global"`: semantic channel filters by VAULT LOCATION (main vault, includes project-tagged notes, `recall.ts:400-407`); lexical channel and graph filter by PROJECT ASSOCIATION (exclude project-tagged notes, `recall-helpers.ts` collectLexicalCandidates, `recall.ts:557-558`). Test `tests/vault-routing.integration.test.ts:379` ("scope: global returns project-tagged notes stored in the main vault") documents the location-based semantic as INTENTIONAL — the "repo you don't own" case: personal notes about a foreign repo stored globally but project-tagged must stay reachable. So lexical/graph deviate from the documented intent; the recall scope param description and README:406 ("only memories with no project association") are also inaccurate.
+- `list`-family funnel `collectVisibleNotes` (`src/helpers/vault.ts:58-129`): "global" = location-based (main vault, regardless of project tag) — consistent with the test intent. `list` sorts current-project notes first under "all".
+- `scope: "project"` + cwd resolves a project = current-project-associated notes (wherever stored) + attached vault notes. This covers notes written under BOTH write policies (project policy → project vault; global policy → main vault WITH project association, still `isCurrentProject`). So a derived read default of "project" finds everything the project wrote, regardless of the write policy.
+
+## Constraints discovered
+
+- MCP `listRoots` (server→client roots request) is DEPRECATED as of protocol 2026-07-28 (SEP-2577) — replacement is "passing paths via tool parameters, resource URIs, or configuration" (`@modelcontextprotocol/server` 2.x `.d.cts` listRoots deprecation notice). Server-side cwd auto-detection via roots is not viable long-term.
+- Env-var cwd pinning breaks multi-project use (one server serves many projects). Rejected.
+- Guessing a project from history (e.g. branch-tracker state) risks cross-project contamination. Rejected.
+- Unadopted-project principle: reads must not create `.mnemonic/` (recall only uses `getProjectVaultIfExists` — safe).
+- Document chunks are collected when `scope === "all" || scope === "project"` (`recall.ts:641` area) — a derived "project" default keeps chunk retrieval working.
+- `recallScopeNoteCount` + effectiveLimit shrink (≤25 visible notes → shrink limit) currently count ALL vaults in searchOrder regardless of scope filter — a derived default makes the count semantics worth revisiting (minor).
+
+## Failure modes confirmed
+
+1. Missing cwd: project memories invisible across ALL read tools and id-based tools; recall output header claims "Recall results (global)" — no hint that passing cwd would unlock project memories. LLMs cannot self-correct because nothing tells them.
+2. Default "all" with broad queries: project + global candidates compete in one fused list; project prior is tiny; global noise crowds out project results and bloats context.
+
+## Solution-space assessment
+
+- Server cannot know the client's cwd reliably (roots deprecated, env wrong, guessing unsafe) → in-band hints + consequence-oriented param descriptions are the honest fix for missing cwd.
+- Derived default scope: when scope omitted AND cwd resolves a project → effective scope "project" (symmetric with write default for adopted projects); otherwise current behavior. Explicit scope always wins. Policy consultation is unnecessary: read "project" finds project-relevant notes under both write policies.
+- Zero-result widening (recall only): derived "project" returns no notes and no document chunks → transparently rerun with "all", header states widening. Preserves recall ability; no bloat in the common case; browse tools (list/recent/graph) get NO widening (listing the whole global vault would be bloat).
+- "global" channel alignment: align recall lexical + graph filters to the location-based semantic (matches semantic channel, list behavior, and test :379 intent); fix scope param description + README wording. Small, separable.
+
+Scouted by subagent (ollama/glm-5.3-flash:cloud) + orchestrator verification of key code paths.

--- a/.mnemonic/notes/research-read-tool-scoping-behavior-and-missing-cwd-handling-8a77b8a5.md
+++ b/.mnemonic/notes/research-read-tool-scoping-behavior-and-missing-cwd-handling-8a77b8a5.md
@@ -8,7 +8,7 @@ tags:
   - policy
 lifecycle: temporary
 createdAt: '2026-08-29T10:53:29.651Z'
-updatedAt: '2026-08-29T20:34:12.952Z'
+updatedAt: '2026-08-29T20:34:25.594Z'
 role: research
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
@@ -52,6 +52,14 @@ Verified against code at HEAD 1ff136a. Request root: `rpir-request-smarter-defau
 ## Verification against existing design notes (addendum)
 
 ## User-confirmed design constraint (decides direction)
+
+## Refined direction: project-anchored precision for the derived default
+
+Keep the derived default scope `all`, but gate SEMANTIC-channel admission of main-vault global notes when cwd resolves a project and scope was NOT explicitly passed: globals are admitted only if curated (`alwaysLoad: true` explicit, or `importance: 'high'`) or strongly matching (`rawScore >= minSimilarity + GLOBAL_BAR_DELTA`, proposed +0.15, code constant). Project notes (current-project-associated, wherever stored) and attached-vault notes keep the normal `minSimilarity`. Lexical and graph channels unchanged — exact token matches and relationship-linked global notes still weave in. Document chunks unchanged.
+
+Empty-pool lift: if admitted notes AND document chunks are both empty, sub-bar global candidates rejoin (bar lifts) — no dead ends, single pass, no rerun. Explicit `scope: 'all'` (caller-passed string) = today's ungated behavior; requires removing the zod `.default('all')` so undefined (derived) vs explicit is distinguishable. Transparency: when gating suppressed globals, append one header line with the count and how to disable (pass explicit scope all). Applies to recall only; list/recent\_memories/memory\_graph keep current defaults plus missing-cwd hints.
+
+This preserves the weaving guarantee for exactly the notes the goal is about (curated anchors, strong matches, relationship-linked, exact lexical matches) while removing weakly-matching global noise from the default top-K — addressing both displacement misses and bloat.
 
 The weaving goal is explicit user intent, not just note prose: the main/global vault holds common rules and design knowledge that must get woven into project context. A hard default `scope: 'project'` contradicts this goal and is rejected by the user.
 

--- a/.mnemonic/notes/review-derived-scope-gating-implementation-continue-with-3-p-b52a2e1d.md
+++ b/.mnemonic/notes/review-derived-scope-gating-implementation-continue-with-3-p-b52a2e1d.md
@@ -8,11 +8,14 @@ tags:
   - gating
 lifecycle: temporary
 createdAt: '2026-08-29T21:27:59.392Z'
-updatedAt: '2026-08-29T21:27:59.392Z'
+updatedAt: '2026-08-29T21:28:05.413Z'
 role: review
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: apply-project-anchored-precision-for-recall-s-derived-defaul-2d318266
+    type: derives-from
 memoryVersion: 1
 ---
 Fresh-context adversarial review (session model) of the derived-scope gating implementation. Outcome: continue. Full review text in subagent session; essentials preserved here.

--- a/.mnemonic/notes/review-derived-scope-gating-implementation-continue-with-3-p-b52a2e1d.md
+++ b/.mnemonic/notes/review-derived-scope-gating-implementation-continue-with-3-p-b52a2e1d.md
@@ -1,0 +1,42 @@
+---
+title: 'Review: derived-scope gating implementation - continue with 3 P2 polish items'
+tags:
+  - workflow
+  - review
+  - recall
+  - scope
+  - gating
+lifecycle: temporary
+createdAt: '2026-08-29T21:27:59.392Z'
+updatedAt: '2026-08-29T21:27:59.392Z'
+role: review
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+Fresh-context adversarial review (session model) of the derived-scope gating implementation. Outcome: continue. Full review text in subagent session; essentials preserved here.
+
+## Constraint checklist: 14/14 PASS
+
+All constraints verified with file:line citations: gate activation (src/tools/recall.ts:203), gate predicate (src/recall.ts:136-142), lexical merge clears flag (src/tools/recall.ts:627), lift guard notes+chunks empty (src/tools/recall.ts:738-741), suppression notice (:765-766), structuredContent schema unchanged, no reads create vaults (getOrCreateProjectVault only in remember.ts:89/move-memory.ts:146), onboarding regressions pass, global scope location-based in lexical (recall-helpers.ts:155) + graph (recall.ts:581) channels, docs accurate, TS-skill clean (no any/assertions; explicit return types; object param).
+
+## Fresh verification evidence
+
+- Command: npm run build - pass
+- Command: npm test - pass (87 files, 1501 tests, 63s; both previously-flaky files passed in-suite, no reruns needed)
+- Command: npm run lint - pass (zero findings)
+- Command: npm run typecheck - pass
+- Command: npm run dogfood:isolated - pass; derivedScopeRecallReturnsResults=true, missingCwdHintShown=true; one pre-existing vault-state advisory (canonical design question) traces to explicit scope:all call, byte-identical to pre-diff behavior, non-blocking
+
+## Findings (no Critical/Important)
+
+1. P2: graph-spreading evidence does NOT clear subBarGlobal for already-scored weak globals (only graph-discovered candidates weave in). In tension with documented 'arrive via graph channels' claim in CHANGELOG/README. Smallest fix: clear flag when graphScore assigned to existing candidate + test.
+2. P2: pathological minSimilarity (1.0 zod max) makes bar 1.15, gating even perfect global matches. Optional hardening: exempt rawScore >= SPREADING_ACTIVATION_GATE (0.5).
+3. P2: get.ts not-found pushes empty string when cwd present - harmless today (element-last + final trim) but fragile; confirm-level smell.
+4. Note: 'fill the limit' phrase at docs/index.html:2249 is pre-existing historical dogfood card, untouched.
+5. Note: collectLexicalRescueCandidates is dead code (pre-existing).
+
+Pre-flagged get.ts finding: CONFIRMED as smell, REJECTED as user-visible bug.
+
+Recommendation: continue; suggestions batched into follow-up polish pass.

--- a/.mnemonic/notes/rpir-request-smarter-default-scoping-for-recall-and-read-too-7ffd0632.md
+++ b/.mnemonic/notes/rpir-request-smarter-default-scoping-for-recall-and-read-too-7ffd0632.md
@@ -5,11 +5,14 @@ tags:
   - request
 lifecycle: temporary
 createdAt: '2026-08-29T10:49:24.929Z'
-updatedAt: '2026-08-29T10:49:24.929Z'
+updatedAt: '2026-08-29T10:53:39.362Z'
 role: context
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
+relatedTo:
+  - id: research-read-tool-scoping-behavior-and-missing-cwd-handling-8a77b8a5
+    type: derives-from
 memoryVersion: 1
 ---
 Request: investigate, plan, and (if warranted) implement improvements so that recall (and potentially other read tools) do smarter scoping by default.

--- a/.mnemonic/notes/rpir-request-smarter-default-scoping-for-recall-and-read-too-7ffd0632.md
+++ b/.mnemonic/notes/rpir-request-smarter-default-scoping-for-recall-and-read-too-7ffd0632.md
@@ -1,0 +1,23 @@
+---
+title: 'RPIR request: smarter default scoping for recall and read tools'
+tags:
+  - workflow
+  - request
+lifecycle: temporary
+createdAt: '2026-08-29T10:49:24.929Z'
+updatedAt: '2026-08-29T10:49:24.929Z'
+role: context
+alwaysLoad: false
+project: https-github-com-danielmarbach-mnemonic
+projectName: mnemonic
+memoryVersion: 1
+---
+Request: investigate, plan, and (if warranted) implement improvements so that recall (and potentially other read tools) do smarter scoping by default.
+
+Problem observed: LLMs using the recall tool often (a) omit `cwd`, so recall only searches the main/global vault and misses project notes entirely, or (b) pass broad queries with default scope `all`, so notes from the project vault AND the global vault are both returned — increasing rank misses and context bloat.
+
+Context: mnemonic has project memory policy settings (`defaultScope: project|global|ask`) that drive WRITE routing via `resolveWriteScope`, but READ tools (recall, list, recent_memories, memory_graph) hard-default `scope: "all"` and never consult the policy.
+
+Question: should read tools derive a smarter default scope from the project policy/settings, or is there another solution (e.g. server-side cwd detection, in-band hints, description improvements)?
+
+Requested outcome: RPIR workflow — research, present direction for confirmation, plan, implement via subagents (ollama/glm-5.3-flash:cloud for scouting/implementation; session model or flash for verification), fresh-context review, consolidate. Push back if nothing should change.

--- a/.mnemonic/notes/rpir-request-smarter-default-scoping-for-recall-and-read-too-7ffd0632.md
+++ b/.mnemonic/notes/rpir-request-smarter-default-scoping-for-recall-and-read-too-7ffd0632.md
@@ -5,13 +5,15 @@ tags:
   - request
 lifecycle: temporary
 createdAt: '2026-08-29T10:49:24.929Z'
-updatedAt: '2026-08-29T10:53:39.362Z'
+updatedAt: '2026-08-29T20:41:26.705Z'
 role: context
 alwaysLoad: false
 project: https-github-com-danielmarbach-mnemonic
 projectName: mnemonic
 relatedTo:
   - id: research-read-tool-scoping-behavior-and-missing-cwd-handling-8a77b8a5
+    type: derives-from
+  - id: plan-project-anchored-precision-for-recall-s-derived-default-88909532
     type: derives-from
 memoryVersion: 1
 ---

--- a/AGENT.md
+++ b/AGENT.md
@@ -244,7 +244,9 @@ When `recall` called with `cwd`, project notes get a small **tiebreaker boost** 
 - Treat `cwd` as mandatory for project-specific `remember`, `recall`, `update`, `move_memory`, `get`, `list`, and `sync` calls
 - `remember` + `scope: "project"` → project vault (creates `.mnemonic/`)
 - `remember` + `scope: "global"` → main vault (keeps project in frontmatter)
-- `scope` omitted → use saved policy or fallback to `project` with `cwd`
+- `scope` omitted (writes) → use saved policy or fallback to `project` with `cwd`
+- `recall` with `scope` omitted and a detected project → derived `all` with project-anchored precision: weakly-matching unassociated global notes are held back from the semantic channel unless `alwaysLoad`-curated, strongly matching, or admitted via lexical/graph evidence; suppressed matches are reported and an empty pool widens back to everything. Explicit `scope` values never gate.
+- Recall/list without `cwd` → main vault only, with a hint telling the caller to pass `cwd`
 - Policy `ask` → ask: "Project vault" or "Private main vault"
 - `remember` without `cwd` → main vault
 - `move_memory` main-vault → project-vault rewrites `project` / `projectName` from `cwd`
@@ -336,7 +338,7 @@ Skills are loaded via the `skill` tool and extend agent capabilities with specia
 | `memory_graph` | Show compact adjacency list of relationships |
 | `move_memory` | Move note between vaults without changing id |
 | `project_memory_summary` | Session-start entrypoint: themes, anchors, orientation, maintenance warnings, and working-state recovery hints |
-| `recall` | Semantic search with optional project boost plus `temporal` and `workflow` modes; `storedIn: "attached"` filters to attached-repo notes. Returns `documentChunks` from document-source attachments alongside memory results for project and all scope. |
+| `recall` | Semantic search with optional project boost plus `temporal` and `workflow` modes; `storedIn: "attached"` filters to attached-repo notes. Returns `documentChunks` from document-source attachments alongside memory results for project and all scope. Omitted `scope` with a detected project derives project-anchored precision (weak global matches gated; alwaysLoad/strong/lexical/graph-linked notes still surface; explicit `all` ungated). |
 | `recent_memories` | Show most recently updated notes for scope |
 | `remember` | Write note + embedding; `cwd` sets context, `scope` picks storage, `lifecycle` picks temporary vs permanent |
 | `relate` | Create typed relationship between notes (bidirectional) |

--- a/AGENT.md
+++ b/AGENT.md
@@ -246,7 +246,8 @@ When `recall` called with `cwd`, project notes get a small **tiebreaker boost** 
 - `remember` + `scope: "global"` → main vault (keeps project in frontmatter)
 - `scope` omitted (writes) → use saved policy or fallback to `project` with `cwd`
 - `recall` with `scope` omitted and a detected project → derived `all` with project-anchored precision: weakly-matching unassociated global notes are held back from the semantic channel unless `alwaysLoad`-curated, strongly matching, or admitted via lexical/graph evidence; suppressed matches are reported and an empty pool widens back to everything. Explicit `scope` values never gate.
-- Recall/list without `cwd` → main vault only, with a hint telling the caller to pass `cwd`
+- Explicit `scope: "global"` on recall → main-vault notes by location: project-tagged personal notes are included ("repo you don't own" case), attached vault notes are excluded
+- Read tools without `cwd` (`recall`/`list`/`recent_memories`/`memory_graph`) → main vault only, with a hint telling the caller to pass `cwd`; `get`/`update`/`forget`/`where_is_memory` add the hint to not-found responses
 - Policy `ask` → ask: "Project vault" or "Private main vault"
 - `remember` without `cwd` → main vault
 - `move_memory` main-vault → project-vault rewrites `project` / `projectName` from `cwd`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 
 ### Added
 
-- Derived default scope for `recall`: when `scope` is omitted and `cwd` detects a project, weakly-matching unassociated global notes are gated out of the semantic channel unless they are curated (`alwaysLoad`), strongly matching, or arrive via the lexical (exact wording) or graph channels. The response reports the count of suppressed global matches, and recall widens to the full pool and reports it when nothing was admitted. Gating never applies to explicit scopes or when `cwd` is absent.
+- Derived default scope for `recall`: when `scope` is omitted and `cwd` detects a project, weakly-matching unassociated global notes are gated out of the semantic channel unless they are curated (`alwaysLoad`), strongly matching, or arrive via the lexical (exact wording) or graph channels. Suppression counts and widening are reported in text and as structured output (`suppressedGlobalCount`, `widenedScope`), and recall widens to the full pool when nothing was admitted. Gating never applies to explicit scopes or when `cwd` is absent.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 
 ### Added
 
+- Derived default scope for `recall`: when `scope` is omitted and `cwd` detects a project, weakly-matching unassociated global notes are gated out of the semantic channel unless they are curated (`alwaysLoad`), strongly matching, or arrive via the lexical (exact wording) or graph channels. The response reports the count of suppressed global matches, and recall widens to the full pool and reports it when nothing was admitted. Gating never applies to explicit scopes or when `cwd` is absent.
+
+### Changed
+
+- Read tools that accept `cwd` (`recall`, `list`, `recent_memories`, `memory_graph`) now append a hint when `cwd` is omitted so callers know only global memories were searched; `get`, `update`, `forget`, and `where_is_memory` mention it when an id cannot be found without `cwd`.
+- `recall` with explicit `scope: "global"` is now location-based across all retrieval channels: the lexical and graph channels include project-tagged notes stored in the main vault, matching the semantic channel and the "repo you don't own" contract.
+
+## [0.43.0] - 2026-08-29
+
+### Added
+
 - `EMBED_MAX_CHUNK_CHARS` environment variable for configuring the maximum size of document-source chunks (default 4000, range 200–100000); non-default values re-chunk attachments on the next sync.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 
 ## [Unreleased]
 
-## [0.43.0] - 2026-08-29
+## [0.44.0] - 2026-08-30
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ The `scope` parameter on `recall` narrows results:
 - `"project"`: only memories for the detected project (project-associated notes wherever stored, plus attached vault notes)
 - `"global"`: memories in the main/global vault, which may include project-tagged personal notes (the "repo you don't own" case)
 
-When `cwd` is omitted, only the global main vault is searched; recall and list tools say so in their output so the caller can pass the project working directory.
+When `cwd` is omitted, only the global main vault is searched; `recall`, `list`, `recent_memories`, and `memory_graph` say so in their output, and `get`, `update`, `forget`, and `where_is_memory` mention it when an id cannot be found, so the caller can pass the project working directory.
 
 ### Note lifecycle
 

--- a/README.md
+++ b/README.md
@@ -402,9 +402,11 @@ Use `verbose: true` together with temporal mode when you want richer change stat
 
 The `scope` parameter on `recall` narrows results:
 
-- `"all"` (default): project memories boosted, then global
-- `"project"`: only memories for the detected project
-- `"global"`: only memories with no project association
+- `"all"` (default): project memories boosted, then global. When `scope` is omitted and `cwd` detects a project, recall applies project-anchored precision: semantic matches from unassociated global notes must be curated (`alwaysLoad`), strongly matching, or arrive via exact-wording lexical or graph-linked evidence to appear; the response reports any suppressed matches and a pass `scope: "all"` includes everything ungated. When no result is admitted at all, recall widens to the full pool and says so.
+- `"project"`: only memories for the detected project (project-associated notes wherever stored, plus attached vault notes)
+- `"global"`: memories in the main/global vault, which may include project-tagged personal notes (the "repo you don't own" case)
+
+When `cwd` is omitted, only the global main vault is searched; recall and list tools say so in their output so the caller can pass the project working directory.
 
 ### Note lifecycle
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1565,7 +1565,7 @@
             <div class="tool-card-name">remember</div>
             <div class="tool-card-purpose">Save something worth keeping</div>
           </div>
-          <div class="tool-card" data-tip="Finds the most relevant notes for any question. With cwd, the default applies project-anchored precision: project memories surface first, curated and strongly matching global notes still appear, and weak global noise is gated (pass scope: &quot;all&quot; for everything). Temporal mode shows how a note changed over time, and optional recall evidence gives a short plain-language reason for each result. Document-source attachments contribute documentChunks alongside memory results.">
+          <div class="tool-card" data-tip="Finds the most relevant notes for any question. With cwd, the default applies project-anchored precision: project memories surface first, curated and strongly matching global notes still appear, and weak global noise is gated (pass scope: &quot;all&quot; for everything). Without cwd only the global vault is searched (the response says so); explicit scope &quot;global&quot; reads the main vault. Temporal mode shows how a note changed over time, and optional recall evidence gives a short plain-language reason for each result. Document-source attachments contribute documentChunks alongside memory results.">
             <div class="tool-card-name">recall</div>
             <div class="tool-card-purpose">Ask what you've previously learned - or how it evolved</div>
           </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1253,7 +1253,7 @@
       <div class="feature-card fade-up">
         <span class="feature-icon">&#x1F3AF;</span>
         <h3>Project-scoped recall</h3>
-        <p>Memories belong to projects. When you're in a repo, relevant notes receive a bounded project preference without hiding stronger global matches. Semantic, exact-wording, and relationship signals work together to surface the right context.</p>
+        <p>Memories belong to projects. When you're in a repo, the default recall applies project-anchored precision: strongly matching global memories, anchored (<code style="font-family:JetBrains Mono,monospace;font-size:0.8em;color:var(--primary-lt)">alwaysLoad</code>) notes, exact wording, and connected context still surface, while weakly-matching global noise stays out of the default set. Pass <code style="font-family:JetBrains Mono,monospace;font-size:0.8em;color:var(--primary-lt)">scope: "all"</code> explicitly to include everything.</p>
       </div>
       <div class="feature-card fade-up">
         <span class="feature-icon">&#x1F33F;</span>
@@ -1565,7 +1565,7 @@
             <div class="tool-card-name">remember</div>
             <div class="tool-card-purpose">Save something worth keeping</div>
           </div>
-          <div class="tool-card" data-tip="Finds the most relevant notes for any question. It surfaces project-specific memories first, then broader personal context. Each result carries signalStrength, confidence, and diversity metrics so agents can gauge what to trust. Temporal mode shows how a note changed over time, and optional recall evidence gives a short plain-language reason for each result. Document-source attachments contribute documentChunks alongside memory results.">
+          <div class="tool-card" data-tip="Finds the most relevant notes for any question. With cwd, the default applies project-anchored precision: project memories surface first, curated and strongly matching global notes still appear, and weak global noise is gated (pass scope: &quot;all&quot; for everything). Temporal mode shows how a note changed over time, and optional recall evidence gives a short plain-language reason for each result. Document-source attachments contribute documentChunks alongside memory results.">
             <div class="tool-card-name">recall</div>
             <div class="tool-card-purpose">Ask what you've previously learned - or how it evolved</div>
           </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@danielmarbach/mnemonic-mcp",
-      "version": "0.43.0",
+      "version": "0.44.0",
       "dependencies": {
         "@modelcontextprotocol/server": "^2.0.0",
         "gray-matter": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "description": "A local MCP memory server backed by markdown + JSON files, synced via git",
   "type": "module",
   "repository": {

--- a/scripts/run-dogfood-packs.mjs
+++ b/scripts/run-dogfood-packs.mjs
@@ -199,6 +199,18 @@ async function main() {
     limit: 5,
     scope: "all",
   });
+  // Derived-scope coverage: recall with cwd but no explicit scope exercises the
+  // project-anchored default (global gating); pass-free cwd check verifies the
+  // missing-cwd hint. Both are non-blocking scorecard observations.
+  const recallDerivedScope = await callTool("recall", {
+    query: "Why are embeddings gitignored?",
+    cwd,
+    limit: 5,
+  });
+  const recallNoCwdHint = await callTool("recall", {
+    query: "Why are embeddings gitignored?",
+    limit: 5,
+  });
   const recentTemporary = await callTool("recent_memories", {
     cwd,
     scope: "all",
@@ -309,6 +321,11 @@ async function main() {
   ).some((p) => typeof (p.noteA?.classification ?? p.noteB?.classification) === "string");
   const recallNoDecayInfo = diagResults.every((r) => r.decayInfo === undefined);
 
+  const derivedScopeRecallReturnsResults =
+    (recallDerivedScope.structured?.results ?? []).length > 0 ||
+    recallDerivedScope.structured?.documentChunks != null;
+  const missingCwdHintShown = recallNoCwdHint.text.includes("no cwd was provided");
+
   const packA = {
     advisory: [
       !canonicalDesignInTopEmbeddings && "recall answers canonical design questions",
@@ -325,6 +342,8 @@ async function main() {
       // consolidate classification is verified by consolidatePairsHaveClassification.
       !recallNoDecayInfo &&
         "decayInfo should not appear in recall structured output (internal-only)",
+      !derivedScopeRecallReturnsResults && "derived-scope recall (cwd, no scope) returns results",
+      !missingCwdHintShown && "recall without cwd shows the missing-cwd hint",
     ].filter(Boolean),
     themeCount: themeEntries.length,
     topEmbeddingResult: b1Top?.title,
@@ -352,6 +371,8 @@ async function main() {
       consolidateDryRunHasMaintenanceKey,
       consolidatePairsHaveClassification,
       recallDecayInfoInternalOnly: recallNoDecayInfo,
+      derivedScopeRecallReturnsResults,
+      missingCwdHintShown,
     },
   };
 

--- a/src/helpers/project.ts
+++ b/src/helpers/project.ts
@@ -15,11 +15,23 @@ import { backfillEmbeddingsAfterSync, removeStaleEmbeddings } from "./embed.js";
 import { expandHomePath } from "../paths.js";
 import { attempt as attemptFn, getErrorMessage } from "../error-utils.js";
 
+const missingCwdHintText =
+  "Note: no cwd was provided — only global memories were searched. Pass the project's absolute working directory to also search project memories.";
+
+/**
+ * Trailing line for read tools when cwd was omitted: without cwd only the
+ * global main vault is visible, so the caller must learn that project memories
+ * were not searched and can self-correct on the next call.
+ */
+export function missingCwdHint(cwd: string | undefined): string {
+  return cwd ? "" : `\n${missingCwdHintText}`;
+}
+
 export const projectParam = z
   .string()
   .optional()
   .describe(
-    "Absolute path of the project working directory. Required for project-scoped routing, vault selection, and search boosting.",
+    "Absolute path of the project working directory. Required for project-scoped routing, vault selection, and search boosting. Without it, only the global main vault is used: project memories are invisible to reads, and writes land in the main vault.",
   );
 
 export async function resolveProject(ctx: ServerContext, cwd?: string) {

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -78,6 +78,13 @@ export interface ScoredRecallCandidate {
   lexicalChannelScore?: number;
   /** Whether this candidate is present in the bounded lexical result list. */
   lexicalChannelCandidate?: boolean;
+  /**
+   * Derived-default scope gating: this unassociated main-vault candidate was
+   * held back from the semantic channel (below the GLOBAL_BAR_DELTA bar and not
+   * alwaysLoad-curated). Cleared by lexical admission or re-admitted by the
+   * empty-pool lift; explicit scopes never set it.
+   */
+  subBarGlobal?: boolean;
   /** Original semantic channel score, when semantic retrieval found this note. */
   semanticScore?: number;
   /** Bounded semantic confidence contribution to final ranking. */
@@ -104,6 +111,50 @@ export interface ScoredRecallCandidate {
 
 export function recallCandidateIdentity(candidate: ScoredRecallCandidate): string {
   return candidate.identityKey ?? `${candidate.vault.storage?.vaultPath ?? ""}::${candidate.id}`;
+}
+
+/**
+ * Semantic-channel admission bar (added to minSimilarity) for unassociated
+ * main-vault ("global") candidates under the derived default scope. With the
+ * default minSimilarity of 0.3 the bar sits at 0.45 — below
+ * SPREADING_ACTIVATION_GATE (0.5), so sub-bar candidates can never become graph
+ * spreading entry points. Curated notes (explicit alwaysLoad) and lexical/
+ * graph admissions are exempt.
+ */
+export const GLOBAL_BAR_DELTA = 0.15;
+
+export interface GateGlobalCandidateInput {
+  gateActive: boolean;
+  vaultProvenance: Vault["provenance"];
+  isCurrentProject: boolean;
+  isAttachedVault: boolean;
+  alwaysLoad: boolean | undefined;
+  rawScore: number;
+  minSimilarity: number;
+}
+
+export function shouldGateGlobalCandidate(input: GateGlobalCandidateInput): boolean {
+  if (!input.gateActive) return false;
+  if (input.vaultProvenance !== "main") return false;
+  if (input.isCurrentProject || input.isAttachedVault) return false;
+  if (input.alwaysLoad === true) return false;
+  return input.rawScore < input.minSimilarity + GLOBAL_BAR_DELTA;
+}
+
+export function partitionGatedCandidates(scored: ScoredRecallCandidate[]): {
+  visible: ScoredRecallCandidate[];
+  gated: ScoredRecallCandidate[];
+} {
+  const visible: ScoredRecallCandidate[] = [];
+  const gated: ScoredRecallCandidate[] = [];
+  for (const candidate of scored) {
+    if (candidate.subBarGlobal === true) {
+      gated.push(candidate);
+    } else {
+      visible.push(candidate);
+    }
+  }
+  return { visible, gated };
 }
 
 export function computeRecallMetadataBoost(metadata?: EffectiveNoteMetadata): number {
@@ -513,10 +564,15 @@ export function enrichRescueCandidateScores(
 export function selectRecallResults(
   scored: ScoredRecallCandidate[],
   limit: number,
-  scope: "project" | "global" | "all",
+  scope: "project" | "global" | "all" | undefined,
+  options?: { includeSubBar?: boolean },
 ): ScoredRecallCandidate[] {
   void scope;
-  const sorted = [...scored].sort(compareByHybridScore);
+  let pool = scored;
+  if (options?.includeSubBar !== true && scored.some((c) => c.subBarGlobal === true)) {
+    pool = scored.filter((candidate) => candidate.subBarGlobal !== true);
+  }
+  const sorted = [...pool].sort(compareByHybridScore);
   return sorted.slice(0, limit);
 }
 
@@ -532,10 +588,15 @@ function computeWorkflowScore(candidate: ScoredRecallCandidate): number {
 export function selectWorkflowResults(
   scored: ScoredRecallCandidate[],
   limit: number,
-  scope: "project" | "global" | "all",
+  scope: "project" | "global" | "all" | undefined,
+  options?: { includeSubBar?: boolean },
 ): ScoredRecallCandidate[] {
   void scope;
-  const sorted = [...scored].sort((a, b) => {
+  let pool = scored;
+  if (options?.includeSubBar !== true && scored.some((c) => c.subBarGlobal === true)) {
+    pool = scored.filter((candidate) => candidate.subBarGlobal !== true);
+  }
+  const sorted = [...pool].sort((a, b) => {
     const workflowDelta = computeWorkflowScore(b) - computeWorkflowScore(a);
     if (workflowDelta !== 0) {
       return workflowDelta;
@@ -602,6 +663,12 @@ export function applyGraphSpreadingActivation(
       const existingCandidate = candidateMap.get(relatedIdentity);
       if (existingCandidate) {
         existingCandidate.graphScore = (existingCandidate.graphScore ?? 0) + propagatedScore;
+        // Graph evidence is weaving evidence: a relationship-linked global held
+        // back by the derived-scope bar joins the visible pool, matching the
+        // documented "graph-linked globals weave in" contract.
+        if (existingCandidate.subBarGlobal === true) {
+          existingCandidate.subBarGlobal = false;
+        }
       } else if (!discovered.has(relatedIdentity)) {
         discovered.set(relatedIdentity, {
           id: rel.id,

--- a/src/structured-content.ts
+++ b/src/structured-content.ts
@@ -125,6 +125,10 @@ export interface RecallResult extends Record<string, unknown> {
   query: string;
   scope: "project" | "global" | "all";
   recallScopeNoteCount?: number;
+  /** Weak global matches held back by the derived default scope and not re-admitted. */
+  suppressedGlobalCount?: number;
+  /** True when derived gating admitted nothing and recall widened to the full pool. */
+  widenedScope?: boolean;
   diversity?: RecallDiversity;
   retrievalCoverage?: RecallRetrievalCoverage;
   results: Array<{
@@ -1031,6 +1035,20 @@ export const RecallResultSchema = z.object({
     .optional()
     .describe(
       "Total notes visible across all vaults for this recall scope. Use to decide whether to increase limit for small vaults.",
+    ),
+  suppressedGlobalCount: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe(
+      "Weakly-matching unassociated global notes held back by the derived default scope and not re-admitted. Present only when derived gating suppressed matches; pass scope: 'all' explicitly to include them.",
+    ),
+  widenedScope: z
+    .boolean()
+    .optional()
+    .describe(
+      "True when derived gating admitted nothing and recall widened to the full pool. The text output reports the widening.",
     ),
   diversity: z
     .object({

--- a/src/tools/forget.ts
+++ b/src/tools/forget.ts
@@ -12,6 +12,7 @@ import {
   resolveProject,
   noteProjectRef,
   ensureBranchSynced,
+  missingCwdHint,
 } from "../helpers/project.js";
 import { memoryId } from "../brands.js";
 import {
@@ -93,7 +94,9 @@ export function registerForgetTool(server: McpServer, ctx: ServerContext): void 
           };
         }
         return {
-          content: [{ type: "text", text: `No memory found with id '${id}'` }],
+          content: [
+            { type: "text", text: `No memory found with id '${id}'${missingCwdHint(cwd)}` },
+          ],
           isError: true,
         };
       }

--- a/src/tools/get.ts
+++ b/src/tools/get.ts
@@ -18,6 +18,7 @@ import {
   resolveProject,
   noteProjectRef,
   projectParam,
+  missingCwdHint,
 } from "../helpers/project.js";
 import { storageLabel } from "../helpers/vault.js";
 import { formatRelationshipPreview } from "../helpers/index.js";
@@ -342,6 +343,12 @@ export function registerGetTool(server: McpServer, ctx: ServerContext): void {
       }
       if (notFound.length > 0) {
         lines.push(`Not found: ${notFound.join(", ")}`);
+        // Without cwd only the main vault was searched — project-vault ids
+        // cannot resolve. Tell the caller how to self-correct.
+        const missingCwd = missingCwdHint(cwd);
+        if (missingCwd) {
+          lines.push(missingCwd.trim());
+        }
       }
 
       const structuredContent: GetResult = {

--- a/src/tools/list.ts
+++ b/src/tools/list.ts
@@ -3,7 +3,12 @@ import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import { ListResultSchema, type ListResult, type ProjectRef } from "../structured-content.js";
 import type { Note, NoteLifecycle } from "../storage.js";
-import { projectParam, ensureBranchSynced, noteProjectRef } from "../helpers/project.js";
+import {
+  projectParam,
+  ensureBranchSynced,
+  noteProjectRef,
+  missingCwdHint,
+} from "../helpers/project.js";
 import { collectVisibleNotes, formatListEntry, storageLabel } from "../helpers/vault.js";
 
 export function registerListTool(server: McpServer, ctx: ServerContext): void {
@@ -99,7 +104,10 @@ export function registerListTool(server: McpServer, ctx: ServerContext): void {
           project: project ? { id: project.id, name: project.name } : undefined,
           notes: [],
         };
-        return { content: [{ type: "text", text: "No memories found." }], structuredContent };
+        return {
+          content: [{ type: "text", text: `No memories found.${missingCwdHint(cwd)}` }],
+          structuredContent,
+        };
       }
 
       const lines = entries.map((entry) =>
@@ -116,7 +124,7 @@ export function registerListTool(server: McpServer, ctx: ServerContext): void {
           ? `${entries.length} memories (project: ${project.name}, scope: ${scope}, storedIn: ${storedIn}):`
           : `${entries.length} memories (scope: ${scope}, storedIn: ${storedIn}):`;
 
-      const textContent = `${header}\n\n${lines.join("\n")}`;
+      const textContent = `${header}\n\n${lines.join("\n")}${missingCwdHint(cwd)}`;
 
       const structuredNotes: Array<{
         id: string;

--- a/src/tools/memory-graph.ts
+++ b/src/tools/memory-graph.ts
@@ -2,7 +2,12 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/server";
 import type { ServerContext } from "../server-context.js";
 import { MemoryGraphResultSchema, type MemoryGraphResult } from "../structured-content.js";
-import { projectParam, toProjectRef, ensureBranchSynced } from "../helpers/project.js";
+import {
+  projectParam,
+  toProjectRef,
+  ensureBranchSynced,
+  missingCwdHint,
+} from "../helpers/project.js";
 import { type NoteEntry, collectVisibleNotes } from "../helpers/vault.js";
 
 export function registerMemoryGraphTool(server: McpServer, ctx: ServerContext): void {
@@ -50,7 +55,10 @@ export function registerMemoryGraphTool(server: McpServer, ctx: ServerContext): 
           limit,
           truncated: false,
         };
-        return { content: [{ type: "text", text: "No memories found." }], structuredContent };
+        return {
+          content: [{ type: "text", text: `No memories found.${missingCwdHint(cwd)}` }],
+          structuredContent,
+        };
       }
 
       const visibleIds = new Set(entries.map((entry) => entry.note.id));
@@ -76,7 +84,9 @@ export function registerMemoryGraphTool(server: McpServer, ctx: ServerContext): 
           truncated: false,
         };
         return {
-          content: [{ type: "text", text: "No relationships found for that scope." }],
+          content: [
+            { type: "text", text: `No relationships found for that scope.${missingCwdHint(cwd)}` },
+          ],
           structuredContent,
         };
       }
@@ -84,7 +94,7 @@ export function registerMemoryGraphTool(server: McpServer, ctx: ServerContext): 
       const header =
         project && scope !== "global" ? `Memory graph for ${project.name}:` : "Memory graph:";
 
-      const textContent = `${header}\n\n${lines.join("\n")}`;
+      const textContent = `${header}\n\n${lines.join("\n")}${missingCwdHint(cwd)}`;
 
       // Build structured graph
       const structuredNodes = entries

--- a/src/tools/recall-helpers.ts
+++ b/src/tools/recall-helpers.ts
@@ -72,6 +72,9 @@ export function buildRecallCandidateContext(
 // Bounded policy priors remain smaller than meaningful multi-channel RRF agreement.
 export const PROJECT_SCOPE_BOOST = 0.005;
 export const ATTACHMENT_BOOST = PROJECT_SCOPE_BOOST / 2;
+// Re-exported for discoverability; defined next to the gate predicate in
+// ../recall.ts to avoid a circular import.
+export { GLOBAL_BAR_DELTA } from "../recall.js";
 // Document chunks fuse into the unified recall ranking with a prior smaller than
 // ATTACHMENT_BOOST so notes outrank chunks by default while documents stay visible
 // (rank just below notes; a dramatically stronger chunk can still rise).
@@ -103,7 +106,7 @@ export async function collectLexicalCandidates(
   query: string,
   temporalQueryHint: TemporalQueryHint | undefined,
   project: { id: string; name: string } | undefined,
-  scope: "project" | "global" | "all",
+  scope: "project" | "global" | "all" | undefined,
   tags: string[] | undefined,
   lifecycle: NoteLifecycle | undefined,
   existingIds: ScoredRecallCandidate[],
@@ -142,12 +145,14 @@ export async function collectLexicalCandidates(
 
       if (lifecycle && note.lifecycle !== lifecycle) continue;
 
-      const isProjectNote = note.project !== undefined;
       const isCurrentProject = project && note.project === project.id;
       const isAttachedVault = vault.provenance === "project-attached";
 
       if (scope === "project" && !isCurrentProject && !isAttachedVault) continue;
-      if (scope === "global" && isProjectNote && !isAttachedVault) continue;
+      // Location-based, matching the semantic channel: "global" scope admits all
+      // main-vault notes, including project-tagged personal notes ("repo you
+      // don't own" case asserted by vault-routing integration tests).
+      if (scope === "global" && vault.provenance !== "main") continue;
       if (
         applyTemporalFilter &&
         temporalFilterWindowDays !== undefined &&

--- a/src/tools/recall.ts
+++ b/src/tools/recall.ts
@@ -36,6 +36,8 @@ import {
   applyCanonicalExplanationPromotion,
   applyGraphSpreadingActivation,
   recallCandidateIdentity,
+  shouldGateGlobalCandidate,
+  partitionGatedCandidates,
   type ScoredRecallCandidate,
 } from "../recall.js";
 import { attempt } from "../error-utils.js";
@@ -56,6 +58,7 @@ import {
   resolveProject,
   noteProjectRef,
   projectParam,
+  missingCwdHint,
 } from "../helpers/project.js";
 import { storageLabel } from "../helpers/vault.js";
 import {
@@ -159,11 +162,14 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
         scope: z
           .enum(["project", "global", "all"])
           .optional()
-          .default("all")
           .describe(
             "'project' = this project's memories and attached vault notes, " +
-              "'global' = only unscoped memories (main/global storage), " +
-              "'all' = both, with project notes boosted (default)",
+              "'global' = memories in the main/global vault (may include project-tagged personal notes), " +
+              "'all' = both, with project notes boosted. " +
+              "When omitted with a cwd-resolved project, scope is derived: semantic matches from " +
+              "unassociated global notes must be curated (alwaysLoad) or strongly matching to appear; " +
+              "exact-wording lexical and graph-linked matches still apply. " +
+              "Explicit values disable derived gating — pass 'all' to always include everything.",
           ),
         lifecycle: z
           .enum(["temporary", "permanent"])
@@ -190,6 +196,12 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
       await ensureBranchSynced(ctx, cwd);
 
       const project = await resolveProject(ctx, cwd);
+      // Derived default scope: when the caller omitted scope and a project was
+      // resolved, unassociated main-vault ("global") semantic candidates are
+      // held back (subBarGlobal) unless curated (alwaysLoad) or strongly
+      // matching. Explicit scopes run fully ungated.
+      const gateActive = scope === undefined && project !== undefined;
+      const cwdHint = missingCwdHint(cwd);
       // Fail-soft: if the query embedding cannot be generated (Ollama down, model
       // not pulled, quota exceeded), skip semantic memory scoring but keep the
       // lexical projection channel and document-source chunks (which are lexical
@@ -407,6 +419,16 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
             if (vault.provenance !== "main") continue;
           }
 
+          const gatedByDerivedScope = shouldGateGlobalCandidate({
+            gateActive,
+            vaultProvenance: vault.provenance,
+            isCurrentProject: Boolean(isCurrentProject),
+            isAttachedVault,
+            alwaysLoad: meta.alwaysLoad,
+            rawScore,
+            minSimilarity,
+          });
+
           if (
             applyTemporalFilter &&
             temporalFilterWindowDays !== undefined &&
@@ -447,6 +469,7 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
             boosted: rawScore + boost,
             vault,
             isCurrentProject: Boolean(isCurrentProject),
+            subBarGlobal: gatedByDerivedScope || undefined,
             lifecycle: context.lifecycle,
             relatedCount: context.relatedCount,
             connectionDiversity: context.connectionDiversity,
@@ -555,7 +578,7 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
         if (lifecycle && meta.lifecycle !== lifecycle) continue;
         const isAttachedVault = candidate.vault.provenance === "project-attached";
         if (scope === "project" && !candidate.isCurrentProject && !isAttachedVault) continue;
-        if (scope === "global" && meta.project !== undefined && !isAttachedVault) continue;
+        if (scope === "global" && candidate.vault.provenance !== "main") continue;
         if (
           applyTemporalFilter &&
           temporalFilterWindowDays !== undefined &&
@@ -600,16 +623,25 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
           existing.projectPrior = existing.projectPrior ?? lexicalCandidate.projectPrior;
           existing.temporalPrior = existing.temporalPrior ?? lexicalCandidate.temporalPrior;
           existing.metadataPrior = existing.metadataPrior ?? lexicalCandidate.metadataPrior;
+          // Exact-token lexical evidence overrides the derived-scope bar.
+          existing.subBarGlobal = false;
         } else {
           candidatesById.set(recallCandidateIdentity(lexicalCandidate), lexicalCandidate);
         }
       }
       const promoted = applyCanonicalExplanationPromotion([...candidatesById.values()]);
 
-      const top =
+      const selectTop = (
+        pool: ScoredRecallCandidate[],
+        options?: { includeSubBar?: boolean },
+      ): ScoredRecallCandidate[] =>
         mode === "workflow"
-          ? selectWorkflowResults(promoted, effectiveLimit, scope)
-          : selectRecallResults(promoted, effectiveLimit, scope);
+          ? selectWorkflowResults(pool, effectiveLimit, scope, options)
+          : selectRecallResults(pool, effectiveLimit, scope, options);
+
+      const { visible, gated } = partitionGatedCandidates(promoted);
+      let top = selectTop(visible);
+      let widenedScope = false;
 
       // Collect document chunks from document-source attachments BEFORE the
       // empty-memory early return. External documents are the primary fallback
@@ -622,7 +654,7 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
       const isDefaultMode = mode === undefined || mode === "default";
       if (
         project &&
-        (scope === "all" || scope === "project") &&
+        (scope === undefined || scope === "all" || scope === "project") &&
         isDefaultMode &&
         !hasTagFilter &&
         !hasLifecycleFilter
@@ -700,6 +732,14 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
         }
       }
 
+      // Empty-pool lift: when derived gating held back every significant
+      // candidate and yielded nothing (and no document chunks either), re-select
+      // from the unfiltered pool — missing everything is worse than weak matches.
+      if (top.length === 0 && gated.length > 0 && documentChunks.length === 0) {
+        top = selectTop(promoted, { includeSubBar: true });
+        widenedScope = top.length > 0;
+      }
+
       if (top.length === 0 && documentChunks.length === 0) {
         const structuredContent: RecallResult = {
           action: "recalled",
@@ -709,14 +749,24 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
           results: [],
         };
         return {
-          content: [{ type: "text", text: "No memories found matching that query." }],
+          content: [{ type: "text", text: `No memories found matching that query.${cwdHint}` }],
           structuredContent,
         };
       }
 
       const header = project
-        ? `Recall results for project **${project.name}** (scope: ${scope}):`
+        ? `Recall results for project **${project.name}** (scope: ${scope ?? "all"}):`
         : `Recall results (global):`;
+
+      const gatingNotices: string[] = [];
+      if (widenedScope) {
+        gatingNotices.push("no project-scoped matches; showing all matches");
+      } else if (gated.length > 0) {
+        gatingNotices.push(
+          `${gated.length} weak global matches suppressed — pass scope: 'all' to include them`,
+        );
+      }
+      const gatingNoticeLine = gatingNotices.length > 0 ? `\n${gatingNotices.join(" | ")}` : "";
 
       const noteEntries: Array<{ kind: "note"; score: number; sortKey: string; text: string }> = [];
       const structuredResults: Array<{
@@ -1017,7 +1067,7 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
       }
       const diagnosticsLine =
         diagnosticsParts.length > 0 ? `\n${diagnosticsParts.join(" | ")}` : "";
-      const textContent = `${header}${diagnosticsLine}\n\n${unifiedText}`;
+      const textContent = `${header}${diagnosticsLine}${gatingNoticeLine}\n\n${unifiedText}${cwdHint}`;
 
       const structuredContent: RecallResult = {
         action: "recalled",

--- a/src/tools/recall.ts
+++ b/src/tools/recall.ts
@@ -108,7 +108,7 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
         "Do not use this when:\n" +
         "- You already know the exact id; use `get`\n" +
         "- You just want to browse by tags or scope; use `list`\n\n" +
-        "Returns: ranked matches (id, title, score, vault, tags, lifecycle, updatedAt), 1-hop relationship previews on top results, temporal history (mode: temporal), retrieval evidence (evidence: compact), including optional score decomposition, diagnostics: recallScopeNoteCount, diversity, retrievalCoverage, signalStrength.\n" +
+        "Returns: ranked matches (id, title, score, vault, tags, lifecycle, updatedAt), 1-hop relationship previews on top results, temporal history (mode: temporal), retrieval evidence (evidence: compact), including optional score decomposition, diagnostics: recallScopeNoteCount, diversity, retrievalCoverage, signalStrength, plus derived-scope gating fields: suppressedGlobalCount (weak global matches held back) and widenedScope (recall widened after an empty admitted pool).\n" +
         "Document-source attachments return documentChunks (kind, chunkId, documentId, score, boosted, semanticScore, lexicalScore, sourcePath, headingAncestry, excerpt, attachmentId, sourceMediaType, extractionMetadata, indexedCommit, generationId, retrievalHandle); chunks rank below memories by default and render inline in the ranked list.\n\n" +
         "Typical next step:\n" +
         "- Use `get`, `update`, `relate`, or `consolidate` based on the results.",
@@ -767,6 +767,11 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
         );
       }
       const gatingNoticeLine = gatingNotices.length > 0 ? `\n${gatingNotices.join(" | ")}` : "";
+      // Structured counterpart of the text notices: the suppression count is
+      // only meaningful when the gated candidates stayed suppressed (a lift
+      // re-admitted them), matching the text rendering exactly.
+      const suppressedGlobalCount =
+        gateActive && !widenedScope && gated.length > 0 ? gated.length : undefined;
 
       const noteEntries: Array<{ kind: "note"; score: number; sortKey: string; text: string }> = [];
       const structuredResults: Array<{
@@ -1074,6 +1079,8 @@ export function registerRecallTool(server: McpServer, ctx: ServerContext): void 
         query,
         scope: scope || "all",
         recallScopeNoteCount,
+        suppressedGlobalCount,
+        widenedScope: widenedScope || undefined,
         diversity,
         retrievalCoverage,
         results: structuredResults,

--- a/src/tools/recent-memories.ts
+++ b/src/tools/recent-memories.ts
@@ -7,6 +7,7 @@ import {
   toProjectRef,
   noteProjectRef,
   ensureBranchSynced,
+  missingCwdHint,
 } from "../helpers/project.js";
 import { collectVisibleNotes, formatListEntry, storageLabel } from "../helpers/vault.js";
 import { hasNoteContent } from "../storage.js";
@@ -72,7 +73,10 @@ export function registerRecentMemoriesTool(server: McpServer, ctx: ServerContext
           limit: limit || 5,
           notes: [],
         };
-        return { content: [{ type: "text", text: "No memories found." }], structuredContent };
+        return {
+          content: [{ type: "text", text: `No memories found.${missingCwdHint(cwd)}` }],
+          structuredContent,
+        };
       }
 
       const header =
@@ -85,7 +89,7 @@ export function registerRecentMemoriesTool(server: McpServer, ctx: ServerContext
         }),
       );
 
-      const textContent = `${header}\n\n${lines.join("\n")}`;
+      const textContent = `${header}\n\n${lines.join("\n")}${missingCwdHint(cwd)}`;
 
       const structuredNotes = recent.map(({ note, vault }) => {
         const content = hasNoteContent(note) ? note.content : "";

--- a/src/tools/update.ts
+++ b/src/tools/update.ts
@@ -6,6 +6,7 @@ import {
   resolveProject,
   noteProjectRef,
   projectParam,
+  missingCwdHint,
 } from "../helpers/project.js";
 import {
   formatCommitBody,
@@ -227,7 +228,9 @@ export function registerUpdateTool(server: McpServer, ctx: ServerContext): void 
           };
         }
         return {
-          content: [{ type: "text", text: `No memory found with id '${id}'` }],
+          content: [
+            { type: "text", text: `No memory found with id '${id}'${missingCwdHint(cwd)}` },
+          ],
           isError: true,
         };
       }

--- a/src/tools/where-is-memory.ts
+++ b/src/tools/where-is-memory.ts
@@ -6,6 +6,7 @@ import {
   resolveProject,
   noteProjectRef,
   projectParam,
+  missingCwdHint,
 } from "../helpers/project.js";
 import { storageLabel } from "../helpers/vault.js";
 import { WhereIsResultSchema, type WhereIsResult, NoteIdSchema } from "../structured-content.js";
@@ -46,7 +47,9 @@ export function registerWhereIsMemoryTool(server: McpServer, ctx: ServerContext)
       const found = await ctx.vaultManager.findNote(id, cwd, { projectId: project?.id });
       if (!found) {
         return {
-          content: [{ type: "text", text: `No memory found with id '${id}'` }],
+          content: [
+            { type: "text", text: `No memory found with id '${id}'${missingCwdHint(cwd)}` },
+          ],
           isError: true,
         };
       }

--- a/tests/__snapshots__/mcp-schema-contract.integration.test.ts.snap
+++ b/tests/__snapshots__/mcp-schema-contract.integration.test.ts.snap
@@ -5012,7 +5012,7 @@ Do not use this when:
 - You already know the exact id; use \`get\`
 - You just want to browse by tags or scope; use \`list\`
 
-Returns: ranked matches (id, title, score, vault, tags, lifecycle, updatedAt), 1-hop relationship previews on top results, temporal history (mode: temporal), retrieval evidence (evidence: compact), including optional score decomposition, diagnostics: recallScopeNoteCount, diversity, retrievalCoverage, signalStrength.
+Returns: ranked matches (id, title, score, vault, tags, lifecycle, updatedAt), 1-hop relationship previews on top results, temporal history (mode: temporal), retrieval evidence (evidence: compact), including optional score decomposition, diagnostics: recallScopeNoteCount, diversity, retrievalCoverage, signalStrength, plus derived-scope gating fields: suppressedGlobalCount (weak global matches held back) and widenedScope (recall widened after an empty admitted pool).
 Document-source attachments return documentChunks (kind, chunkId, documentId, score, boosted, semanticScore, lexicalScore, sourcePath, headingAncestry, excerpt, attachmentId, sourceMediaType, extractionMetadata, indexedCommit, generationId, retrievalHandle); chunks rank below memories by default and render inline in the ranked list.
 
 Typical next step:
@@ -5719,6 +5719,16 @@ Typical next step:
             "all",
           ],
           "type": "string",
+        },
+        "suppressedGlobalCount": {
+          "description": "Weakly-matching unassociated global notes held back by the derived default scope and not re-admitted. Present only when derived gating suppressed matches; pass scope: 'all' explicitly to include them.",
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer",
+        },
+        "widenedScope": {
+          "description": "True when derived gating admitted nothing and recall widened to the full pool. The text output reports the widening.",
+          "type": "boolean",
         },
       },
       "required": [

--- a/tests/__snapshots__/mcp-schema-contract.integration.test.ts.snap
+++ b/tests/__snapshots__/mcp-schema-contract.integration.test.ts.snap
@@ -384,7 +384,7 @@ Typical next step:
           "type": "boolean",
         },
         "cwd": {
-          "description": "Absolute path of the project working directory. Required for project-scoped routing, vault selection, and search boosting.",
+          "description": "Absolute path of the project working directory. Required for project-scoped routing, vault selection, and search boosting. Without it, only the global main vault is used: project memories are invisible to reads, and writes land in the main vault.",
           "type": "string",
         },
         "evidence": {
@@ -1750,7 +1750,7 @@ Typical next step:
           "type": "string",
         },
         "cwd": {
-          "description": "Absolute path of the project working directory. Required for project-scoped routing, vault selection, and search boosting.",
+          "description": "Absolute path of the project working directory. Required for project-scoped routing, vault selection, and search boosting. Without it, only the global main vault is used: project memories are invisible to reads, and writes land in the main vault.",
           "type": "string",
         },
         "lifecycle": {
@@ -2110,7 +2110,7 @@ Typical next step:
           "type": "boolean",
         },
         "cwd": {
-          "description": "Absolute path of the project working directory. Required for project-scoped routing, vault selection, and search boosting.",
+          "description": "Absolute path of the project working directory. Required for project-scoped routing, vault selection, and search boosting. Without it, only the global main vault is used: project memories are invisible to reads, and writes land in the main vault.",
           "type": "string",
         },
         "id": {
@@ -2342,7 +2342,7 @@ Typical next step:
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "cwd": {
-          "description": "Absolute path of the project working directory. Required for project-scoped routing, vault selection, and search boosting.",
+          "description": "Absolute path of the project working directory. Required for project-scoped routing, vault selection, and search boosting. Without it, only the global main vault is used: project memories are invisible to reads, and writes land in the main vault.",
           "type": "string",
         },
         "ids": {
@@ -3402,7 +3402,7 @@ Typical next step:
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "cwd": {
-          "description": "Absolute path of the project working directory. Required for project-scoped routing, vault selection, and search boosting.",
+          "description": "Absolute path of the project working directory. Required for project-scoped routing, vault selection, and search boosting. Without it, only the global main vault is used: project memories are invisible to reads, and writes land in the main vault.",
           "type": "string",
         },
         "includePreview": {
@@ -3883,7 +3883,7 @@ Typical next step:
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "cwd": {
-          "description": "Absolute path of the project working directory. Required for project-scoped routing, vault selection, and search boosting.",
+          "description": "Absolute path of the project working directory. Required for project-scoped routing, vault selection, and search boosting. Without it, only the global main vault is used: project memories are invisible to reads, and writes land in the main vault.",
           "type": "string",
         },
         "limit": {
@@ -4039,7 +4039,7 @@ Typical next step:
           "type": "boolean",
         },
         "cwd": {
-          "description": "Absolute path of the project working directory. Required for project-scoped routing, vault selection, and search boosting.",
+          "description": "Absolute path of the project working directory. Required for project-scoped routing, vault selection, and search boosting. Without it, only the global main vault is used: project memories are invisible to reads, and writes land in the main vault.",
           "type": "string",
         },
         "id": {
@@ -5021,7 +5021,7 @@ Typical next step:
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "cwd": {
-          "description": "Absolute path of the project working directory. Required for project-scoped routing, vault selection, and search boosting.",
+          "description": "Absolute path of the project working directory. Required for project-scoped routing, vault selection, and search boosting. Without it, only the global main vault is used: project memories are invisible to reads, and writes land in the main vault.",
           "type": "string",
         },
         "evidence": {
@@ -5067,8 +5067,7 @@ Typical next step:
           "type": "string",
         },
         "scope": {
-          "default": "all",
-          "description": "'project' = this project's memories and attached vault notes, 'global' = only unscoped memories (main/global storage), 'all' = both, with project notes boosted (default)",
+          "description": "'project' = this project's memories and attached vault notes, 'global' = memories in the main/global vault (may include project-tagged personal notes), 'all' = both, with project notes boosted. When omitted with a cwd-resolved project, scope is derived: semantic matches from unassociated global notes must be curated (alwaysLoad) or strongly matching to appear; exact-wording lexical and graph-linked matches still apply. Explicit values disable derived gating — pass 'all' to always include everything.",
           "enum": [
             "project",
             "global",
@@ -5755,7 +5754,7 @@ Typical next step:
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "cwd": {
-          "description": "Absolute path of the project working directory. Required for project-scoped routing, vault selection, and search boosting.",
+          "description": "Absolute path of the project working directory. Required for project-scoped routing, vault selection, and search boosting. Without it, only the global main vault is used: project memories are invisible to reads, and writes land in the main vault.",
           "type": "string",
         },
         "includePreview": {
@@ -5945,7 +5944,7 @@ Typical next step:
           "type": "boolean",
         },
         "cwd": {
-          "description": "Absolute path of the project working directory. Required for project-scoped routing, vault selection, and search boosting.",
+          "description": "Absolute path of the project working directory. Required for project-scoped routing, vault selection, and search boosting. Without it, only the global main vault is used: project memories are invisible to reads, and writes land in the main vault.",
           "type": "string",
         },
         "fromId": {
@@ -7933,7 +7932,7 @@ Typical next step:
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "cwd": {
-          "description": "Absolute path of the project working directory. Required for project-scoped routing, vault selection, and search boosting.",
+          "description": "Absolute path of the project working directory. Required for project-scoped routing, vault selection, and search boosting. Without it, only the global main vault is used: project memories are invisible to reads, and writes land in the main vault.",
           "type": "string",
         },
         "force": {
@@ -8096,7 +8095,7 @@ Typical next step:
           "type": "boolean",
         },
         "cwd": {
-          "description": "Absolute path of the project working directory. Required for project-scoped routing, vault selection, and search boosting.",
+          "description": "Absolute path of the project working directory. Required for project-scoped routing, vault selection, and search boosting. Without it, only the global main vault is used: project memories are invisible to reads, and writes land in the main vault.",
           "type": "string",
         },
         "fromId": {
@@ -8346,7 +8345,7 @@ Use \`semanticPatch\` for targeted edits (more token-efficient). Use \`content\`
           "type": "string",
         },
         "cwd": {
-          "description": "Absolute path of the project working directory. Required for project-scoped routing, vault selection, and search boosting.",
+          "description": "Absolute path of the project working directory. Required for project-scoped routing, vault selection, and search boosting. Without it, only the global main vault is used: project memories are invisible to reads, and writes land in the main vault.",
           "type": "string",
         },
         "id": {
@@ -8933,7 +8932,7 @@ Typical next step:
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "cwd": {
-          "description": "Absolute path of the project working directory. Required for project-scoped routing, vault selection, and search boosting.",
+          "description": "Absolute path of the project working directory. Required for project-scoped routing, vault selection, and search boosting. Without it, only the global main vault is used: project memories are invisible to reads, and writes land in the main vault.",
           "type": "string",
         },
         "id": {

--- a/tests/recall-scope-gating.integration.test.ts
+++ b/tests/recall-scope-gating.integration.test.ts
@@ -1,0 +1,515 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp, stat } from "fs/promises";
+import os from "os";
+import path from "path";
+
+import {
+  callLocalMcp,
+  callLocalMcpResponse,
+  execFileAsync,
+  initTestRepo,
+  startFakeEmbeddingServer,
+  tempDirs,
+} from "./helpers/mcp.js";
+
+// The fake embedding server returns a constant vector for every input, so all
+// semantic similarities are ~1.0. A bar above 1 (minSimilarity 0.9 + 0.15)
+// gates every unassociated global candidate; a bar below 1 admits everything.
+const GATING_MIN_SIMILARITY = 0.9;
+
+describe("recall-scope-gating", () => {
+  async function setupProject(): Promise<{
+    vaultDir: string;
+    repoDir: string;
+    embeddingServer: Awaited<ReturnType<typeof startFakeEmbeddingServer>>;
+  }> {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-gating-vault-"));
+    const repoDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-gating-repo-"));
+    tempDirs.push(vaultDir, repoDir);
+
+    await initTestRepo(repoDir);
+    await execFileAsync("git", ["remote", "add", "origin", "git@github.com:acme/myapp.git"], {
+      cwd: repoDir,
+    });
+
+    const embeddingServer = await startFakeEmbeddingServer();
+    return { vaultDir, repoDir, embeddingServer };
+  }
+
+  const local = (url: string) => ({ ollamaUrl: url, disableGit: false as const });
+
+  it("derived default gates weak unassociated global candidates; project notes stay visible", async () => {
+    const { vaultDir, repoDir, embeddingServer } = await setupProject();
+    try {
+      const projectNote = await callLocalMcp(
+        vaultDir,
+        "remember",
+        {
+          title: "Zebra pipeline architecture",
+          content: "How the zebra pipeline stages are wired for the release build.",
+          tags: ["gating-project"],
+          summary: "Create project note for gating test",
+          cwd: repoDir,
+          scope: "project",
+        },
+        local(embeddingServer.url),
+      );
+      expect(projectNote).toContain("Persistence: embedding written");
+
+      // Global note without cwd: no project association, stored in the main vault.
+      await callLocalMcp(
+        vaultDir,
+        "remember",
+        {
+          title: "Orchid watering schedule",
+          content: "Gardening note unrelated to any repository work.",
+          tags: ["gating-global"],
+          summary: "Create unassociated global note",
+          scope: "global",
+        },
+        embeddingServer.url,
+      );
+
+      const recalled = await callLocalMcpResponse(
+        vaultDir,
+        "recall",
+        {
+          query: "zebra pipeline architecture release build",
+          cwd: repoDir,
+          limit: 10,
+          minSimilarity: GATING_MIN_SIMILARITY,
+        },
+        local(embeddingServer.url),
+      );
+
+      expect(recalled.structuredContent?.["scope"]).toBe("all");
+      expect(recalled.text).toContain("Zebra pipeline architecture");
+      expect(recalled.text).not.toContain("Orchid watering schedule");
+      expect(recalled.text).toContain("weak global matches suppressed");
+    } finally {
+      await embeddingServer.close();
+    }
+  }, 20000);
+});
+describe("recall-scope-gating (more)", () => {
+  async function setupProject(): Promise<{
+    vaultDir: string;
+    repoDir: string;
+    embeddingServer: Awaited<ReturnType<typeof startFakeEmbeddingServer>>;
+  }> {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-gating-vault-"));
+    const repoDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-gating-repo-"));
+    tempDirs.push(vaultDir, repoDir);
+
+    await initTestRepo(repoDir);
+    await execFileAsync("git", ["remote", "add", "origin", "git@github.com:acme/myapp.git"], {
+      cwd: repoDir,
+    });
+
+    const embeddingServer = await startFakeEmbeddingServer();
+    return { vaultDir, repoDir, embeddingServer };
+  }
+
+  const local = (url: string) => ({ ollamaUrl: url, disableGit: false as const });
+
+  it("exempts alwaysLoad-curated global candidates from derived gating", async () => {
+    const { vaultDir, repoDir, embeddingServer } = await setupProject();
+    try {
+      await callLocalMcp(
+        vaultDir,
+        "remember",
+        {
+          title: "Anchor note",
+          content: "Creates the project vault so the scenario is adopted.",
+          tags: ["gating-adopt"],
+          summary: "Adopt the project vault",
+          cwd: repoDir,
+          scope: "project",
+        },
+        local(embeddingServer.url),
+      );
+
+      await callLocalMcp(
+        vaultDir,
+        "remember",
+        {
+          title: "House coding conventions",
+          content: "Always prefer integration tests over unit-only coverage.",
+          tags: ["gating-conventions"],
+          summary: "Curated global convention note",
+          scope: "global",
+          alwaysLoad: true,
+        },
+        embeddingServer.url,
+      );
+
+      const recalled = await callLocalMcpResponse(
+        vaultDir,
+        "recall",
+        {
+          query: "house coding conventions integration tests",
+          cwd: repoDir,
+          limit: 10,
+          minSimilarity: GATING_MIN_SIMILARITY,
+        },
+        local(embeddingServer.url),
+      );
+
+      expect(recalled.text).toContain("House coding conventions");
+      expect(recalled.text).not.toContain("weak global matches suppressed");
+    } finally {
+      await embeddingServer.close();
+    }
+  }, 20000);
+
+  it("explicit scope all runs fully ungated", async () => {
+    const { vaultDir, repoDir, embeddingServer } = await setupProject();
+    try {
+      await callLocalMcp(
+        vaultDir,
+        "remember",
+        {
+          title: "Adoption anchor",
+          content: "Adopts the project vault for the ungated check.",
+          tags: ["gating-adopt"],
+          summary: "Adopt project vault",
+          cwd: repoDir,
+          scope: "project",
+        },
+        local(embeddingServer.url),
+      );
+      await callLocalMcp(
+        vaultDir,
+        "remember",
+        {
+          title: "Fern propagation notes",
+          content: "Gardening note unrelated to repository work.",
+          tags: ["gating-global"],
+          summary: "Create unassociated global note",
+          scope: "global",
+        },
+        embeddingServer.url,
+      );
+
+      const recalled = await callLocalMcpResponse(
+        vaultDir,
+        "recall",
+        {
+          query: "adoption anchor unrelated content",
+          cwd: repoDir,
+          scope: "all",
+          limit: 10,
+          minSimilarity: GATING_MIN_SIMILARITY,
+        },
+        local(embeddingServer.url),
+      );
+
+      expect(recalled.text).toContain("Fern propagation notes");
+      expect(recalled.text).not.toContain("suppressed");
+    } finally {
+      await embeddingServer.close();
+    }
+  }, 20000);
+});
+
+describe("recall-scope-gating (lift + onboarding)", () => {
+  it("empty-pool lift surfaces weak global matches and reports the widening", async () => {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-gating-vault-"));
+    const repoDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-gating-repo-"));
+    tempDirs.push(vaultDir, repoDir);
+
+    await initTestRepo(repoDir);
+    await execFileAsync("git", ["remote", "add", "origin", "git@github.com:acme/myapp.git"], {
+      cwd: repoDir,
+    });
+
+    const embeddingServer = await startFakeEmbeddingServer();
+    try {
+      // The only note is an unassociated main-vault note: derived gating holds
+      // it back, the project has no matching notes, so the lift re-admits it.
+      await callLocalMcp(
+        vaultDir,
+        "remember",
+        {
+          title: "Photography exposure primer",
+          content: "Aperture and shutter basics unrelated to repository work.",
+          tags: ["gating-global"],
+          summary: "Create global note for lift test",
+          scope: "global",
+        },
+        embeddingServer.url,
+      );
+
+      const recalled = await callLocalMcpResponse(
+        vaultDir,
+        "recall",
+        {
+          query: "quantum flux manifolds",
+          cwd: repoDir,
+          limit: 10,
+          minSimilarity: GATING_MIN_SIMILARITY,
+        },
+        { ollamaUrl: embeddingServer.url, disableGit: false },
+      );
+
+      expect(recalled.text).toContain("Photography exposure primer");
+      expect(recalled.text).toContain("no project-scoped matches; showing all matches");
+    } finally {
+      await embeddingServer.close();
+    }
+  }, 20000);
+
+  it("onboarding: unadopted project recall with cwd neither errors nor creates a vault", async () => {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-gating-vault-"));
+    const repoDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-gating-repo-"));
+    tempDirs.push(vaultDir, repoDir);
+
+    await initTestRepo(repoDir);
+    await execFileAsync("git", ["remote", "add", "origin", "git@github.com:acme/myapp.git"], {
+      cwd: repoDir,
+    });
+
+    const embeddingServer = await startFakeEmbeddingServer();
+    try {
+      const recalled = await callLocalMcpResponse(
+        vaultDir,
+        "recall",
+        {
+          query: "anything at all",
+          cwd: repoDir,
+          limit: 5,
+          minSimilarity: 0.3,
+        },
+        { ollamaUrl: embeddingServer.url, disableGit: false },
+      );
+
+      expect(recalled.text).toContain("No memories found matching that query.");
+      await expect(stat(path.join(repoDir, ".mnemonic"))).rejects.toThrow();
+    } finally {
+      await embeddingServer.close();
+    }
+  }, 20000);
+});
+
+describe("recall-scope-gating (channels + hints)", () => {
+  async function setupRepo(): Promise<{
+    vaultDir: string;
+    repoDir: string;
+    embeddingServer: Awaited<ReturnType<typeof startFakeEmbeddingServer>>;
+  }> {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-gating-vault-"));
+    const repoDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-gating-repo-"));
+    tempDirs.push(vaultDir, repoDir);
+
+    await initTestRepo(repoDir);
+    await execFileAsync("git", ["remote", "add", "origin", "git@github.com:acme/myapp.git"], {
+      cwd: repoDir,
+    });
+
+    const embeddingServer = await startFakeEmbeddingServer();
+    return { vaultDir, repoDir, embeddingServer };
+  }
+
+  const local = (url: string) => ({ ollamaUrl: url, disableGit: false as const });
+
+  it("exact-wording lexical matches override the derived bar", async () => {
+    const { vaultDir, repoDir, embeddingServer } = await setupRepo();
+    try {
+      await callLocalMcp(
+        vaultDir,
+        "remember",
+        {
+          title: "Adoption anchor",
+          content: "Adopts the project vault for the lexical check.",
+          tags: ["gating-adopt"],
+          summary: "Adopt project vault",
+          cwd: repoDir,
+          scope: "project",
+        },
+        local(embeddingServer.url),
+      );
+      await callLocalMcp(
+        vaultDir,
+        "remember",
+        {
+          title: "quartzflux indexing guide",
+          content: "The quartzflux indexing step must run before compaction.",
+          tags: ["gating-quartz"],
+          summary: "Create lexical override note",
+          scope: "global",
+        },
+        embeddingServer.url,
+      );
+
+      const recalled = await callLocalMcpResponse(
+        vaultDir,
+        "recall",
+        {
+          query: "quartzflux indexing",
+          cwd: repoDir,
+          limit: 10,
+          minSimilarity: GATING_MIN_SIMILARITY,
+        },
+        local(embeddingServer.url),
+      );
+
+      expect(recalled.text).toContain("quartzflux indexing guide");
+    } finally {
+      await embeddingServer.close();
+    }
+  }, 20000);
+});
+
+describe("recall-scope-gating (hints)", () => {
+  it("shows the missing-cwd hint on recall, list, and get without cwd", async () => {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-gating-vault-"));
+    tempDirs.push(vaultDir);
+
+    const embeddingServer = await startFakeEmbeddingServer();
+    try {
+      await callLocalMcp(
+        vaultDir,
+        "remember",
+        {
+          title: "Global unassociated note",
+          content: "Stored globally without any project context.",
+          tags: ["gating-global"],
+          summary: "Seed global note",
+          scope: "global",
+        },
+        embeddingServer.url,
+      );
+
+      const recallNoCwd = await callLocalMcp(
+        vaultDir,
+        "recall",
+        { query: "global unassociated note", limit: 5 },
+        embeddingServer.url,
+      );
+      expect(recallNoCwd).toContain("no cwd was provided");
+
+      const listNoCwd = await callLocalMcp(vaultDir, "list", {}, embeddingServer.url);
+      expect(listNoCwd).toContain("no cwd was provided");
+
+      const getNoCwd = await callLocalMcp(
+        vaultDir,
+        "get",
+        { ids: ["does-not-exist-1234"] },
+        embeddingServer.url,
+      );
+      expect(getNoCwd).toContain("Not found");
+      expect(getNoCwd).toContain("no cwd was provided");
+    } finally {
+      await embeddingServer.close();
+    }
+  }, 20000);
+});
+
+describe("recall-scope-gating (global alignment)", () => {
+  async function setupAdoptedRepo(): Promise<{
+    vaultDir: string;
+    repoDir: string;
+    embeddingServer: Awaited<ReturnType<typeof startFakeEmbeddingServer>>;
+  }> {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-gating-vault-"));
+    const repoDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-gating-repo-"));
+    tempDirs.push(vaultDir, repoDir);
+
+    await initTestRepo(repoDir);
+    await execFileAsync("git", ["remote", "add", "origin", "git@github.com:acme/myapp.git"], {
+      cwd: repoDir,
+    });
+
+    const embeddingServer = await startFakeEmbeddingServer();
+    return { vaultDir, repoDir, embeddingServer };
+  }
+
+  it("global scope includes project-tagged main-vault notes via all channels", async () => {
+    const { vaultDir, repoDir, embeddingServer } = await setupAdoptedRepo();
+    try {
+      // "Repo you don't own" case: personal note about this repo, stored in
+      // the main vault WITH project association.
+      const remembered = await callLocalMcpResponse(
+        vaultDir,
+        "remember",
+        {
+          title: "wombatile deploy runbook",
+          content: "Personal deploy steps for the wombat service stored globally.",
+          tags: ["gating-deploy"],
+          summary: "Store personal deploy steps globally",
+          scope: "global",
+          cwd: repoDir,
+        },
+        { ollamaUrl: embeddingServer.url, disableGit: false },
+      );
+      expect(remembered.structuredContent?.["action"]).toBe("remembered");
+
+      const recalled = await callLocalMcpResponse(
+        vaultDir,
+        "recall",
+        {
+          query: "wombatile deploy runbook steps",
+          scope: "global",
+          cwd: repoDir,
+          limit: 10,
+          minSimilarity: GATING_MIN_SIMILARITY,
+          evidence: "compact",
+        },
+        { ollamaUrl: embeddingServer.url, disableGit: false },
+      );
+
+      expect(recalled.text).toContain("wombatile deploy runbook");
+      const results = recalled.structuredContent?.["results"] as Array<{
+        id: string;
+        title?: string;
+        retrievalEvidence?: { channels?: string[] };
+      }>;
+      expect(results.length).toBeGreaterThan(0);
+      // The lexical channel must rank the project-tagged main-vault note (the
+      // old association-based filter would have excluded it from that channel).
+      const lexicalEvidence = results.some(
+        (r) => r.retrievalEvidence?.channels?.includes("lexical") === true,
+      );
+      expect(lexicalEvidence).toBe(true);
+    } finally {
+      await embeddingServer.close();
+    }
+  }, 20000);
+
+  it("keeps global-policy notes (project association, main vault) visible under derived scope", async () => {
+    const { vaultDir, repoDir, embeddingServer } = await setupAdoptedRepo();
+    try {
+      await callLocalMcpResponse(
+        vaultDir,
+        "remember",
+        {
+          title: "Crateful release checklist",
+          content: "Release steps stored privately with project association for recall.",
+          tags: ["gating-release"],
+          summary: "Create global-policy note",
+          scope: "global",
+          cwd: repoDir,
+        },
+        { ollamaUrl: embeddingServer.url, disableGit: false },
+      );
+
+      const recalled = await callLocalMcpResponse(
+        vaultDir,
+        "recall",
+        {
+          query: "crateful release checklist steps",
+          cwd: repoDir,
+          limit: 10,
+          minSimilarity: GATING_MIN_SIMILARITY,
+        },
+        { ollamaUrl: embeddingServer.url, disableGit: false },
+      );
+
+      expect(recalled.structuredContent?.["scope"]).toBe("all");
+      expect(recalled.text).toContain("Crateful release checklist");
+      expect(recalled.text).not.toContain("suppressed");
+    } finally {
+      await embeddingServer.close();
+    }
+  }, 20000);
+});

--- a/tests/recall-scope-gating.integration.test.ts
+++ b/tests/recall-scope-gating.integration.test.ts
@@ -11,6 +11,7 @@ import {
   startFakeEmbeddingServer,
   tempDirs,
 } from "./helpers/mcp.js";
+import { RecallResultSchema } from "../src/structured-content.js";
 
 // The fake embedding server returns a constant vector for every input, so all
 // semantic similarities are ~1.0. A bar above 1 (minSimilarity 0.9 + 0.15)
@@ -86,6 +87,12 @@ describe("recall-scope-gating", () => {
       expect(recalled.text).toContain("Zebra pipeline architecture");
       expect(recalled.text).not.toContain("Orchid watering schedule");
       expect(recalled.text).toContain("weak global matches suppressed");
+      const parsed = RecallResultSchema.safeParse(recalled.structuredContent);
+      expect(parsed.success).toBe(true);
+      if (parsed.success) {
+        expect(parsed.data.suppressedGlobalCount).toBeGreaterThan(0);
+        expect(parsed.data.widenedScope).toBeUndefined();
+      }
     } finally {
       await embeddingServer.close();
     }
@@ -254,6 +261,12 @@ describe("recall-scope-gating (lift + onboarding)", () => {
 
       expect(recalled.text).toContain("Photography exposure primer");
       expect(recalled.text).toContain("no project-scoped matches; showing all matches");
+      const liftParsed = RecallResultSchema.safeParse(recalled.structuredContent);
+      expect(liftParsed.success).toBe(true);
+      if (liftParsed.success) {
+        expect(liftParsed.data.widenedScope).toBe(true);
+        expect(liftParsed.data.suppressedGlobalCount).toBeUndefined();
+      }
     } finally {
       await embeddingServer.close();
     }
@@ -361,7 +374,7 @@ describe("recall-scope-gating (channels + hints)", () => {
 });
 
 describe("recall-scope-gating (hints)", () => {
-  it("shows the missing-cwd hint on recall, list, and get without cwd", async () => {
+  it("shows the missing-cwd hint on read tools and not-found responses without cwd", async () => {
     const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-gating-vault-"));
     tempDirs.push(vaultDir);
 
@@ -399,6 +412,36 @@ describe("recall-scope-gating (hints)", () => {
       );
       expect(getNoCwd).toContain("Not found");
       expect(getNoCwd).toContain("no cwd was provided");
+
+      const recentNoCwd = await callLocalMcp(vaultDir, "recent_memories", {}, embeddingServer.url);
+      expect(recentNoCwd).toContain("no cwd was provided");
+
+      const graphNoCwd = await callLocalMcp(vaultDir, "memory_graph", {}, embeddingServer.url);
+      expect(graphNoCwd).toContain("no cwd was provided");
+
+      const updateNoCwd = await callLocalMcp(
+        vaultDir,
+        "update",
+        { id: "does-not-exist-1234", content: "Should not be written" },
+        embeddingServer.url,
+      );
+      expect(updateNoCwd).toContain("no cwd was provided");
+
+      const forgetNoCwd = await callLocalMcp(
+        vaultDir,
+        "forget",
+        { id: "does-not-exist-1234" },
+        embeddingServer.url,
+      );
+      expect(forgetNoCwd).toContain("no cwd was provided");
+
+      const whereNoCwd = await callLocalMcp(
+        vaultDir,
+        "where_is_memory",
+        { id: "does-not-exist-1234" },
+        embeddingServer.url,
+      );
+      expect(whereNoCwd).toContain("no cwd was provided");
     } finally {
       await embeddingServer.close();
     }
@@ -459,11 +502,12 @@ describe("recall-scope-gating (global alignment)", () => {
       );
 
       expect(recalled.text).toContain("wombatile deploy runbook");
-      const results = recalled.structuredContent?.["results"] as Array<{
-        id: string;
-        title?: string;
-        retrievalEvidence?: { channels?: string[] };
-      }>;
+      const parsed = RecallResultSchema.safeParse(recalled.structuredContent);
+      expect(parsed.success).toBe(true);
+      if (!parsed.success) {
+        throw new Error(`RecallResultSchema parse failed: ${parsed.error.message}`);
+      }
+      const results = parsed.data.results;
       expect(results.length).toBeGreaterThan(0);
       // The lexical channel must rank the project-tagged main-vault note (the
       // old association-based filter would have excluded it from that channel).

--- a/tests/recall.unit.test.ts
+++ b/tests/recall.unit.test.ts
@@ -14,6 +14,9 @@ import {
   computeTemporalRecencyBoost,
   shouldApplyTemporalFiltering,
   isWithinTemporalFilterWindow,
+  GLOBAL_BAR_DELTA,
+  shouldGateGlobalCandidate,
+  partitionGatedCandidates,
   type ScoredRecallCandidate,
 } from "../src/recall.js";
 import type { EffectiveNoteMetadata } from "../src/role-suggestions.js";
@@ -1034,6 +1037,33 @@ describe("applyGraphSpreadingActivation", () => {
     expect(boosted.graphRank).toBe(1);
   });
 
+  it("clears subBarGlobal when graph evidence attaches to a flagged candidate", () => {
+    const candidates: ScoredRecallCandidate[] = [
+      { id: "entry", score: 0.6, boosted: 0.6, vault, isCurrentProject: true },
+      {
+        id: "weak-global",
+        score: 0.35,
+        boosted: 0.35,
+        vault,
+        isCurrentProject: false,
+        subBarGlobal: true,
+      },
+    ];
+
+    const getNoteRelationships = (id: string) => {
+      if (id === "entry") {
+        return [{ id: "weak-global", type: "related-to" as const }];
+      }
+      return undefined;
+    };
+
+    const result = applyGraphSpreadingActivation(candidates, getNoteRelationships);
+
+    const linked = result.find((c) => c.id === "weak-global")!;
+    expect(linked.graphScore).toBeGreaterThan(0);
+    expect(linked.subBarGlobal).toBe(false);
+  });
+
   it("keeps graph identity vault-qualified when note ids collide", () => {
     const projectVault = { storage: { vaultPath: "/project" } } as ScoredRecallCandidate["vault"];
     const mainVault = { storage: { vaultPath: "/main" } } as ScoredRecallCandidate["vault"];
@@ -1310,5 +1340,116 @@ describe("resolveDiscoveredVaults", () => {
 
     expect(candidates[1]!.vault).toBe(projectVault);
     expect(candidates[1]!.isCurrentProject).toBe(true);
+  });
+});
+
+describe("GLOBAL_BAR_DELTA", () => {
+  it("keeps the documented derivation-compatible value", () => {
+    expect(GLOBAL_BAR_DELTA).toBe(0.15);
+  });
+});
+
+describe("shouldGateGlobalCandidate", () => {
+  const baseInput = {
+    gateActive: true,
+    vaultProvenance: "main" as const,
+    isCurrentProject: false,
+    isAttachedVault: false,
+    alwaysLoad: undefined,
+    rawScore: 0.5,
+    minSimilarity: 0.4,
+  };
+
+  it("gates unassociated main-vault candidates below the bar", () => {
+    expect(shouldGateGlobalCandidate(baseInput)).toBe(true);
+  });
+
+  it("admits candidates exactly at the bar (strict less-than)", () => {
+    expect(shouldGateGlobalCandidate({ ...baseInput, rawScore: 0.4 + GLOBAL_BAR_DELTA })).toBe(
+      false,
+    );
+  });
+
+  it("gates candidates one epsilon below the bar", () => {
+    expect(
+      shouldGateGlobalCandidate({ ...baseInput, rawScore: 0.4 + GLOBAL_BAR_DELTA - 1e-9 }),
+    ).toBe(true);
+  });
+
+  it("never gates when the gate is inactive (explicit scope or no project)", () => {
+    expect(shouldGateGlobalCandidate({ ...baseInput, gateActive: false })).toBe(false);
+  });
+
+  it("never gates project-associated candidates", () => {
+    expect(shouldGateGlobalCandidate({ ...baseInput, isCurrentProject: true })).toBe(false);
+  });
+
+  it("never gates attached-vault candidates", () => {
+    expect(shouldGateGlobalCandidate({ ...baseInput, isAttachedVault: true })).toBe(false);
+  });
+
+  it("exempts explicit alwaysLoad curation even below the bar", () => {
+    expect(shouldGateGlobalCandidate({ ...baseInput, alwaysLoad: true, rawScore: 0.31 })).toBe(
+      false,
+    );
+  });
+
+  it("only gates main-vault candidates", () => {
+    expect(shouldGateGlobalCandidate({ ...baseInput, vaultProvenance: "project-local" })).toBe(
+      false,
+    );
+    expect(shouldGateGlobalCandidate({ ...baseInput, vaultProvenance: "project-attached" })).toBe(
+      false,
+    );
+  });
+});
+
+describe("partitionGatedCandidates and derived-scope selection", () => {
+  const mainVault = { storage: { vaultPath: "/main" } } as ScoredRecallCandidate["vault"];
+
+  const candidate = (id: string, score: number, subBarGlobal?: boolean): ScoredRecallCandidate => ({
+    id,
+    score,
+    semanticScore: score,
+    semanticRank: 1,
+    boosted: score,
+    vault: mainVault,
+    isCurrentProject: false,
+    subBarGlobal,
+  });
+
+  it("splits flagged candidates from visible ones", () => {
+    const { visible, gated } = partitionGatedCandidates([
+      candidate("project-note", 0.7),
+      candidate("weak-global", 0.35, true),
+    ]);
+
+    expect(visible.map((c) => c.id)).toEqual(["project-note"]);
+    expect(gated.map((c) => c.id)).toEqual(["weak-global"]);
+  });
+
+  it("selectRecallResults excludes gated candidates and supports the lift", () => {
+    const scored = [candidate("project-note", 0.7), candidate("weak-global", 0.35, true)];
+
+    const defaultSelection = selectRecallResults(scored, 5, "all");
+    expect(defaultSelection.map((c) => c.id)).toEqual(["project-note"]);
+
+    const lifted = selectRecallResults(scored, 5, "all", { includeSubBar: true });
+    expect(lifted.map((c) => c.id)).toEqual(["project-note", "weak-global"]);
+  });
+
+  it("empty-pool lift surfaces only-gated candidates when admitted", () => {
+    const scored = [candidate("weak-global-1", 0.33, true), candidate("weak-global-2", 0.32, true)];
+
+    expect(selectRecallResults(scored, 5, "all")).toEqual([]);
+
+    const lifted = selectRecallResults(scored, 5, "all", { includeSubBar: true });
+    expect(lifted.map((c) => c.id)).toEqual(["weak-global-1", "weak-global-2"]);
+  });
+
+  it("leaves unrelated pools untouched (backward compatible)", () => {
+    const scored = [candidate("a", 0.9), candidate("b", 0.6)];
+
+    expect(selectRecallResults(scored, 5, "all").map((c) => c.id)).toEqual(["a", "b"]);
   });
 });


### PR DESCRIPTION
recall keeps "all" as the derived default but, when cwd resolves a
project and no explicit scope was passed, gates weakly-matching
unassociated main-vault candidates out of the semantic channel
(GLOBAL_BAR_DELTA = 0.15 above minSimilarity). Curated (alwaysLoad),
strongly matching, lexical-exact, and graph-linked globals still weave
in; an empty admitted pool lifts back to the full set and the response
reports suppression counts.

Read tools now append a hint when cwd is omitted (only the global main
vault was searched), id-based tools mention it in not-found responses,
and explicit scope "global" is location-based across all retrieval
channels. Dogfood Pack A gained derived-scope and missing-cwd
observations; README, AGENT.md, and the homepage document the behavior.