### PR TITLE
perf: compute query-token document frequencies once per rerank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 - Consolidation evidence and high-priority anchor selection now read `supersedes` edges under the same passive convention as the rest of the codebase: `supersededBy` is derived from the carrier's own edge, and superseded notes are excluded from anchors.
 - Drop duplicated protected-branch pre-check in executeMerge - A contribution from @claudedowling
 
+### Changed
+
+- `recall` is significantly faster on large result sets: query-token document frequencies for coverage scoring are now computed once per rerank instead of re-tokenising the entire candidate corpus for every candidate, reducing the dominant reranking cost from quadratic to linear (19.5s of a 22.5s recall on a 1026-note vault down to 0.15s) - A contribution from @claudedowling
+
 ## [0.44.0] - 2026-08-30
 
 ### Added

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -460,26 +460,50 @@ function computeSignificantPhraseScore(query: string, candidateText: string): nu
   return normalizedCandidate.includes(phraseTokens.join(" ")) ? 1 : 0;
 }
 
-function computeWeightedQueryCoverage(
+/**
+ * Document frequency of each query token across the corpus.
+ *
+ * This depends only on the query and the corpus, both of which are fixed for a
+ * whole rerank, so it is computed once up front. Computing it inside
+ * {@link computeWeightedQueryCoverage} re-tokenised the entire corpus for every
+ * candidate, making reranking O(N^2) in corpus size — the dominant cost of
+ * recall on a large vault.
+ */
+function buildQueryTokenDocumentFrequencies(
   query: string,
-  candidateText: string,
   corpusTexts: string[],
-): number {
+): Map<string, number> {
   const queryTokens = Array.from(new Set(tokenize(query))).filter((token) => token.length >= 4);
+  const frequencies = new Map<string, number>(queryTokens.map((token) => [token, 0]));
   if (queryTokens.length === 0) {
+    return frequencies;
+  }
+
+  for (const text of corpusTexts) {
+    const tokens = new Set(tokenize(text));
+    for (const token of queryTokens) {
+      if (tokens.has(token)) {
+        frequencies.set(token, (frequencies.get(token) ?? 0) + 1);
+      }
+    }
+  }
+
+  return frequencies;
+}
+
+function computeWeightedQueryCoverage(
+  candidateText: string,
+  documentFrequencies: Map<string, number>,
+): number {
+  if (documentFrequencies.size === 0) {
     return 0;
   }
 
   const candidateTokens = new Set(tokenize(candidateText));
-  const corpusTokenSets = corpusTexts.map((text) => new Set(tokenize(text)));
   let matchedWeight = 0;
   let totalWeight = 0;
 
-  for (const token of queryTokens) {
-    const documentFrequency = corpusTokenSets.reduce(
-      (count, tokens) => count + (tokens.has(token) ? 1 : 0),
-      0,
-    );
+  for (const [token, documentFrequency] of documentFrequencies) {
     const weight = 1 / Math.max(documentFrequency, 1);
     totalWeight += weight;
     if (candidateTokens.has(token)) {
@@ -509,11 +533,13 @@ export function applyLexicalReranking(
     .map((candidate) => getProjectionText(candidate.id, candidate))
     .filter((text): text is string => Boolean(text));
 
+  const documentFrequencies = buildQueryTokenDocumentFrequencies(query, corpusTexts);
+
   for (const candidate of candidates) {
     const projText = getProjectionText(candidate.id, candidate);
     if (projText) {
       candidate.lexicalScore = computeLexicalScore(query, projText);
-      candidate.coverageScore = computeWeightedQueryCoverage(query, projText, corpusTexts);
+      candidate.coverageScore = computeWeightedQueryCoverage(projText, documentFrequencies);
       candidate.phraseScore = computeSignificantPhraseScore(query, projText);
     }
   }
@@ -551,11 +577,13 @@ export function enrichRescueCandidateScores(
     .map((candidate) => getProjectionText(candidate.id, candidate))
     .filter((text): text is string => Boolean(text));
 
+  const documentFrequencies = buildQueryTokenDocumentFrequencies(query, corpusTexts);
+
   for (const candidate of allCandidates) {
     if (!rescueIds.has(candidate.id)) continue;
     const projText = getProjectionText(candidate.id, candidate);
     if (projText) {
-      candidate.coverageScore = computeWeightedQueryCoverage(query, projText, corpusTexts);
+      candidate.coverageScore = computeWeightedQueryCoverage(projText, documentFrequencies);
       candidate.phraseScore = computeSignificantPhraseScore(query, projText);
     }
   }


### PR DESCRIPTION
`applyLexicalReranking` is quadratic in the number of candidates that clear `minSimilarity`. On a 1026-note vault it accounted for **19.5s of a 22.5s recall**; after this change, 0.15s.

`computeWeightedQueryCoverage` derived document frequencies by re-tokenising the entire candidate corpus:

```ts
const corpusTokenSets = corpusTexts.map((text) => new Set(tokenize(text)));
```

and it is called once per candidate. Those frequencies depend only on `query` and `corpusTexts` — both fixed for the whole rerank — so identical work ran N times.

This hoists it into `buildQueryTokenDocumentFrequencies`, computed once and passed in. Same change at both call sites (`applyLexicalReranking`, `enrichRescueCandidateScores`); `computeWeightedQueryCoverage` no longer needs `query`, since the map already encodes the query tokens.

Synthetic benchmark, 60-word projections (real projections are longer, so this understates it):

| N | before | after |
|---|---|---|
| 100 | 130ms | 14ms |
| 400 | 1756ms | 45ms |
| 800 | 6957ms | 82ms |
| 1026 | 11531ms | 107ms |

Scaling goes from ~4x per doubling to ~2x.

Results are unchanged — same tokens, same weights, computed once instead of N times. Existing tests pass unmodified.

Found by adding per-phase tracing to recall; the existing `[recall:timing]` line reports a single total and can't localise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
