### PR TITLE
fix: drop duplicated protected-branch pre-check in executeMerge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 - `unrelate` removes the relationship from whichever note carries it. Passive `supersedes` edges live on the superseded note, so `unrelate(..., bidirectional: false)` previously missed them and left a stale edge behind.
 - `prune-superseded` validates the supersession lineage before deleting anything: mutual pairs, self-loops, longer cycles, ambiguous multiple-target carriers, and carriers whose superseder is out of scope are skipped with a warning instead of deleted, preventing silent knowledge loss on legacy data. Relationship cleanup now only strips references to notes that were actually pruned, and protected-branch pre-checks cover every vault that will be mutated (including relationship-cleanup targets).
 - Consolidation evidence and high-priority anchor selection now read `supersedes` edges under the same passive convention as the rest of the codebase: `supersededBy` is derived from the carrier's own edge, and superseded notes are excluded from anchors.
+- Drop duplicated protected-branch pre-check in executeMerge - A contribution from @claudedownling
 
 ## [0.44.0] - 2026-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is loosely based on Keep a Changelog and uses semver-style version he
 - `unrelate` removes the relationship from whichever note carries it. Passive `supersedes` edges live on the superseded note, so `unrelate(..., bidirectional: false)` previously missed them and left a stale edge behind.
 - `prune-superseded` validates the supersession lineage before deleting anything: mutual pairs, self-loops, longer cycles, ambiguous multiple-target carriers, and carriers whose superseder is out of scope are skipped with a warning instead of deleted, preventing silent knowledge loss on legacy data. Relationship cleanup now only strips references to notes that were actually pruned, and protected-branch pre-checks cover every vault that will be mutated (including relationship-cleanup targets).
 - Consolidation evidence and high-priority anchor selection now read `supersedes` edges under the same passive convention as the rest of the codebase: `supersededBy` is derived from the carrier's own edge, and superseded notes are excluded from anchors.
-- Drop duplicated protected-branch pre-check in executeMerge - A contribution from @claudedownling
+- Drop duplicated protected-branch pre-check in executeMerge - A contribution from @claudedowling
 
 ## [0.44.0] - 2026-08-30
 

--- a/src/tools/consolidate-helpers.ts
+++ b/src/tools/consolidate-helpers.ts
@@ -548,34 +548,6 @@ export async function executeMerge(
     }
   }
 
-  // Pre-check protected branches
-  for (const vault of new Set([targetVault, ...sourceEntries.map((se) => se.vault)])) {
-    const check = await checkVaultProtectedBranch({
-      ctx,
-      vault,
-      allowProtectedBranch,
-      toolName: "consolidate",
-      noteProjectId: project?.id,
-    });
-    if (check.blocked) {
-      const structuredContent: ConsolidateResult = {
-        action: "consolidated",
-        strategy: "execute-merge",
-        project: toProjectRef(project),
-        notesProcessed: entries.length,
-        notesModified: 0,
-        warnings: [check.message],
-      };
-      if (declinedBranchConsent || requestCtx === undefined || !isMrtrSupported(requestCtx)) {
-        return {
-          content: [{ type: "text", text: check.message }],
-          structuredContent,
-        };
-      }
-      return protectedBranchDecision(requestCtx, check);
-    }
-  }
-
   await targetVault.storage.writeNote(consolidatedNote);
 
   // Embed consolidated note

--- a/tests/memory-lifecycle.integration.test.ts
+++ b/tests/memory-lifecycle.integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { mkdtemp, stat, readFile } from "fs/promises";
+import { mkdtemp, readdir, stat, readFile } from "fs/promises";
 import os from "os";
 import path from "path";
 
@@ -1680,6 +1680,120 @@ describe("memory-lifecycle", () => {
         embeddingServer.url,
       );
       expect(protectedPruneOverride).toContain("Pruned");
+    } finally {
+      await embeddingServer.close();
+    }
+  }, 120000);
+
+  it("blocks execute-merge before mutating notes when the project vault is on a protected branch", async () => {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mcp-vault-"));
+    const repoDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mcp-project-"));
+    tempDirs.push(vaultDir, repoDir);
+
+    await initTestRepo(repoDir);
+    await execFileAsync("git", ["checkout", "-B", "main"], { cwd: repoDir });
+
+    const embeddingServer = await startFakeEmbeddingServer();
+    const notesDir = path.join(repoDir, ".mnemonic", "notes");
+
+    try {
+      const setBlock = await callLocalMcpResponse(
+        vaultDir,
+        "set_project_memory_policy",
+        {
+          cwd: repoDir,
+          protectedBranchBehavior: "block",
+          protectedBranchPatterns: ["main"],
+        },
+        embeddingServer.url,
+      );
+      expect(setBlock.text).toContain("protectedBranchBehavior=block");
+
+      const sourceA = await callLocalMcpResponse(
+        vaultDir,
+        "remember",
+        {
+          title: "Execute merge precheck source A",
+          content: "First source note for the execute-merge protected-branch pre-check test.",
+          tags: ["integration", "protected-branch", "consolidate"],
+          summary: "Create first execute-merge pre-check source note",
+          cwd: repoDir,
+          scope: "project",
+          allowProtectedBranch: true,
+        },
+        embeddingServer.url,
+      );
+      const sourceAId = extractRememberedId(sourceA.text);
+
+      const sourceB = await callLocalMcpResponse(
+        vaultDir,
+        "remember",
+        {
+          title: "Execute merge precheck source B",
+          content: "Second source note for the execute-merge protected-branch pre-check test.",
+          tags: ["integration", "protected-branch", "consolidate"],
+          summary: "Create second execute-merge pre-check source note",
+          cwd: repoDir,
+          scope: "project",
+          allowProtectedBranch: true,
+        },
+        embeddingServer.url,
+      );
+      const sourceBId = extractRememberedId(sourceB.text);
+
+      const sourceAPath = path.join(notesDir, `${sourceAId}.md`);
+      const sourceBPath = path.join(notesDir, `${sourceBId}.md`);
+      const sourceABefore = await readFile(sourceAPath, "utf-8");
+      const sourceBBefore = await readFile(sourceBPath, "utf-8");
+      const notesBefore = (await readdir(notesDir)).sort();
+
+      const blockedMerge = await callLocalMcpResponse(
+        vaultDir,
+        "consolidate",
+        {
+          cwd: repoDir,
+          strategy: "execute-merge",
+          mergePlan: {
+            sourceIds: [sourceAId, sourceBId],
+            targetTitle: "Execute merge precheck target",
+            summary: "Should never be written on a protected branch",
+          },
+        },
+        embeddingServer.url,
+      );
+
+      expect(blockedMerge.text).toContain("Auto-commit blocked");
+      expect(blockedMerge.text).toContain("`consolidate`");
+
+      const blockedParsed = ConsolidateResultSchema.parse(blockedMerge.structuredContent);
+      expect(blockedParsed.strategy).toBe("execute-merge");
+      expect(blockedParsed.notesModified).toBe(0);
+      expect(blockedParsed.warnings?.[0]).toContain("Auto-commit blocked");
+
+      // The pre-check must run before any write: source notes and the notes
+      // directory must be byte-for-byte unchanged, and no target note created.
+      await expect(readFile(sourceAPath, "utf-8")).resolves.toBe(sourceABefore);
+      await expect(readFile(sourceBPath, "utf-8")).resolves.toBe(sourceBBefore);
+      expect((await readdir(notesDir)).sort()).toEqual(notesBefore);
+
+      // Sanity check: the same merge succeeds with a one-time override, proving
+      // the block above came from the protected-branch guard and not a bad plan.
+      const overrideMerge = await callLocalMcpResponse(
+        vaultDir,
+        "consolidate",
+        {
+          cwd: repoDir,
+          strategy: "execute-merge",
+          mergePlan: {
+            sourceIds: [sourceAId, sourceBId],
+            targetTitle: "Execute merge precheck target",
+            summary: "Allowed by one-time protected branch override",
+          },
+          allowProtectedBranch: true,
+        },
+        embeddingServer.url,
+      );
+      expect(overrideMerge.text).toContain("Consolidated 2 notes");
     } finally {
       await embeddingServer.close();
     }


### PR DESCRIPTION
`executeMerge` runs the protected-branch pre-check twice, back to back — [L523-L548](https://github.com/danielmarbach/mnemonic/blob/e030f1cebee2982785f50855a20133d65800d47d/src/tools/consolidate-helpers.ts#L523-L548) and [L551-L576](https://github.com/danielmarbach/mnemonic/blob/e030f1cebee2982785f50855a20133d65800d47d/src/tools/consolidate-helpers.ts#L551-L576).

Same vault set, same `checkVaultProtectedBranch` arguments, same `blocked` handling and returns — only the variable names differ (`protectedBranchCheck`/`check`, `e`/`se`). Nothing runs between them, and the first returns on a blocked vault, so the second can never reach a different outcome. Normalising the two identifiers makes the blocks byte-identical.

No behaviour difference, but the cost is real if small: `checkVaultProtectedBranch` bottoms out in `getCurrentGitBranch`, an uncached `git branch --show-current` subprocess, so every execute-merge spawns one redundant git process per writable non-main vault.

This removes the second loop and keeps the first, which hoists the set into a named `vaultsToCheck`.

### On the test

I also added one, because nothing asserted this pre-check's actual contract. The existing `applies protected branch policy for project-vault remember writes` covers the blocked *message*, but not that nothing is written *before* the block — which is what separates a pre-check from the commit-time check downstream.

The new test asserts `notesModified === 0` and that the source notes and the `.mnemonic/notes` listing are byte-for-byte untouched, with a tail that runs the same merge under `allowProtectedBranch: true` to confirm the block is attributable to the guard rather than a malformed plan.

Verified it fails without the guard: neutralising the remaining loop makes the merge run to completion, write the target note and mutate the sources, with only the commit blocked afterwards.

Happy to drop the test if you would rather keep this to the deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
