### PR TITLE
Guard remember against explicit scope overriding saved project policy

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -39,7 +39,7 @@ Before calling `remember`:
 4. Consider lifecycle: use `lifecycle: temporary` for plans and WIP; use `permanent` for decisions and durable knowledge.
 5. If you've made several closely-related captures in this session, consider `consolidate` before wrapping up.
 6. Write the note summary-first: put the main fact, decision, or outcome in the opening sentences, then follow with supporting detail.
-7. Pass `cwd` for anything about the current repo, even if you intend to store it in the main vault with `scope: "global"`.
+7. Pass `cwd` for anything about the current repo. Prefer omitting `scope` on writes: the saved project policy is authoritative when one exists, and an explicit `scope` that contradicts it triggers a user confirmation (or an error asking you to omit `scope` / pass `scopePolicyOverride: true` only when the user explicitly requested the deviation).
 8. Omit `cwd` only for truly cross-project or personal memories; missing `cwd` makes the note global and unassociated.
 9. After `remember`, `update`, `move_memory`, or consolidation writes, inspect the returned structured persistence status before doing extra verification calls. It tells you the note path, embedding path, embedding outcome, and git commit/push outcome, including when push is intentionally skipped by config.
 10. Memory work is not complete after `remember`, `update`, or `consolidate` alone. If the note extends, implements, or was informed by an existing note surfaced via `recall`, `list`, `recent_memories`, or `get`, explicitly decide whether to `relate` or `consolidate` before finishing.
@@ -245,6 +245,8 @@ When `recall` called with `cwd`, project notes get a small **tiebreaker boost** 
 - `remember` + `scope: "project"` → project vault (creates `.mnemonic/`)
 - `remember` + `scope: "global"` → main vault (keeps project in frontmatter)
 - `scope` omitted (writes) → use saved policy or fallback to `project` with `cwd`
+- Explicit `scope` contradicting the saved policy → nothing is written: MRTR clients get a user confirmation prompt, legacy clients an error listing `scopePolicyOverride: true` as the explicit-deviation escape hatch; an "ask" policy conflicts with any explicit `scope`
+- Successful writes record the governing policy: `[policy=global]` in the result text (or `[policy=global→project, override]`) and `policyScope` in structured output
 - `recall` with `scope` omitted and a detected project → derived `all` with project-anchored precision: weakly-matching unassociated global notes are held back from the semantic channel unless `alwaysLoad`-curated, strongly matching, or admitted via lexical/graph evidence; suppressed matches are reported and an empty pool widens back to everything. Explicit `scope` values never gate.
 - Explicit `scope: "global"` on recall → main-vault notes by location: project-tagged personal notes are included ("repo you don't own" case), attached vault notes are excluded
 - Read tools without `cwd` (`recall`/`list`/`recent_memories`/`memory_graph`) → main vault only, with a hint telling the caller to pass `cwd`; `get`/`update`/`forget`/`where_is_memory` add the hint to not-found responses
@@ -252,6 +254,7 @@ When `recall` called with `cwd`, project notes get a small **tiebreaker boost** 
 - `remember` without `cwd` → main vault
 - `move_memory` main-vault → project-vault rewrites `project` / `projectName` from `cwd`
 - `move_memory` project-vault → main-vault preserves project association while changing storage
+- `move_memory` destination accepts `target` (`main-vault`/`project-vault`) or the `scope` alias (`global`/`project`); `target` also accepts both vocabularies
 - project-vault commits from mutating tools (`remember`, `update`, `forget`, `move_memory`, mutating `consolidate`) honor protected-branch policy (`ask` | `block` | `allow`)
 - `recall`, `list`, `get`, `sync` → project vault first, then main
 - `relate`/`unrelate`/`forget` → any vault, commit per vault
@@ -341,7 +344,7 @@ Skills are loaded via the `skill` tool and extend agent capabilities with specia
 | `project_memory_summary` | Session-start entrypoint: themes, anchors, orientation, maintenance warnings, and working-state recovery hints |
 | `recall` | Semantic search with optional project boost plus `temporal` and `workflow` modes; `storedIn: "attached"` filters to attached-repo notes. Returns `documentChunks` from document-source attachments alongside memory results for project and all scope. Omitted `scope` with a detected project derives project-anchored precision (weak global matches gated; alwaysLoad/strong/lexical/graph-linked notes still surface; explicit `all` ungated). |
 | `recent_memories` | Show most recently updated notes for scope |
-| `remember` | Write note + embedding; `cwd` sets context, `scope` picks storage, `lifecycle` picks temporary vs permanent |
+| `remember` | Write note + embedding; `cwd` sets context, `scope` picks storage (prefer omitting so the saved policy governs; contradicting it requires confirmation or `scopePolicyOverride`), `lifecycle` picks temporary vs permanent |
 | `relate` | Create typed relationship between notes (bidirectional) |
 | `remove_attachment` | Remove an attached repository; requires `projectSlug` of the attachment |
 | `set_attachment_branch` | Change the branch an attached repository reads from; requires `projectSlug` and `branch` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `mnemonic` will be documented in this file.
 
 The format is loosely based on Keep a Changelog and uses semver-style version headings.
 
+## [Unreleased]
+
+### Added
+
+- Policy-conflict guard on `remember`: an explicitly passed `scope` that contradicts the project's saved `defaultScope` policy no longer silently overrides it. Nothing is written; clients with elicitation support get a user confirmation prompt ("follow the saved policy" vs "keep the explicit value"), legacy clients get an actionable error. Pass the new `scopePolicyOverride: true` only when the user explicitly requested the deviation. An `ask` policy conflicts with any explicit `scope`, since the user asked to choose every time.
+- `remember` results now record the governing routing: `[policy=global]` in the result text (or `[policy=global→project, override]` after a confirmed deviation) and a `policyScope` field in structured output, so agents and users can see which rule applied.
+- `move_memory` accepts `scope` (`global`/`project`) as an alias for `target`, and `target` itself accepts both vocabularies (`main-vault`/`project-vault` and `global`/`project`), aligning it with `remember`'s parameter names and values.
+
 ## [0.44.1] - 2026-08-31
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `mnemonic` will be documented in this file.
 
 The format is loosely based on Keep a Changelog and uses semver-style version headings.
 
-## [Unreleased]
+## [0.45.0] - 2026-09-03
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ Two vault types store notes:
 
 `cwd` sets project context; `scope` picks storage:
 
-- `cwd` + `scope: "project"` _(default when `cwd` is present)_ → project vault (`.mnemonic/`)
+- `cwd` + `scope: "project"` _(default when `cwd` is present and no policy is saved)_ → project vault (`.mnemonic/`)
 - `cwd` + `scope: "global"` → main vault, with project association in frontmatter
 - no `cwd` → main vault as a plain global memory
 
@@ -358,6 +358,10 @@ Use `set_project_memory_policy` to save per-project defaults:
 - protected-branch patterns (glob strings; defaults are `main`, `master`, `release*`)
 
 When write scope policy is `ask`, `remember` returns a clear storage choice instead of guessing. On supported MCP clients, it asks you to choose project or global storage through the client UI. When protected-branch behavior is `ask`, mutating tools that would commit to the project vault ask for one-time confirmation through the client UI. Clients without that support return the `allowProtectedBranch: true` override option and instructions for persisting `block` or `allow`.
+
+A saved write-scope policy is authoritative: when an explicitly passed `scope` contradicts it, nothing is written. On clients with elicitation support, `remember` asks the user to pick between the policy and the explicit value; other clients get an error explaining the conflict. Pass `scopePolicyOverride: true` only when the user explicitly requested the deviation. An `ask` policy conflicts with any explicit `scope`, since the user asked to choose every time. Successful writes record the governing policy as `[policy=global]` in the result text (or `[policy=global→project, override]`) and as `policyScope` in structured output.
+
+`move_memory` takes `target` (`main-vault` or `project-vault`) and also accepts the `scope` alias with `remember`'s vocabulary (`global`/`project`); `target` values from either vocabulary are normalized.
 
 ### Project identity
 
@@ -558,7 +562,7 @@ Imported notes are written to the main vault with `lifecycle: permanent` and `sc
 | `project_memory_summary`    | Session-start entrypoint: themes, anchors, orientation, maintenance warnings, and working-state recovery hints                                      |
 | `recall`                    | Hybrid semantic, exact-wording, and relationship search with temporal/workflow modes and optional `evidence: "compact"` rationale. Returns `documentChunks` from document-source attachments alongside memory results.                   |
 | `recent_memories`           | Show most recently updated notes for scope                                                                                                          |
-| `remember`                  | Write note + embedding; `cwd` sets context, `scope` picks storage, `lifecycle` picks temporary vs permanent                                         |
+| `remember`                  | Write note + embedding; `cwd` sets context, `scope` picks storage (prefer omitting so the saved policy governs; contradicting it requires confirmation or `scopePolicyOverride`), `lifecycle` picks temporary vs permanent                                         |
 | `relate`                    | Create typed relationship between notes (bidirectional)                                                                                             |
 | `remove_attachment`         | Remove an attached repository by `projectSlug`                                                                                                      |
 | `set_attachment_branch`     | Change the branch an attached repository reads from; requires `projectSlug` and `branch`                                                            |

--- a/SYSTEM_PROMPT.md
+++ b/SYSTEM_PROMPT.md
@@ -6,4 +6,6 @@ No system prompt required. Mnemonic's tools are self-describing — each tool in
 For on-demand workflow guidance, use the `mnemonic-workflow-hint` MCP prompt. It now acts
 as a compact decision protocol: start with `recall` or `list`, inspect with `get`,
 prefer `update` for existing memories, use `remember` only when nothing matches, then
-organize with `relate`, `consolidate`, or `move_memory`.
+organize with `relate`, `consolidate`, or `move_memory`. When writing, omit `scope`
+unless the user explicitly asked for a specific vault: saved project policies are
+authoritative and contradicting them triggers a confirmation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.44.1",
+  "version": "0.45.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@danielmarbach/mnemonic-mcp",
-      "version": "0.44.1",
+      "version": "0.45.0",
       "dependencies": {
         "@modelcontextprotocol/server": "^2.0.0",
         "gray-matter": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmarbach/mnemonic-mcp",
-  "version": "0.44.1",
+  "version": "0.45.0",
   "description": "A local MCP memory server backed by markdown + JSON files, synced via git",
   "type": "module",
   "repository": {

--- a/src/helpers/git-commit.ts
+++ b/src/helpers/git-commit.ts
@@ -6,6 +6,7 @@ import {
   type ProtectedBranchBehavior,
   type WriteScope,
   type ProjectMemoryPolicy,
+  type ProjectPolicyScope,
 } from "../project-memory-policy.js";
 import type { ServerContext } from "../server-context.js";
 import type { Vault } from "../vault.js";
@@ -116,6 +117,23 @@ export function formatAskForWriteScope(
     '- `scope: "global"` — private main vault with project association',
     "",
     "To avoid being asked again: call `set_project_memory_policy` with your preferred scope.",
+  ].join("\n");
+}
+
+export function formatScopePolicyConflict(
+  project: { id: string; name: string } | null | undefined,
+  explicitScope: WriteScope,
+  policyScope: ProjectPolicyScope,
+): string {
+  const projectLabel = project ? `${project.name} (${project.id})` : "this context";
+  const policyScopeLabel = policyScope === "ask" ? "always ask" : `"${policyScope}"`;
+  return [
+    `Explicit scope="${explicitScope}" contradicts the saved project memory policy for ${projectLabel} (defaultScope=${policyScopeLabel}). The note was NOT stored.`,
+    "Resolve the conflict and call `remember` again with one of:",
+    "- Omit `scope` entirely to follow the saved policy (recommended unless the user asked otherwise)",
+    `- Pass \`scopePolicyOverride: true\` together with \`scope: "${explicitScope}"\` only when the user explicitly requested this deviation`,
+    "",
+    "When unsure, ask the user. Update the saved routing with `set_project_memory_policy` if it should change permanently.",
   ].join("\n");
 }
 

--- a/src/project-memory-policy.ts
+++ b/src/project-memory-policy.ts
@@ -117,3 +117,21 @@ export function resolveWriteScope(
 
   return hasProjectContext ? "project" : "global";
 }
+
+/**
+ * Whether an explicitly passed `scope` contradicts the project's saved
+ * write-scope policy. An explicit scope that matches the policy agrees with
+ * it, but an "ask" policy is contradicted by any explicit scope because the
+ * user asked to choose every time. Agents habitually pass the schema default
+ * explicitly, so without this check a saved routing rule can be silently
+ * overridden (see the kimi/NServiceBus incident).
+ */
+export function explicitScopeConflictsWithPolicy(
+  explicitScope: WriteScope | undefined,
+  policyScope: ProjectPolicyScope | undefined,
+): boolean {
+  if (explicitScope === undefined || policyScope === undefined) {
+    return false;
+  }
+  return policyScope === "ask" || explicitScope !== policyScope;
+}

--- a/src/structured-content.ts
+++ b/src/structured-content.ts
@@ -113,6 +113,8 @@ export interface RememberResult extends Record<string, unknown> {
   title: string;
   project?: { id: string; name: string };
   scope: "project" | "global";
+  /** Saved project write-scope policy that governed this write, if one exists. */
+  policyScope?: "project" | "global" | "ask";
   vault: string;
   tags: string[];
   lifecycle: NoteLifecycle;
@@ -914,6 +916,7 @@ export const RememberResultSchema = z.object({
   title: z.string(),
   project: ProjectRefSchema.optional(),
   scope: z.enum(["project", "global"]),
+  policyScope: z.enum(["project", "global", "ask"]).optional(),
   vault: _VaultLabel,
   tags: z.array(z.string()),
   lifecycle: _NoteLifecycle,

--- a/src/tools/move-memory.ts
+++ b/src/tools/move-memory.ts
@@ -44,9 +44,16 @@ export function registerMoveMemoryTool(server: McpServer, ctx: ServerContext): v
           "Exact memory id, or a document/chunk handle (doc:... / chunk:...). Document entities are read-only and rejected. Use an id returned by `recall`, `list`, `recent_memories`, or `where_is`.",
         ),
         target: z
-          .enum(["main-vault", "project-vault"])
+          .enum(["main-vault", "project-vault", "global", "project"])
+          .optional()
           .describe(
-            "Destination: 'main-vault' for private/global storage, 'project-vault' for shared project storage",
+            "Destination: 'main-vault' (or 'global') for private/global storage, 'project-vault' (or 'project') for shared project storage. 'global'/'project' mirror remember's scope vocabulary.",
+          ),
+        scope: z
+          .enum(["global", "project"])
+          .optional()
+          .describe(
+            "Alias for `target` using remember's scope vocabulary: 'global' = main vault, 'project' = project vault. Pass either `target` or `scope`, not both.",
           ),
         vaultFolder: z
           .string()
@@ -67,11 +74,62 @@ export function registerMoveMemoryTool(server: McpServer, ctx: ServerContext): v
       outputSchema: MoveResultSchema,
     },
     async (
-      { id, target, vaultFolder, cwd, allowProtectedBranch: allowProtectedBranchArg = false },
+      {
+        id,
+        target,
+        scope,
+        vaultFolder,
+        cwd,
+        allowProtectedBranch: allowProtectedBranchArg = false,
+      },
       requestCtx,
     ) => {
       const branchConsent = readProtectedBranchConsentState(requestCtx);
       const allowProtectedBranch = allowProtectedBranchArg || branchConsent === "granted";
+
+      // Accept remember's scope vocabulary alongside the native target names:
+      // 'global'/'project' normalize to 'main-vault'/'project-vault'. Exactly
+      // one of target/scope must be provided.
+      if (target !== undefined && scope !== undefined) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "Pass either `target` or `scope`, not both. They are aliases for the destination vault.",
+            },
+          ],
+          isError: true,
+        };
+      }
+      const rawTarget = target ?? scope;
+      if (rawTarget === undefined) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "Missing destination: pass `target` ('main-vault' or 'project-vault') or its alias `scope` ('global' or 'project').",
+            },
+          ],
+          isError: true,
+        };
+      }
+      const normalizedTarget =
+        rawTarget === "global"
+          ? ("main-vault" as const)
+          : rawTarget === "project"
+            ? ("project-vault" as const)
+            : rawTarget;
+      if (normalizedTarget !== "main-vault" && normalizedTarget !== "project-vault") {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Invalid destination '${String(rawTarget)}'. Use 'main-vault'/'global' or 'project-vault'/'project'.`,
+            },
+          ],
+          isError: true,
+        };
+      }
       await ensureBranchSynced(ctx, cwd);
       guardAgainstDocumentSourceMutation(id, "move");
 
@@ -111,7 +169,7 @@ export function registerMoveMemoryTool(server: McpServer, ctx: ServerContext): v
 
       let targetVault: Vault;
       let targetProject: Awaited<ReturnType<typeof resolveProject>> | undefined;
-      if (target === "main-vault") {
+      if (normalizedTarget === "main-vault") {
         targetVault = ctx.vaultManager.main;
       } else {
         if (!cwd) {
@@ -184,7 +242,7 @@ export function registerMoveMemoryTool(server: McpServer, ctx: ServerContext): v
 
       let noteToWrite = found.note;
       let metadataRewritten = false;
-      if (target === "project-vault" && targetProject) {
+      if (normalizedTarget === "project-vault" && targetProject) {
         const rewrittenProject = targetProject.id;
         const rewrittenProjectName = targetProject.name;
         metadataRewritten =

--- a/src/tools/remember.ts
+++ b/src/tools/remember.ts
@@ -18,12 +18,18 @@ import {
 } from "../cache.js";
 import { suggestAutoRelationships } from "../auto-relate.js";
 import { MarkdownLintError, cleanMarkdown } from "../markdown.js";
-import { resolveWriteScope, WRITE_SCOPES, type WriteScope } from "../project-memory-policy.js";
+import {
+  explicitScopeConflictsWithPolicy,
+  resolveWriteScope,
+  WRITE_SCOPES,
+  type WriteScope,
+} from "../project-memory-policy.js";
 import { resolveProject, ensureBranchSynced, describeProject } from "../helpers/project.js";
 import {
   extractSummary,
   formatCommitBody,
   formatAskForWriteScope,
+  formatScopePolicyConflict,
   checkVaultProtectedBranch,
   commitVaultWithProtection,
 } from "../helpers/git-commit.js";
@@ -222,8 +228,17 @@ export function registerRememberTool(server: McpServer, ctx: ServerContext): voi
           .describe(
             "Where to store: 'project' writes to the shared project vault visible to all contributors; " +
               "'global' writes to the private main vault visible only on this machine. " +
+              "Prefer omitting this: the project's saved policy (see set_project_memory_policy) is authoritative when one exists, and passing a value that contradicts it triggers a user confirmation " +
+              "(or an error on clients without prompts; retry with scopePolicyOverride=true only when the user explicitly requested the deviation). " +
               "When writable attached vaults exist for the project, you may be asked to pick the write target. " +
-              "When omitted, uses the project's saved policy or defaults to 'project'.",
+              "When omitted and no policy exists, defaults to 'project' when cwd is present, otherwise 'global'.",
+          ),
+        scopePolicyOverride: z
+          .boolean()
+          .optional()
+          .describe(
+            "One-time override for the saved write-scope policy. " +
+              "Set true only when the user explicitly asked to store somewhere that contradicts the project's saved policy; the result then records the override.",
           ),
         allowProtectedBranch: z
           .boolean()
@@ -252,6 +267,7 @@ export function registerRememberTool(server: McpServer, ctx: ServerContext): voi
         alwaysLoad,
         cwd,
         scope,
+        scopePolicyOverride = false,
         allowProtectedBranch: allowProtectedBranchArg = false,
       },
       requestCtx,
@@ -293,22 +309,48 @@ export function registerRememberTool(server: McpServer, ctx: ServerContext): voi
         ? Boolean(await ctx.vaultManager.getProjectVaultIfExists(cwd))
         : true;
       let writeScope = resolveWriteScope(scope, policyScope, Boolean(project), projectVaultExists);
-      if (writeScope === "ask") {
+      // An explicit scope that contradicts the saved policy must not silently
+      // override it (agents habitually restate the default explicitly). Route
+      // it through the same choice flow as policy "ask": a folded MRTR
+      // response wins, a decline or legacy client gets actionable error text,
+      // otherwise elicit. scopePolicyOverride short-circuits the guard when
+      // the user explicitly requested the deviation.
+      const scopeConflictsWithPolicy =
+        scope !== undefined &&
+        policyScope !== undefined &&
+        !scopePolicyOverride &&
+        explicitScopeConflictsWithPolicy(scope, policyScope);
+      if (writeScope === "ask" || scopeConflictsWithPolicy) {
         const unadopted = !projectVaultExists && !policyScope;
         const scopeChoice = readWriteScopeChoice(requestCtx);
         if (scopeChoice?.kind === "accepted") {
           writeScope = scopeChoice.value.scope;
         } else if (scopeChoice?.kind === "declined" || !isMrtrSupported(requestCtx)) {
+          const text = scopeConflictsWithPolicy
+            ? formatScopePolicyConflict(project, scope, policyScope)
+            : formatAskForWriteScope(project, unadopted);
           return {
-            content: [{ type: "text", text: formatAskForWriteScope(project, unadopted) }],
+            content: [{ type: "text", text }],
             isError: true,
           };
         } else {
-          const header = formatAskForWriteScope(project, unadopted).split("\n")[0] ?? "";
-          const message =
-            `${header} Where should this memory be stored? ` +
-            `"project" stores in the shared project vault for all contributors; ` +
-            `"global" stores in the private main vault for this machine only.`;
+          const conflictMessage =
+            policyScope === "ask"
+              ? `The saved memory policy for ${describeProject(project)} is set to always ask, but scope="${scope}" was passed explicitly. ` +
+                `Where should this memory be stored? "project" stores in the shared project vault for all contributors; ` +
+                `"global" stores in the private main vault for this machine only.`
+              : `Explicit scope="${scope}" contradicts the saved memory policy for ${describeProject(project)} (defaultScope="${policyScope}"). ` +
+                `Where should this memory be stored? "${policyScope}" follows the saved policy; "${scope}" overrides it.`;
+          const message = scopeConflictsWithPolicy
+            ? conflictMessage
+            : (() => {
+                const header = formatAskForWriteScope(project, unadopted).split("\n")[0] ?? "";
+                return (
+                  `${header} Where should this memory be stored? ` +
+                  `"project" stores in the shared project vault for all contributors; ` +
+                  `"global" stores in the private main vault for this machine only.`
+                );
+              })();
           return scopeSelectionDecision(requestCtx, message);
         }
       }
@@ -443,7 +485,12 @@ export function registerRememberTool(server: McpServer, ctx: ServerContext): voi
       });
 
       const vaultLabel = ` [${storageLabel(vault)}]`;
-      const textContent = `Remembered as \`${id}\` [${projectScope}, stored=${writeScope}]${vaultLabel}\n${formatPersistenceSummary(persistence)}`;
+      const policyMarker = policyScope
+        ? writeScope === policyScope || scope === undefined
+          ? ` [policy=${policyScope}]`
+          : ` [policy=${policyScope}→${writeScope}, override]`
+        : "";
+      const textContent = `Remembered as \`${id}\` [${projectScope}, stored=${writeScope}]${policyMarker}${vaultLabel}\n${formatPersistenceSummary(persistence)}`;
 
       const structuredContent: RememberResult = {
         action: "remembered",
@@ -451,6 +498,7 @@ export function registerRememberTool(server: McpServer, ctx: ServerContext): voi
         title,
         project: project ? { id: project.id, name: project.name } : undefined,
         scope: writeScope,
+        policyScope,
         vault: storageLabel(vault),
         tags: tags || [],
         lifecycle: note.lifecycle,

--- a/tests/__snapshots__/mcp-schema-contract.integration.test.ts.snap
+++ b/tests/__snapshots__/mcp-schema-contract.integration.test.ts.snap
@@ -4048,11 +4048,21 @@ Typical next step:
           "pattern": "^([a-zA-Z0-9_-]+|(doc|chunk):.+)$",
           "type": "string",
         },
+        "scope": {
+          "description": "Alias for \`target\` using remember's scope vocabulary: 'global' = main vault, 'project' = project vault. Pass either \`target\` or \`scope\`, not both.",
+          "enum": [
+            "global",
+            "project",
+          ],
+          "type": "string",
+        },
         "target": {
-          "description": "Destination: 'main-vault' for private/global storage, 'project-vault' for shared project storage",
+          "description": "Destination: 'main-vault' (or 'global') for private/global storage, 'project-vault' (or 'project') for shared project storage. 'global'/'project' mirror remember's scope vocabulary.",
           "enum": [
             "main-vault",
             "project-vault",
+            "global",
+            "project",
           ],
           "type": "string",
         },
@@ -4063,7 +4073,6 @@ Typical next step:
       },
       "required": [
         "id",
-        "target",
       ],
       "type": "object",
     },
@@ -6250,12 +6259,16 @@ Typical next step:
           "type": "string",
         },
         "scope": {
-          "description": "Where to store: 'project' writes to the shared project vault visible to all contributors; 'global' writes to the private main vault visible only on this machine. When writable attached vaults exist for the project, you may be asked to pick the write target. When omitted, uses the project's saved policy or defaults to 'project'.",
+          "description": "Where to store: 'project' writes to the shared project vault visible to all contributors; 'global' writes to the private main vault visible only on this machine. Prefer omitting this: the project's saved policy (see set_project_memory_policy) is authoritative when one exists, and passing a value that contradicts it triggers a user confirmation (or an error on clients without prompts; retry with scopePolicyOverride=true only when the user explicitly requested the deviation). When writable attached vaults exist for the project, you may be asked to pick the write target. When omitted and no policy exists, defaults to 'project' when cwd is present, otherwise 'global'.",
           "enum": [
             "project",
             "global",
           ],
           "type": "string",
+        },
+        "scopePolicyOverride": {
+          "description": "One-time override for the saved write-scope policy. Set true only when the user explicitly asked to store somewhere that contradicts the project's saved policy; the result then records the override.",
+          "type": "boolean",
         },
         "summary": {
           "description": "Git commit summary only. Imperative mood, concise, and focused on why the change matters.",

--- a/tests/mrtr.integration.test.ts
+++ b/tests/mrtr.integration.test.ts
@@ -257,6 +257,73 @@ describe("MRTR native round-trips (modern 2026-07-28 client)", () => {
     }
   }, 60000);
 
+  it("elicits a scope choice when explicit scope contradicts the saved policy", async () => {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mrtr-vault-"));
+    const repoDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-mrtr-repo-"));
+    tempDirs.push(vaultDir, repoDir);
+
+    await initTestVaultRepo(vaultDir);
+    await initTestRepo(repoDir);
+    const embeddingServer = await startFakeEmbeddingServer();
+
+    try {
+      const session = await createModernMcpSession(vaultDir, {
+        ollamaUrl: embeddingServer.url,
+        disableGit: false,
+      });
+
+      try {
+        await session.callTool(
+          "set_project_memory_policy",
+          {
+            cwd: repoDir,
+            defaultScope: "global",
+          },
+          () => ({}),
+        );
+
+        const raw = (await session.callToolRaw("remember", {
+          title: "MRTR policy conflict note",
+          content: "Conflict between explicit scope and saved policy.",
+          tags: ["integration", "mrtr"],
+          summary: "MRTR policy conflict test",
+          cwd: repoDir,
+          scope: "project",
+        })) as ToolCallResult;
+
+        expect(raw.resultType).toBe("input_required");
+        const scopeRequest = raw.inputRequests?.["writeScope"] as {
+          params?: { message?: string };
+        };
+        expect(scopeRequest?.params?.message).toContain("contradicts the saved memory policy");
+
+        const chosen = (await session.callTool(
+          "remember",
+          {
+            title: "MRTR policy conflict note",
+            content: "Conflict between explicit scope and saved policy.",
+            tags: ["integration", "mrtr"],
+            summary: "MRTR policy conflict test",
+            cwd: repoDir,
+            scope: "project",
+          },
+          () => ({
+            writeScope: elicitAccept({ scope: "global" }),
+          }),
+        )) as ToolCallResult;
+
+        const chosenId = extractRememberedId(chosen.content?.[0]?.text ?? "");
+        expect(chosen.content?.[0]?.text).toContain("stored=global");
+        expect(chosen.content?.[0]?.text).toContain("[policy=global]");
+        await expect(stat(path.join(vaultDir, "notes", `${chosenId}.md`))).resolves.toBeDefined();
+      } finally {
+        await session.close();
+      }
+    } finally {
+      await embeddingServer.close();
+    }
+  }, 60000);
+
   it("writes into a writable attached vault when the vault picker selects it", async () => {
     const { vaultDir, repoDir, attachedDir } = await setupWritableAttachedVaultFixture();
     const embeddingServer = await startFakeEmbeddingServer();

--- a/tests/project-memory-policy.unit.test.ts
+++ b/tests/project-memory-policy.unit.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { MnemonicConfigStore } from "../src/config.js";
 import {
   branchMatchesProtectedPattern,
+  explicitScopeConflictsWithPolicy,
   isProtectedBranch,
   resolveProtectedBranchBehavior,
   resolveProtectedBranchPatterns,
@@ -49,6 +50,33 @@ describe("resolveWriteScope", () => {
 
   it("saved policy bypasses unadopted project check", () => {
     expect(resolveWriteScope(undefined, "global", true, false)).toBe("global");
+  });
+});
+
+describe("explicitScopeConflictsWithPolicy", () => {
+  it("returns false when no explicit scope is passed", () => {
+    expect(explicitScopeConflictsWithPolicy(undefined, "global")).toBe(false);
+    expect(explicitScopeConflictsWithPolicy(undefined, "ask")).toBe(false);
+  });
+
+  it("returns false when no policy is saved", () => {
+    expect(explicitScopeConflictsWithPolicy("project", undefined)).toBe(false);
+    expect(explicitScopeConflictsWithPolicy("global", undefined)).toBe(false);
+  });
+
+  it("returns false when the explicit scope matches the policy", () => {
+    expect(explicitScopeConflictsWithPolicy("global", "global")).toBe(false);
+    expect(explicitScopeConflictsWithPolicy("project", "project")).toBe(false);
+  });
+
+  it("returns true when the explicit scope differs from the policy", () => {
+    expect(explicitScopeConflictsWithPolicy("project", "global")).toBe(true);
+    expect(explicitScopeConflictsWithPolicy("global", "project")).toBe(true);
+  });
+
+  it("returns true for any explicit scope when the policy is ask", () => {
+    expect(explicitScopeConflictsWithPolicy("project", "ask")).toBe(true);
+    expect(explicitScopeConflictsWithPolicy("global", "ask")).toBe(true);
   });
 });
 

--- a/tests/scope-policy-guard.integration.test.ts
+++ b/tests/scope-policy-guard.integration.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp, readdir, stat } from "fs/promises";
+import os from "os";
+import path from "path";
+
+import {
+  callLocalMcpResponse,
+  extractRememberedId,
+  initTestRepo,
+  initTestVaultRepo,
+  startFakeEmbeddingServer,
+  tempDirs,
+} from "./helpers/mcp.js";
+
+/**
+ * Guard behavior when an explicitly passed `scope` contradicts the project's
+ * saved write-scope policy (the kimi/NServiceBus incident): the write must be
+ * blocked with actionable guidance unless the caller acknowledges the
+ * deviation with `scopePolicyOverride`.
+ */
+describe("scope policy guard (legacy client)", () => {
+  it("blocks the write when explicit scope contradicts the saved policy", async () => {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-guard-vault-"));
+    const repoDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-guard-repo-"));
+    tempDirs.push(vaultDir, repoDir);
+
+    await initTestVaultRepo(vaultDir);
+    await initTestRepo(repoDir);
+    const embeddingServer = await startFakeEmbeddingServer();
+
+    try {
+      await callLocalMcpResponse(
+        vaultDir,
+        "set_project_memory_policy",
+        { cwd: repoDir, defaultScope: "global" },
+        { ollamaUrl: embeddingServer.url, disableGit: false },
+      );
+
+      const response = await callLocalMcpResponse(
+        vaultDir,
+        "remember",
+        {
+          title: "Guard conflict note",
+          content: "Must not be stored while the conflict is unresolved.",
+          tags: ["integration", "guard"],
+          summary: "Guard conflict test",
+          cwd: repoDir,
+          scope: "project",
+        },
+        { ollamaUrl: embeddingServer.url, disableGit: false },
+      );
+
+      expect(response.text).toContain("contradicts the saved project memory policy");
+      expect(response.text).toContain('defaultScope="global"');
+      expect(response.text).toContain("The note was NOT stored");
+      expect(response.text).toContain("scopePolicyOverride");
+
+      // Nothing landed in either vault.
+      await expect(readdir(path.join(repoDir, ".mnemonic", "notes"))).rejects.toThrow();
+      await expect(readdir(path.join(vaultDir, "notes"))).resolves.toEqual([]);
+    } finally {
+      await embeddingServer.close();
+    }
+  }, 15000);
+
+  it("stores with scopePolicyOverride and records the override", async () => {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-guard-vault-"));
+    const repoDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-guard-repo-"));
+    tempDirs.push(vaultDir, repoDir);
+
+    await initTestVaultRepo(vaultDir);
+    await initTestRepo(repoDir);
+    const embeddingServer = await startFakeEmbeddingServer();
+
+    try {
+      await callLocalMcpResponse(
+        vaultDir,
+        "set_project_memory_policy",
+        { cwd: repoDir, defaultScope: "global" },
+        { ollamaUrl: embeddingServer.url, disableGit: false },
+      );
+
+      const response = await callLocalMcpResponse(
+        vaultDir,
+        "remember",
+        {
+          title: "Guard override note",
+          content: "Stored in the project vault because the user asked for it.",
+          tags: ["integration", "guard"],
+          summary: "Guard override test",
+          cwd: repoDir,
+          scope: "project",
+          scopePolicyOverride: true,
+        },
+        { ollamaUrl: embeddingServer.url, disableGit: false },
+      );
+
+      expect(response.text).toContain("stored=project");
+      expect(response.text).toContain("[policy=global→project, override]");
+      expect(response.structuredContent?.["policyScope"]).toBe("global");
+
+      const noteId = extractRememberedId(response.text);
+      await expect(
+        stat(path.join(repoDir, ".mnemonic", "notes", `${noteId}.md`)),
+      ).resolves.toBeDefined();
+    } finally {
+      await embeddingServer.close();
+    }
+  }, 15000);
+
+  it("follows the saved policy when scope is omitted and records it", async () => {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-guard-vault-"));
+    const repoDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-guard-repo-"));
+    tempDirs.push(vaultDir, repoDir);
+
+    await initTestVaultRepo(vaultDir);
+    await initTestRepo(repoDir);
+    const embeddingServer = await startFakeEmbeddingServer();
+
+    try {
+      await callLocalMcpResponse(
+        vaultDir,
+        "set_project_memory_policy",
+        { cwd: repoDir, defaultScope: "global" },
+        { ollamaUrl: embeddingServer.url, disableGit: false },
+      );
+
+      const response = await callLocalMcpResponse(
+        vaultDir,
+        "remember",
+        {
+          title: "Guard policy-follow note",
+          content: "Stored in the main vault following the saved policy.",
+          tags: ["integration", "guard"],
+          summary: "Guard policy-follow test",
+          cwd: repoDir,
+        },
+        { ollamaUrl: embeddingServer.url, disableGit: false },
+      );
+
+      expect(response.text).toContain("stored=global");
+      expect(response.text).toContain("[policy=global]");
+
+      const noteId = extractRememberedId(response.text);
+      await expect(stat(path.join(vaultDir, "notes", `${noteId}.md`))).resolves.toBeDefined();
+    } finally {
+      await embeddingServer.close();
+    }
+  }, 15000);
+
+  it("accepts remember's scope vocabulary on move_memory", async () => {
+    const vaultDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-guard-vault-"));
+    const repoDir = await mkdtemp(path.join(os.tmpdir(), "mnemonic-guard-repo-"));
+    tempDirs.push(vaultDir, repoDir);
+
+    await initTestVaultRepo(vaultDir);
+    await initTestRepo(repoDir);
+    const embeddingServer = await startFakeEmbeddingServer();
+
+    try {
+      const rememberResponse = await callLocalMcpResponse(
+        vaultDir,
+        "remember",
+        {
+          title: "Alias move source note",
+          content: "Stored in the project vault, then moved with the scope alias.",
+          tags: ["integration", "guard"],
+          summary: "Alias move test",
+          cwd: repoDir,
+          scope: "project",
+        },
+        { ollamaUrl: embeddingServer.url, disableGit: false },
+      );
+      expect(rememberResponse.text).toContain("stored=project");
+      const noteId = extractRememberedId(rememberResponse.text);
+
+      const moveResponse = await callLocalMcpResponse(
+        vaultDir,
+        "move_memory",
+        { id: noteId, scope: "global", cwd: repoDir },
+        { ollamaUrl: embeddingServer.url, disableGit: false },
+      );
+
+      expect(moveResponse.text).toContain("Moved");
+      expect(moveResponse.text).toContain("main-vault");
+      await expect(stat(path.join(vaultDir, "notes", `${noteId}.md`))).resolves.toBeDefined();
+    } finally {
+      await embeddingServer.close();
+    }
+  }, 15000);
+});


### PR DESCRIPTION
An explicitly passed scope silently overrode the project's saved
defaultScope policy: resolveWriteScope returned the explicit value before
consulting the policy, so agents that habitually restate the schema
default (kimi passing scope:"project" for NServiceBus despite the saved
global routing) landed notes in the wrong vault with no warning. The
policy was invisible to the agent the whole time.

An explicit scope that contradicts a saved policy now blocks the write
and routes through the same choice flow as policy "ask": MRTR-capable
clients get a native elicitation (follow the saved policy vs keep the
explicit value; an accepted choice is folded into the retry round), and
legacy clients or declines get actionable error text. A new
scopePolicyOverride flag is the explicit-deviation escape hatch, mirroring
allowProtectedBranch. An "ask" policy conflicts with any explicit scope,
since the user asked to choose every time — previously explicit scope
bypassed that too.

Successful writes now record the governing routing: [policy=global] in
the result text ([policy=global→project, override] after a confirmed
deviation) and policyScope in structured output. The scope parameter
description tells agents to prefer omitting it because the saved policy
is authoritative.

move_memory now accepts scope ("global"/"project") as an alias for
target, and target accepts both vocabularies, fixing the cross-tool
schema friction where the cleanup call after a wrong-vault write failed
validation because remember and move_memory used different parameter
names and values for the same concept.